### PR TITLE
Automatically label bugs / feature requests for triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report to help us improve dask-sql
 title: "[BUG]"
-labels: "bug"
+labels: "bug, needs triage"
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for dask-sql
 title: "[ENH]"
-labels: "enhancement"
+labels: "enhancement, needs triage"
 assignees: ''
 
 ---


### PR DESCRIPTION
Part of addressing #259; we might also want to mark questions / doc requests for triage as well