### PR TITLE
Add gpuCI support

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,12 @@
 import pytest
 
 pytest_plugins = ["distributed.utils_test", "tests.integration.fixtures"]
+
+
+def pytest_addoption(parser):
+    parser.addoption("--gpu", action="store_true", help="run tests meant for GPU")
+
+
+def pytest_runtest_setup(item):
+    if "gpu" in item.keywords and not item.config.getoption("--gpu"):
+        pytest.skip("need --gpu option to run")

--- a/conftest.py
+++ b/conftest.py
@@ -4,9 +4,9 @@ pytest_plugins = ["distributed.utils_test", "tests.integration.fixtures"]
 
 
 def pytest_addoption(parser):
-    parser.addoption("--gpu", action="store_true", help="run tests meant for GPU")
+    parser.addoption("--rungpu", action="store_true", help="run tests meant for GPU")
 
 
 def pytest_runtest_setup(item):
-    if "gpu" in item.keywords and not item.config.getoption("--gpu"):
-        pytest.skip("need --gpu option to run")
+    if "gpu" in item.keywords and not item.config.getoption("--rungpu"):
+        pytest.skip("need --rungpu option to run")

--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -8,6 +8,6 @@ LINUX_VER:
 - ubuntu18.04
 
 RAPIDS_VER:
-- "21.10"
+- "21.12"
 
 excludes:

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,5 @@ addopts =
     --cov-report=term-missing
 testpaths =
     tests
+markers =
+    gpu: marks tests that require GPUs (skipped by default, run with '--rungpu')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[tool:pytest]
-markers:
-  gpu: marks tests we want to run on GPUs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+markers:
+  gpu: marks tests we want to run on GPUs

--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -8,7 +8,8 @@ from tests.integration.fixtures import skip_if_external_scheduler
 
 
 @skip_if_external_scheduler
-def test_create_from_csv(c, df, temporary_data_file):
+@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+def test_create_from_csv(c, df, temporary_data_file, gpu):
     df.to_csv(temporary_data_file, index=False)
 
     c.sql(
@@ -17,7 +18,8 @@ def test_create_from_csv(c, df, temporary_data_file):
             new_table
         WITH (
             location = '{temporary_data_file}',
-            format = 'csv'
+            format = 'csv',
+            gpu = {gpu}
         )
     """
     )
@@ -28,10 +30,14 @@ def test_create_from_csv(c, df, temporary_data_file):
     """
     ).compute()
 
+    if gpu:
+        result_df = result_df.to_pandas()
+
     assert_frame_equal(result_df, df)
 
 
-def test_cluster_memory(client, c, df):
+@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+def test_cluster_memory(client, c, df, gpu):
     client.publish_dataset(df=dd.from_pandas(df, npartitions=1))
 
     c.sql(
@@ -40,7 +46,8 @@ def test_cluster_memory(client, c, df):
             new_table
         WITH (
             location = 'df',
-            format = 'memory'
+            format = 'memory',
+            gpu = {gpu}
         )
     """
     )
@@ -55,7 +62,8 @@ def test_cluster_memory(client, c, df):
 
 
 @skip_if_external_scheduler
-def test_create_from_csv_persist(c, df, temporary_data_file):
+@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+def test_create_from_csv_persist(c, df, temporary_data_file, gpu):
     df.to_csv(temporary_data_file, index=False)
 
     c.sql(
@@ -65,7 +73,8 @@ def test_create_from_csv_persist(c, df, temporary_data_file):
         WITH (
             location = '{temporary_data_file}',
             format = 'csv',
-            persist = True
+            persist = True,
+            gpu = {gpu}
         )
     """
     )
@@ -75,6 +84,9 @@ def test_create_from_csv_persist(c, df, temporary_data_file):
         SELECT * FROM new_table
     """
     ).compute()
+
+    if gpu:
+        return_df = return_df.to_pandas()
 
     assert_frame_equal(df, return_df)
 
@@ -143,7 +155,20 @@ def test_create_from_query(c, df):
 
 
 @skip_if_external_scheduler
-def test_view_table_persist(c, temporary_data_file, df):
+@pytest.mark.parametrize(
+    "gpu",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=(
+                pytest.mark.gpu,
+                pytest.mark.xfail(reason="to_pandas() changes int precision"),
+            ),
+        ),
+    ],
+)
+def test_view_table_persist(c, temporary_data_file, df, gpu):
     df.to_csv(temporary_data_file, index=False)
     c.sql(
         f"""
@@ -151,7 +176,8 @@ def test_view_table_persist(c, temporary_data_file, df):
             new_table
         WITH (
             location = '{temporary_data_file}',
-            format = 'csv'
+            format = 'csv',
+            gpu = {gpu}
         )
     """
     )
@@ -177,21 +203,27 @@ def test_view_table_persist(c, temporary_data_file, df):
     """
     )
 
-    assert_frame_equal(
-        c.sql("SELECT c FROM count_view").compute(), pd.DataFrame({"c": [700]})
-    )
-    assert_frame_equal(
-        c.sql("SELECT c FROM count_table").compute(), pd.DataFrame({"c": [700]})
-    )
+    from_view = c.sql("SELECT c FROM count_view").compute()
+    from_table = c.sql("SELECT c FROM count_table").compute()
+
+    if gpu:
+        from_view = from_view.to_pandas()
+        from_table = from_table.to_pandas()
+
+    assert_frame_equal(from_view, pd.DataFrame({"c": [700]}))
+    assert_frame_equal(from_table, pd.DataFrame({"c": [700]}))
 
     df.iloc[:10].to_csv(temporary_data_file, index=False)
 
-    assert_frame_equal(
-        c.sql("SELECT c FROM count_view").compute(), pd.DataFrame({"c": [10]})
-    )
-    assert_frame_equal(
-        c.sql("SELECT c FROM count_table").compute(), pd.DataFrame({"c": [700]})
-    )
+    from_view = c.sql("SELECT c FROM count_view").compute()
+    from_table = c.sql("SELECT c FROM count_table").compute()
+
+    if gpu:
+        from_view = from_view.to_pandas()
+        from_table = from_table.to_pandas()
+
+    assert_frame_equal(from_view, pd.DataFrame({"c": [10]}))
+    assert_frame_equal(from_table, pd.DataFrame({"c": [700]}))
 
 
 def test_replace_and_error(c, temporary_data_file, df):

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -88,7 +88,19 @@ def test_explain(gpu):
     )
 
 
-@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+@pytest.mark.parametrize(
+    "gpu",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=(
+                pytest.mark.gpu,
+                pytest.mark.xfail(reason="create_table(gpu=True) doesn't work"),
+            ),
+        ),
+    ],
+)
 def test_sql(gpu):
     c = Context()
 
@@ -110,7 +122,19 @@ def test_sql(gpu):
     dd.assert_eq(result, data_frame)
 
 
-@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+@pytest.mark.parametrize(
+    "gpu",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=(
+                pytest.mark.gpu,
+                pytest.mark.xfail(reason="create_table(gpu=True) doesn't work"),
+            ),
+        ),
+    ],
+)
 def test_input_types(temporary_data_file, gpu):
     c = Context()
     df = pd.DataFrame({"a": [1, 2, 3]})
@@ -147,7 +171,21 @@ def test_input_types(temporary_data_file, gpu):
         c.create_table("df", strangeThing, gpu=gpu)
 
 
-@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+@pytest.mark.parametrize(
+    "gpu",
+    [
+        False,
+        pytest.param(
+            True,
+            marks=(
+                pytest.mark.gpu,
+                pytest.mark.xfail(
+                    reason="GPU tables aren't picked up by _get_tables_from_stack"
+                ),
+            ),
+        ),
+    ],
+)
 def test_tables_from_stack(gpu):
     c = Context()
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -151,7 +151,7 @@ def test_input_types(temporary_data_file, gpu):
     assert_correct_output(gpu=gpu)
 
     df.to_csv(temporary_data_file, index=False)
-    c.create_table("df", temporary_data_file, gpu=True)
+    c.create_table("df", temporary_data_file, gpu=gpu)
     assert_correct_output(gpu=gpu)
 
     df.to_csv(temporary_data_file, index=False)


### PR DESCRIPTION
This PR adds:
- pytest marker `gpu`, which when added to tests causes them to be skipped by default unless `--rungpu` is provided
- tests for the GPU table creation added in #220 and #224 
- the build files used by gpuCI to run on any open PRs