### PR TITLE
Pass `return_type` through to `meta` in apply

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -815,7 +815,7 @@ class Context:
         schema = self.schema[schema_name]
 
         if not aggregation:
-            f = UDF(f, row_udf)
+            f = UDF(f, row_udf, return_type)
 
         lower_name = name.lower()
         if lower_name in schema.functions:

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -182,7 +182,7 @@ class DataContainer:
 
 
 class UDF:
-    def __init__(self, func, row_udf: bool):
+    def __init__(self, func, row_udf: bool, return_type=None):
         """
         Helper class that handles different types of UDFs and manages
         how they should be mapped to dask operations. Two versions of
@@ -194,13 +194,14 @@ class UDF:
         """
         self.row_udf = row_udf
         self.func = func
+        self.meta = (None, return_type)
 
     def __call__(self, *args, **kwargs):
         if self.row_udf:
             df = args[0].to_frame()
             for operand in args[1:]:
                 df[operand.name] = operand
-            result = df.apply(self.func, axis=1)
+            result = df.apply(self.func, axis=1, meta=self.meta)
         else:
             result = self.func(*args, **kwargs)
         return result


### PR DESCRIPTION
UDFs that call `apply` currently trigger a dask warning since the return type is not packed into the `meta` that the final `apply` call uses. This PR passes the original return type passed by the user into `apply` to prevent the warning. 