### PR TITLE
Use string separator in nightly version string

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,7 +216,7 @@ jobs:
         shell: bash -l {0}
         run: |
           # suffix for nightly package versions
-          export VERSION_SUFFIX=`date +%y%m%d`
+          export VERSION_SUFFIX=a`date +%y%m%d`
 
           mamba build continuous_integration/recipe \
                       --no-anaconda-upload \


### PR DESCRIPTION
Some RAPIDS folk have noticed that dask-sql nightly versions include the date of their publishing:

```
$ conda search --override-channel -c dask/label/dev dask-sql=0.4.0211102
Loading channels: done
# Name                       Version           Build  Channel             
dask-sql                 0.4.0211102 py38_g77f1d87_1  dask/label/dev
```

This is an issue because it means you can't install nightlies of a specific minor version; for example:

```
$ conda search --override-channel -c dask/label/dev dask-sql=0.4.0
No match found for: dask-sql=0.4.0. Search: *dask-sql*=0.4.0

PackagesNotFoundError: The following packages are not available from current channels:

  - dask-sql=0.4.0
```

This PR adds a string separator between the package version and publishing date, which should allow `conda install -c dask/label/dev dask-sql=0.4.0` to work.

Another potential solution I considered is to make a new pre-release tag with a string appended, e.g. `0.4.1a`. This would achieve the same result as this PR, but I feel that it will be awkward naming pre-release tags when we eventually move over to CalVer (as we don't have a scheduled release cycle to go by).

cc @jakirkham 