### PR TITLE
Use the mambaforge installer to speed up the build process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ jobs:
           key: ${{ runner.os }}-conda-v1-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          use-mamba: true
+          python-version: 3.8
       - name: Install dependencies
         shell: bash -l {0}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v1-${{ hashFiles('conda.txt') }}
+          key: ${{ runner.os }}-conda-v3-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,11 +30,9 @@ jobs:
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          use-mamba: true
           python-version: 3.8
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
-          use-only-tar-bz2: true
       - name: Install dependencies and build the jar
         shell: bash -l {0}
         run: |
@@ -77,11 +75,9 @@ jobs:
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          use-mamba: true
           python-version: ${{ matrix.python }}
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
-          use-only-tar-bz2: true
       - name: Download the pre-build jar
         uses: actions/download-artifact@v1
         with:
@@ -142,11 +138,9 @@ jobs:
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          use-mamba: true
           python-version: 3.8
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
-          use-only-tar-bz2: true
       - name: Download the pre-build jar
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v2-${{ hashFiles('conda.txt') }}
+          key: ${{ runner.os }}-conda-v3-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v2-${{ matrix.java }}-${{ matrix.python }}-${{ hashFiles('conda.txt') }}
+          key: ${{ runner.os }}-conda-v3-${{ matrix.java }}-${{ matrix.python }}-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -134,7 +134,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-v2-11-${{ hashFiles('conda.txt') }}
+          key: ${{ runner.os }}-conda-v3-11-${{ hashFiles('conda.txt') }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:


### PR DESCRIPTION
Our current CI build process involves multiple conda installations. I could already speed it up in the past by switching from conda to mamba - with the drawback that the setup of the conda installation (miniconda) takes a long time as it needs to install mamba.
Let's hope that starting with "mambaforge" makes it faster.