### PR TITLE
Add groupby split_out config options to dask-sql

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -540,19 +540,61 @@ class Context:
         Add configuration options to a schema.
         A configuration option could be used to set the behavior of certain configurirable operations.
 
-        Eg: `dask.groupby.agg.split_out` can be used to split the output of a groupby agrregation to multiple partitions
+        Eg: `dask.groupby.agg.split_out` can be used to split the output of a groupby agrregation to multiple partitions.
+
+        Args:
+            config_options (:obj:`Tuple[str,val]` or :obj:`Dict[str,val]`): config_option and value to set
+            schema_name (:obj:`str`): Optionally select schema for setting configs
+
+        Example:
+            .. code-block:: python
+
+                from dask_sql import Context
+
+                c = Context()
+                c.set_config(("dask.groupby.aggregate.split_out", 1))
+                c.set_config(
+                    {
+                        "dask.groupby.aggregate.split_out": 2,
+                        "dask.groupby.aggregate.split_every": 4,
+                    }
+                )
+
         """
         schema_name = schema_name or self.schema_name
         self.schema[schema_name].config.set_config(config_options)
 
     def drop_config(
-        self, config_str: Union[str, List[str]], schema_name: str = None,
+        self, config_strs: Union[str, List[str]], schema_name: str = None,
     ):
         """
         Drop user set configuration options from schema
+
+        Args:
+            config_strs (:obj:`str` or :obj:`List[str]`): config key or keys to drop
+            schema_name (:obj:`str`): Optionally select schema for dropping configs
+
+        Example:
+            .. code-block:: python
+
+                from dask_sql import Context
+
+                c = Context()
+                c.set_config(
+                    {
+                        "dask.groupby.aggregate.split_out": 2,
+                        "dask.groupby.aggregate.split_every": 4,
+                    }
+                )
+                c.drop_config(
+                    [
+                        "dask.groupby.aggregate.split_out",
+                        "dask.groupby.aggregate.split_every",
+                    ]
+                )
         """
         schema_name = schema_name or self.schema_name
-        self.schema[schema_name].config.drop_config(config_str)
+        self.schema[schema_name].config.drop_config(config_strs)
 
     def ipython_magic(self, auto_include=False):  # pragma: no cover
         """

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -531,6 +531,20 @@ class Context:
         schema_name = schema_name or self.schema_name
         self.schema[schema_name].models[model_name.lower()] = (model, training_columns)
 
+    def set_config(
+        self,
+        config_options: Union[Tuple[str, Any], Dict[str, Any]],
+        schema_name: str = None,
+    ):
+        """
+        Add configuration options to a schema.
+        A configuration option could be used to set the behavior of certain configurirable operations.
+
+        Eg: `dask.groupby.agg.split_out` can be used to split the output of a groupby agrregation to multiple partitions
+        """
+        schema_name = schema_name or self.schema_name
+        self.schema[schema_name].config.set_config(config_options)
+
     def ipython_magic(self, auto_include=False):  # pragma: no cover
         """
         Register a new ipython/jupyter magic function "sql"

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -545,6 +545,15 @@ class Context:
         schema_name = schema_name or self.schema_name
         self.schema[schema_name].config.set_config(config_options)
 
+    def drop_config(
+        self, config_str: Union[str, List[str]], schema_name: str = None,
+    ):
+        """
+        Drop user set configuration options from schema
+        """
+        schema_name = schema_name or self.schema_name
+        self.schema[schema_name].config.drop_config(config_str)
+
     def ipython_magic(self, auto_include=False):  # pragma: no cover
         """
         Register a new ipython/jupyter magic function "sql"

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -815,7 +815,7 @@ class Context:
         schema = self.schema[schema_name]
 
         if not aggregation:
-            f = UDF(f, row_udf)
+            f = UDF(f, row_udf, return_type)
 
         lower_name = name.lower()
         if lower_name in schema.functions:

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -224,3 +224,30 @@ class SchemaContainer:
         self.models: Dict[str, Tuple[Any, List[str]]] = {}
         self.functions: Dict[str, UDF] = {}
         self.function_lists: List[FunctionDescription] = []
+        self.config: ConfigContainer = ConfigContainer()
+
+
+class ConfigContainer:
+    """
+    Helper class that contains configuration options required for specific operations
+    Eg: dask groupby aggregate operations can be configured via with the `split_out` option
+    to determine number of output partitions or the `split_every` option to determine
+    the number of partitions used during the groupby tree reduction step.
+    """
+
+    def __init__(self):
+        self.config_dict = {
+            "dask.groupby.aggregate.split_out": 1,
+            "dask.groupby.aggregate.split_every": None,
+        }
+
+    def set_config(self, config_options: Union[Tuple[str, Any], Dict[str, Any]]):
+        if isinstance(config_options, tuple):
+            config_options = [config_options]
+        self.config_dict.update(config_options)
+
+    def get_groupby_aggregate_configs(self):
+        return {
+            "split_out": self.config_dict.get("dask.groupby.aggregate.split_out"),
+            "split_every": self.config_dict.get("dask.groupby.aggregate.split_every"),
+        }

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -261,10 +261,10 @@ class ConfigContainer:
             config_options = [config_options]
         self.config_dict.update(config_options)
 
-    def drop_config(self, config_str: Union[str, List[str]]):
-        if isinstance(config_str, str):
-            config_str = [config_str]
-        for config_key in config_str:
+    def drop_config(self, config_strs: Union[str, List[str]]):
+        if isinstance(config_strs, str):
+            config_strs = [config_strs]
+        for config_key in config_strs:
             self.config_dict.pop(config_key)
 
     def get_config_by_prefix(self, config_prefix: str):

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -272,38 +272,38 @@ class ConfigContainer:
         Returns all configuration options matching the prefix in `config_prefix`
 
         Example:
-            . code-block:: python
+            .. code-block:: python
 
-            from dask_sql.datacontainer import ConfigContainer
+                from dask_sql.datacontainer import ConfigContainer
 
-            sql_config = ConfigContainer()
-            sql_config.set_config(
-                {
-                 "dask.groupby.aggregate.split_out":1,
-                 "dask.groupby.aggregate.split_every": 1,
-                 "dask.sort.persist": True,
-                }
-            )
+                sql_config = ConfigContainer()
+                sql_config.set_config(
+                    {
+                     "dask.groupby.aggregate.split_out":1,
+                     "dask.groupby.aggregate.split_every": 1,
+                     "dask.sort.persist": True,
+                    }
+                )
 
-            sql_config.get_config_by_prefix("dask.groupby")
-            # Returns {
-            #   "dask.groupby.aggregate.split_out":1,
-            #   "dask.groupby.aggregate.split_every":1
-            # }
+                sql_config.get_config_by_prefix("dask.groupby")
+                # Returns {
+                #   "dask.groupby.aggregate.split_out": 1,
+                #   "dask.groupby.aggregate.split_every": 1
+                # }
 
-            sql_config.get_config_by_prefix("dask")
-            # Returns {
-            #   "dask.groupby.aggregate.split_out":1,
-            #   "dask.groupby.aggregate.split_every":1,
-            #   "dask.sort.persist": True
-            #   }
+                sql_config.get_config_by_prefix("dask")
+                # Returns {
+                #   "dask.groupby.aggregate.split_out": 1,
+                #   "dask.groupby.aggregate.split_every": 1,
+                #   "dask.sort.persist": True
+                #   }
 
-            sql_config.get_config_by_prefix("dask.sort")
-            # Returns {"dask.sort.persist": True}
+                sql_config.get_config_by_prefix("dask.sort")
+                # Returns {"dask.sort.persist": True}
 
-            sql_config.get_config_by_prefix("missing.key")
-            sql_config.get_config_by_prefix(None)
-            # Both return {}
+                sql_config.get_config_by_prefix("missing.key")
+                sql_config.get_config_by_prefix(None)
+                # Both return {}
 
         """
         return (

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -295,7 +295,7 @@ class ConfigContainer:
             # Returns {
             #   "dask.groupby.aggregate.split_out":1,
             #   "dask.groupby.aggregate.split_every":1,
-            #   "dask.sort.persistpersist": True
+            #   "dask.sort.persist": True
             #   }
 
             sql_config.get_config_by_prefix("dask.sort")

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -183,7 +183,7 @@ class DataContainer:
 
 
 class UDF:
-    def __init__(self, func, row_udf: bool):
+    def __init__(self, func, row_udf: bool, return_type=None):
         """
         Helper class that handles different types of UDFs and manages
         how they should be mapped to dask operations. Two versions of
@@ -195,13 +195,14 @@ class UDF:
         """
         self.row_udf = row_udf
         self.func = func
+        self.meta = (None, return_type)
 
     def __call__(self, *args, **kwargs):
         if self.row_udf:
             df = args[0].to_frame()
             for operand in args[1:]:
                 df[operand.name] = operand
-            result = df.apply(self.func, axis=1)
+            result = df.apply(self.func, axis=1, meta=self.meta)
         else:
             result = self.func(*args, **kwargs)
         return result

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -236,24 +236,82 @@ class SchemaContainer:
 class ConfigContainer:
     """
     Helper class that contains configuration options required for specific operations
-    Eg: dask groupby aggregate operations can be configured via with the `split_out` option
-    to determine number of output partitions or the `split_every` option to determine
-    the number of partitions used during the groupby tree reduction step.
+    Configurations are stored in a dictionary where keys strings are delimited by `.`
+    for easier nested access of multiple configurations
+    Example:
+        Dask groupby aggregate operations can be configured via with the `split_out` option
+        to determine number of output partitions or the `split_every` option to determine
+        the number of partitions used during the groupby tree reduction step.
     """
 
     def __init__(self):
         self.config_dict = {
-            "dask.groupby.aggregate.split_out": 1,
-            "dask.groupby.aggregate.split_every": None,
+            # Do not set defaults here unless needed
+            # This mantains the list of configuration options supported that can be set
+            # "dask.groupby.aggregate.split_out": 1,
+            # "dask.groupby.aggregate.split_every": None,
         }
 
     def set_config(self, config_options: Union[Tuple[str, Any], Dict[str, Any]]):
+        """
+        Accepts either a tuple of (config, val) or a dictionary containing multiple
+        {config1: val1, config2: val2} pairs and updates the schema config with these values
+        """
         if isinstance(config_options, tuple):
             config_options = [config_options]
         self.config_dict.update(config_options)
 
-    def get_groupby_aggregate_configs(self):
-        return {
-            "split_out": self.config_dict.get("dask.groupby.aggregate.split_out"),
-            "split_every": self.config_dict.get("dask.groupby.aggregate.split_every"),
-        }
+    def drop_config(self, config_str: Union[str, List[str]]):
+        if isinstance(config_str, str):
+            config_str = [config_str]
+        for config_key in config_str:
+            self.config_dict.pop(config_key)
+
+    def get_config_by_prefix(self, config_prefix: str):
+        """
+        Returns all configuration options matching the prefix in `config_prefix`
+
+        Example:
+            . code-block:: python
+
+            from dask_sql.datacontainer import ConfigContainer
+
+            sql_config = ConfigContainer()
+            sql_config.set_config(
+                {
+                 "dask.groupby.aggregate.split_out":1,
+                 "dask.groupby.aggregate.split_every": 1,
+                 "dask.sort.persist": True,
+                }
+            )
+
+            sql_config.get_config_by_prefix("dask.groupby")
+            # Returns {
+            #   "dask.groupby.aggregate.split_out":1,
+            #   "dask.groupby.aggregate.split_every":1
+            # }
+
+            sql_config.get_config_by_prefix("dask")
+            # Returns {
+            #   "dask.groupby.aggregate.split_out":1,
+            #   "dask.groupby.aggregate.split_every":1,
+            #   "dask.sort.persistpersist": True
+            #   }
+
+            sql_config.get_config_by_prefix("dask.sort")
+            # Returns {"dask.sort.persist": True}
+
+            sql_config.get_config_by_prefix("missing.key")
+            sql_config.get_config_by_prefix(None)
+            # Both return {}
+
+        """
+        return (
+            {
+                key: val
+                for key, val in self.config_dict.items()
+                if key.startswith(config_prefix)
+            }
+            if config_prefix
+            else {}
+        )

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -171,14 +171,15 @@ class DataContainer:
         a dataframe which has the the columns specified in the
         stored ColumnContainer.
         """
-        df = self.df.assign(
-            **{
-                col_from: self.df[col_to]
-                for col_from, col_to in self.column_container.mapping()
-                if col_from in self.column_container.columns
-            }
-        )
-        return df[self.column_container.columns]
+        df = self.df[
+            [
+                self.column_container._frontend_backend_mapping[out_col]
+                for out_col in self.column_container.columns
+            ]
+        ]
+        df.columns = self.column_container.columns
+
+        return df
 
 
 class UDF:

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -233,7 +233,13 @@ class LogicalAggregatePlugin(BaseRelPlugin):
 
         groupby_agg_options = context.schema[
             context.schema_name
-        ].config.get_groupby_aggregate_configs()
+        ].config.get_config_by_prefix("dask.groupby.aggregate")
+        # Update the config string to only include the actual param value
+        # i.e. dask.groupby.aggregate.split_out -> split_out
+        for config_key in list(groupby_agg_options.keys()):
+            groupby_agg_options[
+                config_key.rpartition(".")[2]
+            ] = groupby_agg_options.pop(config_key)
         # Now we can go ahead and use these grouped aggregations
         # to perform the actual aggregation
         # It is very important to start with the non-filtered entry.

--- a/dask_sql/physical/rel/logical/window.py
+++ b/dask_sql/physical/rel/logical/window.py
@@ -395,7 +395,9 @@ class LogicalWindowPlugin(BaseRelPlugin):
                 operation = self.OPERATION_MAPPING[operator_name]
             except KeyError:  # pragma: no cover
                 try:
-                    operation = context.functions[operator_name]
+                    operation = context.schema[context.schema_name].functions[
+                        operator_name
+                    ]
                 except KeyError:  # pragma: no cover
                     raise NotImplementedError(f"{operator_name} not (yet) implemented")
 

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pandas as pd
+import pytest
+from dask import dataframe as dd
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 
@@ -345,3 +347,60 @@ def test_stats_aggregation(c, timeseries_df):
         check_dtype=False,
         check_names=False,
     )
+
+
+@pytest.mark.parametrize(
+    "input_table",
+    ["user_table_1", pytest.param("gpu_user_table_1", marks=pytest.mark.gpu),],
+)
+@pytest.mark.parametrize("split_out", [None, 2, 4])
+def test_groupby_split_out(c, input_table, split_out, request):
+    user_table = request.getfixturevalue(input_table)
+    c.set_config(("dask.groupby.aggregate.split_out", split_out))
+    df = c.sql(
+        f"""
+        SELECT
+        user_id, SUM(b) AS "S"
+        FROM {input_table}
+        GROUP BY user_id
+        """
+    )
+    expected_df = (
+        user_table.groupby(by="user_id").agg({"b": "sum"}).reset_index(drop=False)
+    )
+    expected_df = expected_df.rename(columns={"b": "S"})
+    expected_df = expected_df.sort_values("user_id")
+    assert df.npartitions == split_out if split_out else 1
+    dd.assert_eq(df.compute().sort_values("user_id"), expected_df, check_index=False)
+    c.drop_config("dask.groupby.aggregate.split_out")
+
+
+@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+@pytest.mark.parametrize("split_every,expected_keys", [(2, 154), (3, 148), (4, 144)])
+def test_groupby_split_every(c, gpu, split_every, expected_keys):
+    xd = pytest.importorskip("cudf") if gpu else pd
+    input_ddf = dd.from_pandas(
+        xd.DataFrame({"user_id": [1, 2, 3, 4] * 16, "b": [5, 6, 7, 8] * 16}),
+        npartitions=16,
+    )  # Need an input with multiple partitions to demonstrate split_every
+    c.create_table("split_every_input", input_ddf)
+    c.set_config(("dask.groupby.aggregate.split_every", split_every))
+    df = c.sql(
+        """
+        SELECT
+        user_id, SUM(b) AS "S"
+        FROM split_every_input
+        GROUP BY user_id
+        """
+    )
+    expected_df = (
+        input_ddf.groupby(by="user_id")
+        .agg({"b": "sum"}, split_every=split_every)
+        .reset_index(drop=False)
+    )
+    expected_df = expected_df.rename(columns={"b": "S"})
+    expected_df = expected_df.sort_values("user_id")
+    assert len(df.dask.keys()) == expected_keys
+    dd.assert_eq(df.compute().sort_values("user_id"), expected_df, check_index=False)
+    c.drop_config("dask.groupby.aggregate.split_every")
+    c.drop_table("split_every_input")


### PR DESCRIPTION
This PR is an initial pass based on the approach discussed in https://github.com/dask-contrib/dask-sql/issues/241#issuecomment-944504551.

The PR does the following:
- [X] Create a `ConfigContainer` class responsible for storing the configuration dictionary as well as providing helper methods to set/update and retrieve configurations. 
  - This class has a set of defaults to use when no configuration options are provided. One con of this approach is that it would need to be updated if any upstream library changes their default behavior. I'm considering if this should be left empty instead?
-  [X] The `ConfigContainer` object belongs to a schema. This means that each schema uses the same configuration set.   
   - [ ] Consider making the configs changeable per `context.sql` run in addition to having a schema wide config.
- [X] Adds the usage of the `split_out` and `split_every` config options during groupby aggregations in the `aggregate` plan. 
  - In practice this doesn't work right now due to an edgecase with how dask-sql calls groupby and how dask hashes output partitions when splitting out. 
  - [X] Raise an issue for the above - dask/dask/issues/8307
  - [X] Unblocked by #289 
- [ ] Add tests for config
- [x] Add tests for groupby w/ configs
- [ ] Add docs explaining the different config options