### PR TITLE
More efficient window implementation

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -427,7 +427,7 @@ class Context:
             cc = dc.column_container
             cc = cc.rename(
                 {
-                    df_col: df_col if not df_col.startswith("EXPR$") else select_name
+                    df_col: select_name
                     for df_col, select_name in zip(cc.columns, select_names)
                 }
             )
@@ -711,12 +711,18 @@ class Context:
             sqlNode = generator.getSqlNode(sql)
             sqlNodeClass = get_java_class(sqlNode)
 
-            if sqlNodeClass.startswith("com.dask.sql.parser."):
-                rel = sqlNode
-                rel_string = ""
-            else:
+            select_names = None
+            rel = sqlNode
+            rel_string = ""
+
+            if not sqlNodeClass.startswith("com.dask.sql.parser."):
                 validatedSqlNode = generator.getValidatedNode(sqlNode)
                 nonOptimizedRelNode = generator.getRelationalAlgebra(validatedSqlNode)
+                # Optimization might remove some alias projects. Make sure to keep them here.
+                select_names = [
+                    str(name)
+                    for name in nonOptimizedRelNode.getRowType().getFieldNames()
+                ]
                 rel = generator.getOptimizedRelationalAlgebra(nonOptimizedRelNode)
                 rel_string = str(generator.getRelationalAlgebraString(rel))
         except (ValidationException, SqlParseException) as e:
@@ -741,13 +747,14 @@ class Context:
         if sqlNodeClass == "org.apache.calcite.sql.SqlSelect":
             select_names = [
                 self._to_sql_string(s, default_dialect=default_dialect)
-                for s in sqlNode.getSelectList()
+                if current_name.startswith("EXPR$")
+                else current_name
+                for s, current_name in zip(sqlNode.getSelectList(), select_names)
             ]
         else:
             logger.debug(
                 "Not extracting output column names as the SQL is not a SELECT call"
             )
-            select_names = None
 
         logger.debug(f"Extracted relational algebra:\n {rel_string}")
         return rel, select_names, rel_string

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -86,6 +86,7 @@ class Context:
         RelConverter.add_plugin_class(logical.LogicalTableScanPlugin, replace=False)
         RelConverter.add_plugin_class(logical.LogicalUnionPlugin, replace=False)
         RelConverter.add_plugin_class(logical.LogicalValuesPlugin, replace=False)
+        RelConverter.add_plugin_class(logical.LogicalWindowPlugin, replace=False)
         RelConverter.add_plugin_class(logical.SamplePlugin, replace=False)
         RelConverter.add_plugin_class(custom.AnalyzeTablePlugin, replace=False)
         RelConverter.add_plugin_class(custom.CreateExperimentPlugin, replace=False)
@@ -108,7 +109,6 @@ class Context:
         RexConverter.add_plugin_class(core.RexCallPlugin, replace=False)
         RexConverter.add_plugin_class(core.RexInputRefPlugin, replace=False)
         RexConverter.add_plugin_class(core.RexLiteralPlugin, replace=False)
-        RexConverter.add_plugin_class(core.RexOverPlugin, replace=False)
 
         InputUtil.add_plugin_class(input_utils.DaskInputPlugin, replace=False)
         InputUtil.add_plugin_class(input_utils.PandasInputPlugin, replace=False)

--- a/dask_sql/physical/rel/logical/__init__.py
+++ b/dask_sql/physical/rel/logical/__init__.py
@@ -7,6 +7,7 @@ from .sort import LogicalSortPlugin
 from .table_scan import LogicalTableScanPlugin
 from .union import LogicalUnionPlugin
 from .values import LogicalValuesPlugin
+from .window import LogicalWindowPlugin
 
 __all__ = [
     LogicalAggregatePlugin,
@@ -17,5 +18,6 @@ __all__ = [
     LogicalTableScanPlugin,
     LogicalUnionPlugin,
     LogicalValuesPlugin,
+    LogicalWindowPlugin,
     SamplePlugin,
 ]

--- a/dask_sql/physical/rel/logical/window.py
+++ b/dask_sql/physical/rel/logical/window.py
@@ -145,7 +145,6 @@ class Indexer(BaseIndexer):
         return start, end
 
 
-@make_pickable_without_dask_sql
 def map_on_each_group(
     partitioned_group: pd.DataFrame,
     sort_columns: List[str],
@@ -312,7 +311,9 @@ class LogicalWindowPlugin(BaseRelPlugin):
         # TODO: That is a bit of a hack. We should really use the real column dtype
         meta = df._meta.assign(**{col: 0.0 for col in newly_created_columns})
 
-        df = df.groupby(group_columns).apply(filled_map, meta=meta)
+        df = df.groupby(group_columns).apply(
+            make_pickable_without_dask_sql(filled_map), meta=meta
+        )
         df = df.drop(columns=temporary_columns).reset_index(drop=True)
 
         dc = DataContainer(df, cc)

--- a/dask_sql/physical/rex/core/__init__.py
+++ b/dask_sql/physical/rex/core/__init__.py
@@ -1,6 +1,5 @@
 from .call import RexCallPlugin
 from .input_ref import RexInputRefPlugin
 from .literal import RexLiteralPlugin
-from .over import RexOverPlugin
 
-__all__ = [RexCallPlugin, RexInputRefPlugin, RexLiteralPlugin, RexOverPlugin]
+__all__ = [RexCallPlugin, RexInputRefPlugin, RexLiteralPlugin]

--- a/tests/integration/test_filter.py
+++ b/tests/integration/test_filter.py
@@ -23,7 +23,7 @@ def test_filter_scalar(c, df):
     return_df = return_df.compute()
 
     expected_df = df.head(0)
-    assert_frame_equal(return_df, expected_df)
+    assert_frame_equal(return_df, expected_df, check_index_type=False)
 
     return_df = c.sql("SELECT * FROM df WHERE (1 = 1)")
     return_df = return_df.compute()
@@ -35,7 +35,7 @@ def test_filter_scalar(c, df):
     return_df = return_df.compute()
 
     expected_df = df.head(0)
-    assert_frame_equal(return_df, expected_df)
+    assert_frame_equal(return_df, expected_df, check_index_type=False)
 
 
 def test_filter_complicated(c, df):

--- a/tests/integration/test_over.py
+++ b/tests/integration/test_over.py
@@ -3,20 +3,31 @@ import pandas as pd
 from pandas.testing import assert_frame_equal
 
 
+def assert_frame_equal_after_sorting(df, expected_df, columns=None, **kwargs):
+    columns = columns or ["user_id", "b"]
+
+    df = df.sort_values(columns).reset_index(drop=True)
+    expected_df = expected_df.sort_values(columns).reset_index(drop=True)
+    assert_frame_equal(df, expected_df, **kwargs)
+
+
 def test_over_with_sorting(c, user_table_1):
     df = c.sql(
         """
     SELECT
         user_id,
+        b,
         ROW_NUMBER() OVER (ORDER BY user_id, b) AS R
     FROM user_table_1
     """
     )
     df = df.compute()
 
-    expected_df = pd.DataFrame({"user_id": user_table_1.user_id, "R": [3, 1, 2, 4]})
+    expected_df = pd.DataFrame(
+        {"user_id": user_table_1.user_id, "b": user_table_1.b, "R": [3, 1, 2, 4]}
+    )
     expected_df["R"] = expected_df["R"].astype("Int64")
-    assert_frame_equal(df, expected_df)
+    assert_frame_equal_after_sorting(df, expected_df, columns=["user_id", "b"])
 
 
 def test_over_with_partitioning(c, user_table_2):
@@ -24,15 +35,18 @@ def test_over_with_partitioning(c, user_table_2):
         """
     SELECT
         user_id,
+        c,
         ROW_NUMBER() OVER (PARTITION BY c) AS R
     FROM user_table_2
     """
     )
     df = df.compute()
 
-    expected_df = pd.DataFrame({"user_id": user_table_2.user_id, "R": [1, 1, 1, 1]})
+    expected_df = pd.DataFrame(
+        {"user_id": user_table_2.user_id, "c": user_table_2.c, "R": [1, 1, 1, 1]}
+    )
     expected_df["R"] = expected_df["R"].astype("Int64")
-    assert_frame_equal(df, expected_df)
+    assert_frame_equal_after_sorting(df, expected_df, columns=["user_id", "c"])
 
 
 def test_over_with_grouping_and_sort(c, user_table_1):
@@ -40,15 +54,18 @@ def test_over_with_grouping_and_sort(c, user_table_1):
         """
     SELECT
         user_id,
+        b,
         ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY b) AS R
     FROM user_table_1
     """
     )
     df = df.compute()
 
-    expected_df = pd.DataFrame({"user_id": user_table_1.user_id, "R": [2, 1, 1, 1]})
+    expected_df = pd.DataFrame(
+        {"user_id": user_table_1.user_id, "b": user_table_1.b, "R": [2, 1, 1, 1]}
+    )
     expected_df["R"] = expected_df["R"].astype("Int64")
-    assert_frame_equal(df, expected_df)
+    assert_frame_equal_after_sorting(df, expected_df, columns=["user_id", "b"])
 
 
 def test_over_with_different(c, user_table_1):
@@ -56,6 +73,7 @@ def test_over_with_different(c, user_table_1):
         """
     SELECT
         user_id,
+        b,
         ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY b) AS R1,
         ROW_NUMBER() OVER (ORDER BY user_id, b) AS R2
     FROM user_table_1
@@ -64,20 +82,25 @@ def test_over_with_different(c, user_table_1):
     df = df.compute()
 
     expected_df = pd.DataFrame(
-        {"user_id": user_table_1.user_id, "R1": [2, 1, 1, 1], "R2": [3, 1, 2, 4],}
+        {
+            "user_id": user_table_1.user_id,
+            "b": user_table_1.b,
+            "R1": [2, 1, 1, 1],
+            "R2": [3, 1, 2, 4],
+        }
     )
     for col in ["R1", "R2"]:
         expected_df[col] = expected_df[col].astype("Int64")
-    assert_frame_equal(
-        df.sort_values("user_id").reset_index(drop=True),
-        expected_df.sort_values("user_id").reset_index(drop=True),
-    )
+
+    assert_frame_equal_after_sorting(df, expected_df, columns=["user_id", "b"])
 
 
-def test_over_calls(c):
+def test_over_calls(c, user_table_1):
     df = c.sql(
         """
     SELECT
+        user_id,
+        b,
         ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY b) AS O1,
         FIRST_VALUE(user_id*10 - b) OVER (PARTITION BY user_id ORDER BY b) AS O2,
         SINGLE_VALUE(user_id*10 - b) OVER (PARTITION BY user_id ORDER BY b) AS O3,
@@ -95,6 +118,8 @@ def test_over_calls(c):
 
     expected_df = pd.DataFrame(
         {
+            "user_id": user_table_1.user_id,
+            "b": user_table_1.b,
             "O1": [2, 1, 1, 1],
             "O2": [19, 7, 19, 27],
             "O3": [19, 7, 19, 27],
@@ -108,11 +133,12 @@ def test_over_calls(c):
         }
     )
     for col in expected_df.columns:
-        if col in ["06"]:
+        if col in ["06", "user_id", "b"]:
             continue
         expected_df[col] = expected_df[col].astype("Int64")
-    expected_df["O6"] = expected_df["O6"].astype("float64")
-    assert_frame_equal(df, expected_df)
+    expected_df["O6"] = expected_df["O6"].astype("Float64")
+
+    assert_frame_equal_after_sorting(df, expected_df, columns=["user_id", "b"])
 
 
 def test_over_with_windows(c):
@@ -122,6 +148,7 @@ def test_over_with_windows(c):
     df = c.sql(
         """
     SELECT
+        a,
         SUM(a) OVER (ORDER BY a ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS O1,
         SUM(a) OVER (ORDER BY a ROWS BETWEEN 2 PRECEDING AND 3 FOLLOWING) AS O2,
         SUM(a) OVER (ORDER BY a ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING) AS O3,
@@ -139,6 +166,7 @@ def test_over_with_windows(c):
 
     expected_df = pd.DataFrame(
         {
+            "a": df.a,
             "O1": [0, 1, 3, 6, 9],
             "O2": [6, 10, 10, 10, 9],
             "O3": [10, 10, 10, 10, 9],
@@ -152,5 +180,8 @@ def test_over_with_windows(c):
         }
     )
     for col in expected_df.columns:
+        if col in ["a"]:
+            continue
         expected_df[col] = expected_df[col].astype("Int64")
-    assert_frame_equal(df, expected_df)
+
+    assert_frame_equal_after_sorting(df, expected_df, columns=["a"])

--- a/tests/integration/test_over.py
+++ b/tests/integration/test_over.py
@@ -68,7 +68,10 @@ def test_over_with_different(c, user_table_1):
     )
     for col in ["R1", "R2"]:
         expected_df[col] = expected_df[col].astype("Int64")
-    assert_frame_equal(df, expected_df)
+    assert_frame_equal(
+        df.sort_values("user_id").reset_index(drop=True),
+        expected_df.sort_values("user_id").reset_index(drop=True),
+    )
 
 
 def test_over_calls(c):


### PR DESCRIPTION
The current `OVER` implementation works as follows:
If there is are `OVER` calls in a `SELECT` (aka a projection), they are treated one after the other by first storing the current index, partitioning and sorting, then grouping and applying the window and finally restoring the current sorting/partitioning/sorting. The reason for this is, that if we mix `OVER` and non-`OVER` calls in a single project, they will not fit together if they have different partitioning/sorting/index.
This PR introduces a much easier implementation: using one of the optimization rules in calcite, we split up projections into projections without `OVER` and ones that only contain window operations (which are now called `LogicalWindow`). This allows us to group and shuffle without the need to restore any ordering or partitioning, as the window is now treated independently.

I did not do any benchmarking so far (will do later), but I would expect this to be much faster for larger data sets and many `OVER` operations.