### PR TITLE
Remove null-splitting from `_perform_aggregation`

### DIFF
--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -15,6 +15,7 @@ except ImportError:
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.physical.rel.base import BaseRelPlugin
 from dask_sql.physical.rex.core.call import IsNullOperation
+from dask_sql.physical.utils.groupby import get_groupby_with_nulls_cols
 from dask_sql.utils import new_temporary_column
 
 if TYPE_CHECKING:
@@ -360,33 +361,44 @@ class LogicalAggregatePlugin(BaseRelPlugin):
     ):
         tmp_df = df
 
+        # format aggregations for Dask; also check if we can use fast path for
+        # groupby, which is only supported if we are not using any custom aggregations
+        aggregations_dict = defaultdict(dict)
+        fast_groupby = True
+        for aggregation in aggregations:
+            input_col, output_col, aggregation_f = aggregation
+            aggregations_dict[input_col][output_col] = aggregation_f
+            if not isinstance(aggregation_f, str):
+                fast_groupby = False
+
+        # filter dataframe if specified
         if filter_column:
             filter_expression = tmp_df[filter_column]
             tmp_df = tmp_df[filter_expression]
-
             logger.debug(f"Filtered by {filter_column} before aggregation.")
+
+        # we might need a temporary column name if no groupby columns are specified
         if additional_column_name is None:
             additional_column_name = new_temporary_column(df)
-        if not group_columns:
-            group_columns = [additional_column_name]
 
-        grouped_df = tmp_df.groupby(by=group_columns, dropna=False)
+        # perform groupby operation; if we are using custom aggreagations, we must handle
+        # null values manually (this is slow)
+        if fast_groupby:
+            grouped_df = tmp_df.groupby(
+                by=(group_columns or [additional_column_name]), dropna=False
+            )
+        else:
+            group_columns = [tmp_df[group_column] for group_column in group_columns]
+            group_columns_and_nulls = get_groupby_with_nulls_cols(
+                tmp_df, group_columns, additional_column_name
+            )
+            grouped_df = tmp_df.groupby(by=group_columns_and_nulls)
 
-        # Convert into the correct format for dask
-        aggregations_dict = defaultdict(dict)
-        for aggregation in aggregations:
-            input_col, output_col, aggregation_f = aggregation
-
-            aggregations_dict[input_col][output_col] = aggregation_f
-
-        # Now apply the aggregation
+        # apply the aggregation(s)
         logger.debug(f"Performing aggregation {dict(aggregations_dict)}")
         agg_result = grouped_df.agg(aggregations_dict)
 
-        # ... fix the column names to a single level ...
+        # fix the column names to a single level
         agg_result.columns = agg_result.columns.get_level_values(-1)
-
-        # TODO: if we want to move nulls to the front of the dataframe,
-        # we should probably do it here
 
         return agg_result

--- a/dask_sql/physical/utils/groupby.py
+++ b/dask_sql/physical/utils/groupby.py
@@ -19,7 +19,6 @@ def get_groupby_with_nulls_cols(
 
     group_columns_and_nulls = []
     for group_column in group_columns:
-        # the ~ makes NaN come first
         is_null_column = group_column.isnull()
         non_nan_group_column = group_column.fillna(0)
 

--- a/dask_sql/physical/utils/groupby.py
+++ b/dask_sql/physical/utils/groupby.py
@@ -20,7 +20,7 @@ def get_groupby_with_nulls_cols(
     group_columns_and_nulls = []
     for group_column in group_columns:
         # the ~ makes NaN come first
-        is_null_column = ~(group_column.isnull())
+        is_null_column = group_column.isnull()
         non_nan_group_column = group_column.fillna(0)
 
         group_columns_and_nulls += [is_null_column, non_nan_group_column]

--- a/tests/integration/test_compatibility.py
+++ b/tests/integration/test_compatibility.py
@@ -296,7 +296,9 @@ def test_agg_count():
             COUNT(DISTINCT d) AS cd_d,
             COUNT(e) AS c_e,
             COUNT(DISTINCT a) AS cd_e
-        FROM a GROUP BY a, b
+        FROM a GROUP BY a, b ORDER BY
+            a NULLS FIRST,
+            b NULLS FIRST
         """,
         a=a,
     )
@@ -346,7 +348,9 @@ def test_agg_sum_avg():
             AVG(e) AS avg_e,
             SUM(a)+AVG(e) AS mix_1,
             SUM(a+e) AS mix_2
-        FROM a GROUP BY a,b
+        FROM a GROUP BY a, b ORDER BY
+            a NULLS FIRST,
+            b NULLS FIRST
         """,
         a=a,
     )
@@ -415,7 +419,9 @@ def test_agg_min_max():
             MAX(g) AS max_g,
             MIN(a+e) AS mix_1,
             MIN(a)+MIN(e) AS mix_2
-        FROM a GROUP BY a, b
+        FROM a GROUP BY a, b ORDER BY
+            a NULLS FIRST,
+            b NULLS FIRST
         """,
         a=a,
     )


### PR DESCRIPTION
dask-sql currently uses a workaround `get_groupby_with_nulls_cols` to split a dataframe by nulls/non-nulls before performing a groupby. This seems unnecessary, as we can use `groupby(dropna=False)` to keep nulls in the groupby result, and then later move them to the front of the dataframe (depending on how strictly we want to follow PostgreSQL). For comparison, here are the task graphs for a basic SQL operation:

```sql
SELECT
     user_id, SUM(b) AS "S"
FROM user_table_1
GROUP BY user_id
```

Before this PR:

```
HighLevelGraph with 20 layers.
<dask.highlevelgraph.HighLevelGraph object at 0x7fbc344ae590>
 0. from_pandas-b5125674539d8b5d1f754260e384e1fa
 1. assign-e29cf71863faee69539b6f78b8dbc8f3
 2. getitem-aa5bcd5e86836ebad1df2a90117e16f6
 3. fillna-94de4188d246caf9e1b4bf4f1debce03
 4. isnull-76ff5f3bc798aa3da45b6b16dae758fc
 5. inv-8c38b3dd8368fbb685b718f17180f00b
 6. aggregate-agg-838eda3f7eb4dbc264011a4f8e14a10b
 7. rename-c2e63c54b4d4fff51825029f94563613
 8. reset_index-3a34f3d8a1856ef12b299845da6afa8c
 9. rename-79dfdb294050405020a476146c8b5845
 10. getitem-be78c3b9d2c681e09cccdfdf783dbd1f
 11. eq-77e1f642c7c2a8e643f4a22b61af4e11
 12. inv-07fa50e82ef9e1e810819771a8e1ce2d
 13. getitem-1cc4911cff51b0537d276b6a9de6ebf7
 14. where-7cc4db419a8a2172e17accd935b851f4
 15. assign-8ac7e56123d06d1204acb6609e9541b6
 16. getitem-0ab1e73633488c2092c98ca87c31333c
 17. getitem-2a55368cca98a96e0d82198cd6bd7802
 18. assign-837d2902d726cbdd2f356860ab530f04
 19. getitem-f7c62a09776201bb03dae99feccd8138
```

And after:

```
HighLevelGraph with 16 layers.
<dask.highlevelgraph.HighLevelGraph object at 0x7f9c4455d730>
 0. from_pandas-b5125674539d8b5d1f754260e384e1fa
 1. assign-d126cb139c7dfef7033f0e1f1559a8aa
 2. aggregate-agg-5b194136cacfc9fef1c06119ce6a453f
 3. rename-529a9e13861a74ca909376c58eb77c82
 4. reset_index-fcfd12137febeac9b4cfed91590b47c5
 5. rename-1b4bcbd7d2f03cb785833918fd7e148a
 6. getitem-583c0b466bd64af2ba8edf50c31ec41b
 7. eq-c3e82a692e1f30a2482a526c57bfdf74
 8. inv-dd614b43ef9503c3ee6b6c1d0afabe65
 9. getitem-c598fe29b226039022009f4aca4598be
 10. where-491a45d0103973393d8e07a9b82481e9
 11. assign-fb69ab150f02d3d829815441b5e38bc1
 12. getitem-fc12148fe3ee2696902590cbf32e2620
 13. getitem-643b1fd05b327c34403caedd348cd66b
 14. assign-35d81a9f9ef223a5cc776b41dd7dc231
 15. getitem-801bb5652b721f072ea3d18ab9de6db9
```

This is currently excluding null position handling - adding that in will probably bring back some layers