### PR TITLE
Do not persist data to memory by default when creating tables

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,12 @@
 import pytest
 
 pytest_plugins = ["distributed.utils_test", "tests.integration.fixtures"]
+
+
+def pytest_addoption(parser):
+    parser.addoption("--rungpu", action="store_true", help="run tests meant for GPU")
+
+
+def pytest_runtest_setup(item):
+    if "gpu" in item.keywords and not item.config.getoption("--rungpu"):
+        pytest.skip("need --rungpu option to run")

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -123,7 +123,7 @@ class Context:
         table_name: str,
         input_table: InputType,
         format: str = None,
-        persist: bool = True,
+        persist: bool = False,
         schema_name: str = None,
         gpu: bool = False,
         **kwargs,
@@ -144,8 +144,9 @@ class Context:
         Typical file formats are csv or parquet.
         Any additional parameters will get passed on to the read method.
         Please note that some file formats require additional libraries.
-        By default, the data will be loaded directly into the memory
-        of the nodes. If you do not want that, set persist to False.
+        By default, the data will be lazily loaded. If you would like to
+        load the data directly into memory you can do so by setting
+        persist=True.
 
         See :ref:`data_input` for more information.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+markers:
+  gpu: marks tests we want to run on GPUs


### PR DESCRIPTION
Currently data is persisted into memory when create_table is invoked. Instead this PR will set the default for persist to False which will prevent that from happening.

This Closes: dask-contrib#218