### PR TITLE
Add conda dev environment for Python 3.7, 3.8

### DIFF
--- a/continuous_integration/environment-3.7-dev.yaml
+++ b/continuous_integration/environment-3.7-dev.yaml
@@ -1,0 +1,37 @@
+name: dask-sql
+channels:
+- conda-forge
+- defaults
+dependencies:
+- black=19.10b0
+- dask-ml>=1.7.0
+- dask>=2.19.0,!=2021.3.0  # dask 2021.3.0 makes dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+- fastapi>=0.61.1
+- intake>=0.6.0
+- isort=5.7.0
+- jpype1>=1.0.2
+- lightgbm>=3.2.1
+- maven>=3.6.0
+- mlflow>=1.19.0
+- mock>=4.0.3
+- nest-asyncio>=1.4.3
+- openjdk>=8
+- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pip=20.2.4
+- pre-commit>=2.11.1
+- prompt_toolkit>=3.0.8
+- psycopg2>=2.9.1
+- pyarrow>=0.15.1
+- pygments>=2.7.1
+- pyhive>=0.6.4
+- pytest-cov>=2.10.1
+- pytest-xdist
+- pytest>=6.0.1
+- python=3.7
+- scikit-learn>=0.24.2
+- sphinx>=3.2.1
+- tpot>=0.11.7
+- tzlocal>=2.1
+- uvicorn>=0.11.3
+- pip:
+  - fugue[sql]>=0.5.3

--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -23,7 +23,7 @@ dependencies:
 - pytest-cov>=2.10.1
 - pytest-xdist
 - pytest>=6.0.1
-- python>=3.7
+- python=3.7
 - scikit-learn>=0.24.2
 - sphinx>=3.2.1
 - tzlocal>=2.1

--- a/continuous_integration/environment-3.7.yaml
+++ b/continuous_integration/environment-3.7.yaml
@@ -1,0 +1,32 @@
+name: dask-sql
+channels:
+- conda-forge
+- defaults
+dependencies:
+- black=19.10b0
+- dask-ml>=1.7.0
+- dask>=2.19.0,!=2021.3.0  # dask 2021.3.0 makes dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+- fastapi>=0.61.1
+- intake>=0.6.0
+- isort=5.7.0
+- jpype1>=1.0.2
+- maven>=3.6.0
+- mock>=4.0.3
+- nest-asyncio>=1.4.3
+- openjdk>=8
+- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pip=20.2.4
+- pre-commit>=2.11.1
+- prompt_toolkit>=3.0.8
+- pyarrow>=0.15.1
+- pygments>=2.7.1
+- pytest-cov>=2.10.1
+- pytest-xdist
+- pytest>=6.0.1
+- python>=3.7
+- scikit-learn>=0.24.2
+- sphinx>=3.2.1
+- tzlocal>=2.1
+- uvicorn>=0.11.3
+- pip:
+  - fugue[sql]>=0.5.3

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -1,0 +1,37 @@
+name: dask-sql
+channels:
+- conda-forge
+- defaults
+dependencies:
+- black=19.10b0
+- dask-ml>=1.7.0
+- dask>=2.19.0,!=2021.3.0  # dask 2021.3.0 makes dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+- fastapi>=0.61.1
+- intake>=0.6.0
+- isort=5.7.0
+- jpype1>=1.0.2
+- lightgbm>=3.2.1
+- maven>=3.6.0
+- mlflow>=1.19.0
+- mock>=4.0.3
+- nest-asyncio>=1.4.3
+- openjdk>=8
+- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pip=20.2.4
+- pre-commit>=2.11.1
+- prompt_toolkit>=3.0.8
+- psycopg2>=2.9.1
+- pyarrow>=0.15.1
+- pygments>=2.7.1
+- pyhive>=0.6.4
+- pytest-cov>=2.10.1
+- pytest-xdist
+- pytest>=6.0.1
+- python=3.8
+- scikit-learn>=0.24.2
+- sphinx>=3.2.1
+- tpot>=0.11.7
+- tzlocal>=2.1
+- uvicorn>=0.11.3
+- pip:
+  - fugue[sql]>=0.5.3

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -1,0 +1,32 @@
+name: dask-sql
+channels:
+- conda-forge
+- defaults
+dependencies:
+- black=19.10b0
+- dask-ml>=1.7.0
+- dask>=2.19.0,!=2021.3.0  # dask 2021.3.0 makes dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+- fastapi>=0.61.1
+- intake>=0.6.0
+- isort=5.7.0
+- jpype1>=1.0.2
+- maven>=3.6.0
+- mock>=4.0.3
+- nest-asyncio>=1.4.3
+- openjdk>=8
+- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pip=20.2.4
+- pre-commit>=2.11.1
+- prompt_toolkit>=3.0.8
+- pyarrow>=0.15.1
+- pygments>=2.7.1
+- pytest-cov>=2.10.1
+- pytest-xdist
+- pytest>=6.0.1
+- python>=3.8
+- scikit-learn>=0.24.2
+- sphinx>=3.2.1
+- tzlocal>=2.1
+- uvicorn>=0.11.3
+- pip:
+  - fugue[sql]>=0.5.3

--- a/continuous_integration/environment-3.8.yaml
+++ b/continuous_integration/environment-3.8.yaml
@@ -23,7 +23,7 @@ dependencies:
 - pytest-cov>=2.10.1
 - pytest-xdist
 - pytest>=6.0.1
-- python>=3.8
+- python=3.8
 - scikit-learn>=0.24.2
 - sphinx>=3.2.1
 - tzlocal>=2.1

--- a/tests/integration/test_hive.py
+++ b/tests/integration/test_hive.py
@@ -150,6 +150,11 @@ def hive_cursor():
         hive_server.exec_run(["chmod", "a+rwx", "-R", tmpdir_parted])
 
         yield cursor
+    except docker.errors.ImageNotFound:
+        pytest.skip(
+            "Hive testing requires 'bde2020/hive:2.3.2-postgresql-metastore' and "
+            "'bde2020/hive-metastore-postgresql:2.3.0' docker images"
+        )
     finally:
         # Now clean up: remove the containers and the network and the folders
         for container in [hive_server, hive_metastore, hive_postgres]:

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -414,7 +414,7 @@ def test_export_model(c, training_df, tmpdir):
 
 def test_mlflow_export(c, training_df, tmpdir):
     # Test only when mlflow was installed
-    mlflow = pytest.importorskip("mlflow", reason="mflow not installed")
+    mlflow = pytest.importorskip("mlflow", reason="mlflow not installed")
 
     c.sql(
         f"""
@@ -470,7 +470,7 @@ def test_mlflow_export(c, training_df, tmpdir):
 
 def test_mlflow_export_xgboost(c, client, training_df, tmpdir):
     # Test only when mlflow & xgboost was installed
-    mlflow = pytest.importorskip("mlflow", reason="mflow not installed")
+    mlflow = pytest.importorskip("mlflow", reason="mlflow not installed")
     xgboost = pytest.importorskip("xgboost", reason="xgboost not installed")
     c.sql(
         f"""
@@ -501,7 +501,7 @@ def test_mlflow_export_xgboost(c, client, training_df, tmpdir):
 
 def test_mlflow_export_lightgbm(c, training_df, tmpdir):
     # Test only when mlflow & lightgbm was installed
-    mlflow = pytest.importorskip("mlflow", reason="mflow not installed")
+    mlflow = pytest.importorskip("mlflow", reason="mlflow not installed")
     lightgbm = pytest.importorskip("lightgbm", reason="lightgbm not installed")
     c.sql(
         f"""


### PR DESCRIPTION
Meant to address [this issue ](https://github.com/rapidsai/dask-build-environment/pull/4#discussion_r706417850) with the planned dask-sql gpuCI images, this PR adds conda environments for Python 3.7 and 3.8:

- `environment-3.*.yaml` is essentially a copy of `conda.txt`, but specifying Python version; we might be able to trim more from this env if we would like it to represent the bare requirements for dask-sql
- `environment-3.*-dev.yaml` contains all the packages from `conda.txt`, as well as those required for testing and development; this can be used in place of `conda.txt` in the GitHub Actions workflows

I also made some minor changes in the Hive tests so that they are skipped with an informative message if we don't have the required Docker images pulled.