### PR TITLE
Creating tables with a dask-cudf DataFrame

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -125,6 +125,7 @@ class Context:
         format: str = None,
         persist: bool = True,
         schema_name: str = None,
+        gpu: bool = False,
         **kwargs,
     ):
         """
@@ -199,6 +200,7 @@ class Context:
             table_name=table_name,
             format=format,
             persist=persist,
+            gpu=gpu,
             **kwargs,
         )
         self.schema[schema_name].tables[table_name.lower()] = dc

--- a/dask_sql/input_utils/convert.py
+++ b/dask_sql/input_utils/convert.py
@@ -37,6 +37,7 @@ class InputUtil(Pluggable):
         table_name: str,
         format: str = None,
         persist: bool = True,
+        gpu: bool = False,
         **kwargs,
     ) -> DataContainer:
         """
@@ -45,7 +46,7 @@ class InputUtil(Pluggable):
         maybe persist them to cluster memory before.
         """
         filled_get_dask_dataframe = lambda *args: cls._get_dask_dataframe(
-            *args, table_name=table_name, format=format, **kwargs,
+            *args, table_name=table_name, format=format, gpu=gpu, **kwargs,
         )
 
         if isinstance(input_item, list):
@@ -60,7 +61,7 @@ class InputUtil(Pluggable):
 
     @classmethod
     def _get_dask_dataframe(
-        cls, input_item: InputType, table_name: str, format: str = None, **kwargs,
+        cls, input_item: InputType, table_name: str, format: str = None, gpu: bool = False, **kwargs,
     ):
         plugin_list = cls.get_plugins()
 
@@ -69,7 +70,7 @@ class InputUtil(Pluggable):
                 input_item, table_name=table_name, format=format, **kwargs
             ):
                 return plugin.to_dc(
-                    input_item, table_name=table_name, format=format, **kwargs
+                    input_item, table_name=table_name, format=format, gpu=gpu, **kwargs
                 )
 
         raise ValueError(f"Do not understand the input type {type(input_item)}")

--- a/dask_sql/input_utils/convert.py
+++ b/dask_sql/input_utils/convert.py
@@ -61,7 +61,12 @@ class InputUtil(Pluggable):
 
     @classmethod
     def _get_dask_dataframe(
-        cls, input_item: InputType, table_name: str, format: str = None, gpu: bool = False, **kwargs,
+        cls,
+        input_item: InputType,
+        table_name: str,
+        format: str = None,
+        gpu: bool = False,
+        **kwargs,
     ):
         plugin_list = cls.get_plugins()
 

--- a/dask_sql/input_utils/intake.py
+++ b/dask_sql/input_utils/intake.py
@@ -18,11 +18,21 @@ class IntakeCatalogInputPlugin(BaseInputPlugin):
             isinstance(input_item, intake.catalog.Catalog) or format == "intake"
         )
 
-    def to_dc(self, input_item: Any, table_name: str, format: str = None, **kwargs):
+    def to_dc(
+        self,
+        input_item: Any,
+        table_name: str,
+        format: str = None,
+        gpu: bool = False,
+        **kwargs
+    ):
         table_name = kwargs.pop("intake_table_name", table_name)
         catalog_kwargs = kwargs.pop("catalog_kwargs", {})
 
         if isinstance(input_item, str):
             input_item = intake.open_catalog(input_item, **catalog_kwargs)
 
-        return input_item[table_name].to_dask(**kwargs)
+        if gpu:
+            raise Exception("Intake does not support gpu")
+        else:
+            return input_item[table_name].to_dask(**kwargs)

--- a/dask_sql/input_utils/location.py
+++ b/dask_sql/input_utils/location.py
@@ -15,7 +15,7 @@ class LocationInputPlugin(BaseInputPlugin):
     ):
         return isinstance(input_item, str)
 
-    def to_dc(self, input_item: Any, table_name: str, format: str = None, **kwargs):
+    def to_dc(self, input_item: Any, table_name: str, format: str = None, gpu: bool = False, **kwargs):
 
         if format == "memory":
             client = default_client()
@@ -27,7 +27,11 @@ class LocationInputPlugin(BaseInputPlugin):
             format = extension.lstrip(".")
 
         try:
-            read_function = getattr(dd, f"read_{format}")
+            if gpu:
+                import dask_cudf
+                read_function = getattr(dask_cudf, f"read_{format}")
+            else:
+                read_function = getattr(dd, f"read_{format}")
         except AttributeError:
             raise AttributeError(f"Can not read files of format {format}")
 

--- a/dask_sql/input_utils/location.py
+++ b/dask_sql/input_utils/location.py
@@ -15,7 +15,14 @@ class LocationInputPlugin(BaseInputPlugin):
     ):
         return isinstance(input_item, str)
 
-    def to_dc(self, input_item: Any, table_name: str, format: str = None, gpu: bool = False, **kwargs):
+    def to_dc(
+        self,
+        input_item: Any,
+        table_name: str,
+        format: str = None,
+        gpu: bool = False,
+        **kwargs
+    ):
 
         if format == "memory":
             client = default_client()

--- a/dask_sql/input_utils/pandas.py
+++ b/dask_sql/input_utils/pandas.py
@@ -22,12 +22,11 @@ class PandasInputPlugin(BaseInputPlugin):
     ):
         npartitions = kwargs.pop("npartitions", 1)
         if gpu:
-            import cudf, dask_cudf
+            import cudf
+            import dask_cudf
 
             return dask_cudf.from_cudf(
-                cudf.from_pandas(input_item),
-                npartitions=npartitions,
-                **kwargs,
+                cudf.from_pandas(input_item), npartitions=npartitions, **kwargs,
             )
         else:
             return dd.from_pandas(input_item, npartitions=npartitions, **kwargs)

--- a/dask_sql/input_utils/pandas.py
+++ b/dask_sql/input_utils/pandas.py
@@ -12,6 +12,18 @@ class PandasInputPlugin(BaseInputPlugin):
     ):
         return isinstance(input_item, pd.DataFrame) or format == "dask"
 
-    def to_dc(self, input_item, table_name: str, format: str = None, **kwargs):
+    def to_dc(
+        self,
+        input_item,
+        table_name: str,
+        format: str = None,
+        gpu: bool = False,
+        **kwargs,
+    ):
         npartitions = kwargs.pop("npartitions", 1)
-        return dd.from_pandas(input_item, npartitions=npartitions, **kwargs)
+        if gpu:
+            import dask_cudf
+
+            return dask_cudf.from_cudf(input_item, npartitions=npartitions, **kwargs)
+        else:
+            return dd.from_pandas(input_item, npartitions=npartitions, **kwargs)

--- a/dask_sql/input_utils/pandas.py
+++ b/dask_sql/input_utils/pandas.py
@@ -22,8 +22,12 @@ class PandasInputPlugin(BaseInputPlugin):
     ):
         npartitions = kwargs.pop("npartitions", 1)
         if gpu:
-            import dask_cudf
+            import cudf, dask_cudf
 
-            return dask_cudf.from_cudf(input_item, npartitions=npartitions, **kwargs)
+            return dask_cudf.from_cudf(
+                cudf.from_pandas(input_item),
+                npartitions=npartitions,
+                **kwargs,
+            )
         else:
             return dd.from_pandas(input_item, npartitions=npartitions, **kwargs)

--- a/dask_sql/physical/rel/custom/create_table.py
+++ b/dask_sql/physical/rel/custom/create_table.py
@@ -62,11 +62,17 @@ class CreateTablePlugin(BaseRelPlugin):
         except KeyError:
             raise AttributeError("Parameters must include a 'location' parameter.")
 
+        try:
+            gpu = kwargs.pop("gpu")
+        except KeyError:
+            gpu = False
+
         context.create_table(
             table_name,
             location,
             format=format,
             persist=persist,
             schema_name=schema_name,
+            gpu=gpu,
             **kwargs,
         )


### PR DESCRIPTION
Dask-SQL can create tables directly from storage in SQL syntax:
```
CREATE TABLE my_data WITH (
    format = 'csv',
    location = './iris.csv'
)
```
As suggested by @randerzander it would be nice to have a way to create this backed by a dask-cudf DF instead of a Dask CPU DF. This is my first step toward achieving that. 

So far, I just added a boolean parameter `gpu`, although perhaps something like `HOW='gpu'` vs default `HOW='cpu'` would be better. These changes are also only for reading in a single file. Mainly want to get your thoughts about how to support this @nils-braun :)

For example, something like this works with this PR: 
```
CREATE OR REPLACE TABLE my_data WITH (
    format = 'csv',
    location = './iris.csv',
    gpu=True
)
```