### PR TITLE
Support pandas style row udfs

### DIFF
--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -188,4 +188,5 @@ class SchemaContainer:
         self.experiments: Dict[str, pd.DataFrame] = {}
         self.models: Dict[str, Tuple[Any, List[str]]] = {}
         self.functions: Dict[str, Callable] = {}
+        self.row_functions: Dict[str, Callable] = {}
         self.function_lists: List[FunctionDescription] = []

--- a/dask_sql/physical/rel/convert.py
+++ b/dask_sql/physical/rel/convert.py
@@ -49,7 +49,7 @@ class RelConverter(Pluggable):
             raise NotImplementedError(
                 f"No conversion for class {class_name} available (yet)."
             )
-
+        print(f"Processing REL {rel} using {plugin_instance.__class__.__name__}...)")
         logger.debug(
             f"Processing REL {rel} using {plugin_instance.__class__.__name__}..."
         )

--- a/docs/pages/custom.rst
+++ b/docs/pages/custom.rst
@@ -33,6 +33,22 @@ After registration, the function can be used as any other usual SQL function:
 
 Scalar functions can have one or more input parameters and can combine columns and literal values.
 
+Row-Wise Pandas UDFs
+----------------
+In some cases it may be easier to write custom functions which process a dict like row object, such as those consumed by ``pandas.DataFrame.apply``.
+These functions may be registered as above and flagged as row UDFs using the `row_udf` keyword argument:
+
+.. code-block:: python
+
+    def f(row):
+        return row['a'] + row['b']
+
+    # todo - fix the api
+    c.register_function(f, "f", [], None, row_udf=True)
+    c.sql("SELECT f(a, b) FROM data")
+
+** Note: Row UDFs use `apply` which may have unpredictable performance characteristics, depending on the function and dataframe library **
+
 Aggregation Functions
 ---------------------
 

--- a/tests/integration/test_function.py
+++ b/tests/integration/test_function.py
@@ -20,6 +20,23 @@ def test_custom_function(c, df):
 
     assert_frame_equal(return_df.reset_index(drop=True), df[["a"]] ** 2)
 
+def test_custom_function_row(c, df):
+    def f(row):
+        return row['a'] ** 2
+
+    c.register_function(f, "f", [("x", np.float64)], np.float64, row_udf=True)
+
+    return_df = c.sql(
+        """
+        SELECT F(a) AS a
+        FROM df
+        """
+    )
+    return_df = return_df.compute()
+
+    assert_frame_equal(return_df.reset_index(drop=True), df[["a"]] ** 2)
+
+
 
 def test_multiple_definitions(c, df_simple):
     def f(x):


### PR DESCRIPTION
WIP. Closes https://github.com/dask-contrib/dask-sql/issues/225.

Lets users invoke functions that map onto `xyz.DataFrame.apply`, such as:

```python
  def f(row):
      if row['a'] is pd.NA:
          return 42
      return row['a'] + row['b']
```

