### PR TITLE
Prevent JVM Segfault

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -9,8 +9,8 @@ import pandas as pd
 from dask.base import optimize
 from dask.distributed import Client
 
-try
-    import dask_cuda
+try:
+    import dask_cuda # noqa: F401
 except: ImportError: # pragma: no cover
     pass
 

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -8,7 +8,11 @@ import dask.dataframe as dd
 import pandas as pd
 from dask.base import optimize
 from dask.distributed import Client
-import dask_cuda
+
+try
+    import dask_cuda
+except: ImportError: # pragma: no cover
+    pass
 
 from dask_sql import input_utils
 from dask_sql.datacontainer import (

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -11,7 +11,7 @@ from dask.distributed import Client
 
 try:
     import dask_cuda # noqa: F401
-except: ImportError: # pragma: no cover
+except ImportError: # pragma: no cover
     pass
 
 from dask_sql import input_utils

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -9,6 +9,11 @@ import pandas as pd
 from dask.base import optimize
 from dask.distributed import Client
 
+try:
+    import dask_cuda  # noqa: F401
+except ImportError:  # pragma: no cover
+    pass
+
 from dask_sql import input_utils
 from dask_sql.datacontainer import (
     UDF,
@@ -33,12 +38,6 @@ from dask_sql.mappings import python_to_sql_type
 from dask_sql.physical.rel import RelConverter, custom, logical
 from dask_sql.physical.rex import RexConverter, core
 from dask_sql.utils import ParsingException
-
-try:
-    import dask_cuda  # noqa: F401
-except ImportError:  # pragma: no cover
-    pass
-
 
 if TYPE_CHECKING:
     from dask_sql.java import org

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -9,11 +9,6 @@ import pandas as pd
 from dask.base import optimize
 from dask.distributed import Client
 
-try:
-    import dask_cuda  # noqa: F401
-except ImportError:  # pragma: no cover
-    pass
-
 from dask_sql import input_utils
 from dask_sql.datacontainer import (
     UDF,
@@ -38,6 +33,13 @@ from dask_sql.mappings import python_to_sql_type
 from dask_sql.physical.rel import RelConverter, custom, logical
 from dask_sql.physical.rex import RexConverter, core
 from dask_sql.utils import ParsingException
+
+# try:
+#    import dask_cuda  # noqa: F401
+# except ImportError:  # pragma: no cover
+#    pass
+#
+
 
 if TYPE_CHECKING:
     from dask_sql.java import org

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -10,8 +10,8 @@ from dask.base import optimize
 from dask.distributed import Client
 
 try:
-    import dask_cuda # noqa: F401
-except ImportError: # pragma: no cover
+    import dask_cuda  # noqa: F401
+except ImportError:  # pragma: no cover
     pass
 
 from dask_sql import input_utils

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -34,11 +34,10 @@ from dask_sql.physical.rel import RelConverter, custom, logical
 from dask_sql.physical.rex import RexConverter, core
 from dask_sql.utils import ParsingException
 
-# try:
-#    import dask_cuda  # noqa: F401
-# except ImportError:  # pragma: no cover
-#    pass
-#
+try:
+    import dask_cuda  # noqa: F401
+except ImportError:  # pragma: no cover
+    pass
 
 
 if TYPE_CHECKING:

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -8,8 +8,17 @@ import dask.dataframe as dd
 import pandas as pd
 from dask.base import optimize
 from dask.distributed import Client
+import dask_cuda
 
-# START - This import block must occur before any other dask_sql imports or a segfault will occur.
+from dask_sql import input_utils
+from dask_sql.datacontainer import (
+    UDF,
+    DataContainer,
+    FunctionDescription,
+    SchemaContainer,
+)
+from dask_sql.input_utils import InputType, InputUtil
+from dask_sql.integrations.ipython import ipython_integration
 from dask_sql.java import (
     DaskAggregateFunction,
     DaskScalarFunction,
@@ -21,24 +30,13 @@ from dask_sql.java import (
     ValidationException,
     get_java_class,
 )
-
-if TYPE_CHECKING:
-    from dask_sql.java import org
-# END - This import block must occur before any other dask_sql imports or a segfault will occur.
-
-from dask_sql import input_utils
-from dask_sql.datacontainer import (
-    UDF,
-    DataContainer,
-    FunctionDescription,
-    SchemaContainer,
-)
-from dask_sql.input_utils import InputType, InputUtil
-from dask_sql.integrations.ipython import ipython_integration
 from dask_sql.mappings import python_to_sql_type
 from dask_sql.physical.rel import RelConverter, custom, logical
 from dask_sql.physical.rex import RexConverter, core
 from dask_sql.utils import ParsingException
+
+if TYPE_CHECKING:
+    from dask_sql.java import org
 
 logger = logging.getLogger(__name__)
 

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -9,15 +9,7 @@ import pandas as pd
 from dask.base import optimize
 from dask.distributed import Client
 
-from dask_sql import input_utils
-from dask_sql.datacontainer import (
-    UDF,
-    DataContainer,
-    FunctionDescription,
-    SchemaContainer,
-)
-from dask_sql.input_utils import InputType, InputUtil
-from dask_sql.integrations.ipython import ipython_integration
+# START - This import block must occur before any other dask_sql imports or a segfault will occur.
 from dask_sql.java import (
     DaskAggregateFunction,
     DaskScalarFunction,
@@ -29,13 +21,24 @@ from dask_sql.java import (
     ValidationException,
     get_java_class,
 )
+
+if TYPE_CHECKING:
+    from dask_sql.java import org
+# END - This import block must occur before any other dask_sql imports or a segfault will occur.
+
+from dask_sql import input_utils
+from dask_sql.datacontainer import (
+    UDF,
+    DataContainer,
+    FunctionDescription,
+    SchemaContainer,
+)
+from dask_sql.input_utils import InputType, InputUtil
+from dask_sql.integrations.ipython import ipython_integration
 from dask_sql.mappings import python_to_sql_type
 from dask_sql.physical.rel import RelConverter, custom, logical
 from dask_sql.physical.rex import RexConverter, core
 from dask_sql.utils import ParsingException
-
-if TYPE_CHECKING:
-    from dask_sql.java import org
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -19,11 +19,11 @@ try:
 except ImportError:
     dask_cudf = None
 
-from dask_sql.context import Context
+try:
+    from dask_cuda import LocalCUDACluster
+except ImportError:
+    dask_cuda = None
 
-# fmt: off
-from dask_cuda import LocalCUDACluster  # noqa: F401
-# fmt: on
 
 @pytest.fixture()
 def timeseries_df(c):
@@ -154,6 +154,7 @@ def c(
     }
 
     # Lazy import, otherwise the pytest framework has problems
+    from dask_sql.context import Context
 
     c = Context()
     for df_name, df in dfs.items():

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -14,10 +14,16 @@ try:
 except ImportError:
     cudf = None
 
+try:
+    import dask_cudf
+except ImportError:
+    dask_cudf = None
 
 from dask_sql.context import Context
 
+# fmt: off
 from dask_cuda import LocalCUDACluster  # noqa: F401
+# fmt: on
 
 @pytest.fixture()
 def timeseries_df(c):

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -15,6 +15,10 @@ except ImportError:
     cudf = None
 
 
+from dask_sql.context import Context
+
+from dask_cuda import LocalCUDACluster  # noqa: F401
+
 @pytest.fixture()
 def timeseries_df(c):
     pdf = timeseries(freq="1d").compute().reset_index(drop=True)
@@ -144,7 +148,6 @@ def c(
     }
 
     # Lazy import, otherwise the pytest framework has problems
-    from dask_sql.context import Context
 
     c = Context()
     for df_name, df in dfs.items():

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -11,18 +11,12 @@ from pandas.testing import assert_frame_equal
 
 try:
     import cudf
-except ImportError:
-    cudf = None
 
-try:
-    import dask_cudf
-except ImportError:
-    dask_cudf = None
-
-try:
+    # importing to check for JVM segfault
+    import dask_cudf  # noqa: F401
     from dask_cuda import LocalCUDACluster  # noqa: F401
 except ImportError:
-    dask_cuda = None
+    cudf = None
 
 
 @pytest.fixture()

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -20,7 +20,7 @@ except ImportError:
     dask_cudf = None
 
 try:
-    from dask_cuda import LocalCUDACluster
+    from dask_cuda import LocalCUDACluster  # noqa: F401
 except ImportError:
     dask_cuda = None
 


### PR DESCRIPTION
Under certain circumstances importing `dask_cuda` after any `dask_sql` imports will cause an underlying segfault to be triggered in the JVM. In tests thus far adjusting that import order in `context.py` prevents that from happening. Subsequent PRs may be required after further testing.