### PR TITLE
Support creating tables from cudf dataframes

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -111,7 +111,7 @@ class Context:
         RexConverter.add_plugin_class(core.RexLiteralPlugin, replace=False)
 
         InputUtil.add_plugin_class(input_utils.DaskInputPlugin, replace=False)
-        InputUtil.add_plugin_class(input_utils.PandasInputPlugin, replace=False)
+        InputUtil.add_plugin_class(input_utils.PandasLikeInputPlugin, replace=False)
         InputUtil.add_plugin_class(input_utils.HiveInputPlugin, replace=False)
         InputUtil.add_plugin_class(input_utils.IntakeCatalogInputPlugin, replace=False)
         InputUtil.add_plugin_class(input_utils.SqlalchemyHiveInputPlugin, replace=False)

--- a/dask_sql/input_utils/__init__.py
+++ b/dask_sql/input_utils/__init__.py
@@ -3,7 +3,7 @@ from .dask import DaskInputPlugin
 from .hive import HiveInputPlugin
 from .intake import IntakeCatalogInputPlugin
 from .location import LocationInputPlugin
-from .pandas import PandasInputPlugin
+from .pandaslike import PandasLikeInputPlugin
 from .sqlalchemy import SqlalchemyHiveInputPlugin
 
 __all__ = [
@@ -13,6 +13,6 @@ __all__ = [
     HiveInputPlugin,
     IntakeCatalogInputPlugin,
     LocationInputPlugin,
-    PandasInputPlugin,
+    PandasLikeInputPlugin,
     SqlalchemyHiveInputPlugin,
 ]

--- a/dask_sql/input_utils/convert.py
+++ b/dask_sql/input_utils/convert.py
@@ -14,7 +14,11 @@ InputType = Union[
     dd.DataFrame,
     pd.DataFrame,
     str,
-    Union["sqlalchemy.engine.base.Connection", "hive.Cursor"],
+    Union[
+        "sqlalchemy.engine.base.Connection",
+        "hive.Cursor",
+        "cudf.core.dataframe.DataFrame",
+    ],
 ]
 
 

--- a/dask_sql/input_utils/pandas.py
+++ b/dask_sql/input_utils/pandas.py
@@ -1,6 +1,11 @@
 import dask.dataframe as dd
 import pandas as pd
 
+try:
+    import cudf
+except ImportError:
+    cudf = None
+
 from dask_sql.input_utils.base import BaseInputPlugin
 
 
@@ -10,7 +15,8 @@ class PandasInputPlugin(BaseInputPlugin):
     def is_correct_input(
         self, input_item, table_name: str, format: str = None, **kwargs
     ):
-        return isinstance(input_item, pd.DataFrame) or format == "dask"
+        is_cudf_type = cudf and isinstance(input_item, cudf.DataFrame)
+        return is_cudf_type or isinstance(input_item, pd.DataFrame) or format == "dask"
 
     def to_dc(self, input_item, table_name: str, format: str = None, **kwargs):
         npartitions = kwargs.pop("npartitions", 1)

--- a/dask_sql/input_utils/pandaslike.py
+++ b/dask_sql/input_utils/pandaslike.py
@@ -10,7 +10,7 @@ from dask_sql.input_utils.base import BaseInputPlugin
 
 
 class PandasLikeInputPlugin(BaseInputPlugin):
-    """Input Plugin for Pandas DataFrames, which get converted to dask DataFrames"""
+    """Input Plugin for Pandas Like DataFrames, which get converted to dask DataFrames"""
 
     def is_correct_input(
         self, input_item, table_name: str, format: str = None, **kwargs

--- a/dask_sql/input_utils/pandaslike.py
+++ b/dask_sql/input_utils/pandaslike.py
@@ -3,13 +3,13 @@ import pandas as pd
 
 try:
     import cudf
-except ImportError:
+except ImportError:  # pragma: no cover
     cudf = None
 
 from dask_sql.input_utils.base import BaseInputPlugin
 
 
-class PandasInputPlugin(BaseInputPlugin):
+class PandasLikeInputPlugin(BaseInputPlugin):
     """Input Plugin for Pandas DataFrames, which get converted to dask DataFrames"""
 
     def is_correct_input(


### PR DESCRIPTION
This PR updates the `PandasInputPlugin` class to also accept (optionally) cudf dataframes, to support operations like:
```python
df = cudf.DataFrame({'a': [1,2,3]})

context.create_table("sql_table", df)
```

Opted to update the existing Pandas class since `dd.from_pandas` syntax works on cudf dataframes as well. Happy to split the implementation as well if that's preferred. 