### PR TITLE
Make `meta` consistent with results of cross join

### DIFF
--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -121,7 +121,7 @@ class LogicalJoinPlugin(BaseRelPlugin):
                 rhs_partition = rhs_partition.assign(common=1)
                 merged_data = lhs_partition.merge(rhs_partition, on=["common"])
 
-                return merged_data.drop(columns=["common"])
+                return merged_data
 
             # Iterate nested over all partitions from lhs and rhs and merge them
             name = "cross-join-" + tokenize(df_lhs_renamed, df_rhs_renamed)
@@ -140,7 +140,11 @@ class LogicalJoinPlugin(BaseRelPlugin):
             )
 
             meta = dd.dispatch.concat(
-                [df_lhs_renamed._meta_nonempty, df_rhs_renamed._meta_nonempty], axis=1
+                [
+                    df_lhs_renamed._meta_nonempty.assign(common=1),
+                    df_rhs_renamed._meta_nonempty,
+                ],
+                axis=1,
             )
             # TODO: Do we know the divisions in any way here?
             divisions = [None] * (len(dsk) + 1)

--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -121,7 +121,7 @@ class LogicalJoinPlugin(BaseRelPlugin):
                 rhs_partition = rhs_partition.assign(common=1)
                 merged_data = lhs_partition.merge(rhs_partition, on=["common"])
 
-                return merged_data
+                return merged_data.drop(columns=["common"])
 
             # Iterate nested over all partitions from lhs and rhs and merge them
             name = "cross-join-" + tokenize(df_lhs_renamed, df_rhs_renamed)

--- a/tests/integration/test_compatibility.py
+++ b/tests/integration/test_compatibility.py
@@ -239,7 +239,15 @@ def test_join_left():
 def test_join_cross():
     a = make_rand_df(10, a=(int, 4), b=(str, 4), c=(float, 4))
     b = make_rand_df(20, dd=(float, 1), aa=(int, 1), bb=(str, 1))
-    eq_sqlite("SELECT * FROM a CROSS JOIN b", a=a, b=b)
+    eq_sqlite(
+        """
+        SELECT * FROM a
+            CROSS JOIN b
+        ORDER BY a.a NULLS FIRST, a.b NULLS FIRST, a.c NULLS FIRST, dd NULLS FIRST
+        """,
+        a=a,
+        b=b,
+    )
 
 
 def test_join_multi():


### PR DESCRIPTION
It looks like when we do cross joins, we join on a temporary `common` column that we forget to include in the `meta` of the resulting dataframe. This doesn't actually cause issues for the join operation itself, but can cause problems when trying to do follow up operations after the join (or any operation that implicitly uses it), such as an `ORDER BY`:

<details>

```python
dask_sql/context.py:433: in sql
    dc = RelConverter.convert(rel, context=self)
dask_sql/physical/rel/convert.py:60: in convert
    df = plugin_instance.convert(rel, context=context)
dask_sql/physical/rel/logical/project.py:29: in convert
    (dc,) = self.assert_inputs(rel, 1, context)
dask_sql/physical/rel/base.py:85: in assert_inputs
    return [RelConverter.convert(input_rel, context) for input_rel in input_rels]
dask_sql/physical/rel/base.py:85: in <listcomp>
    return [RelConverter.convert(input_rel, context) for input_rel in input_rels]
dask_sql/physical/rel/convert.py:60: in convert
    df = plugin_instance.convert(rel, context=context)
dask_sql/physical/rel/logical/sort.py:45: in convert
    df = apply_sort(df, sort_columns, sort_ascending, sort_null_first)
dask_sql/physical/utils/sort.py:23: in apply_sort
    return df.map_partitions(
../dask/dask/base.py:261: in persist
    (result,) = persist(self, traverse=False, **kwargs)
../dask/dask/base.py:844: in persist
    results = schedule(dsk, keys, **kwargs)
../dask/dask/threaded.py:79: in get
    results = get_async(
../dask/dask/local.py:507: in get_async
    raise_exception(exc, tb)
../dask/dask/local.py:315: in reraise
    raise exc
../dask/dask/local.py:220: in execute_task
    result = _execute_task(task, data)
../dask/dask/core.py:119: in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
../dask/dask/optimization.py:969: in __call__
    return core.get(self.dsk, self.outkey, dict(zip(self.inkeys, args)))
../dask/dask/core.py:149: in get
    result = _execute_task(task, cache)
../dask/dask/core.py:119: in _execute_task
    return func(*(_execute_task(a, cache) for a in args))
../dask/dask/utils.py:37: in apply
    return func(*args, **kwargs)
../dask/dask/dataframe/core.py:5972: in apply_and_enforce
    check_matching_columns(meta, df)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

meta = Empty DataFrame
Columns: [lhs_0, lhs_1, lhs_2, rhs_0, rhs_1, rhs_2]
Index: []
actual =     lhs_0 lhs_1     lhs_2  common     rhs_0  rhs_1    rhs_2
33    NaN  None       NaN       1       NaN    1.0  ssssss...3       1  0.891773    4.0  ssssss5
88    7.0  None  0.537373       1  0.963663    1.0  ssssss9

[200 rows x 7 columns]

    def check_matching_columns(meta, actual):
        # Need nan_to_num otherwise nan comparison gives False
        if not np.array_equal(np.nan_to_num(meta.columns), np.nan_to_num(actual.columns)):
            extra = methods.tolist(actual.columns.difference(meta.columns))
            missing = methods.tolist(meta.columns.difference(actual.columns))
            if extra or missing:
                extra_info = f"  Extra:   {extra}\n  Missing: {missing}"
            else:
                extra_info = "Order of columns does not match"
>           raise ValueError(
                "The columns in the computed data do not match"
                " the columns in the provided metadata\n"
                f"{extra_info}"
            )
E           ValueError: The columns in the computed data do not match the columns in the provided metadata
E             Extra:   ['common']
E             Missing: []

../dask/dask/dataframe/utils.py:421: ValueError
```

</details>

~~This PR ensures that this column is dropped, and modifies the simple cross join test to do a follow up sort to cover this issue (planning to add more tests like this through #273).~~

~~Since the extra column doesn't seem to be in the cross join result, I'm interested in if a simpler solution here would be to add the `common` column to the generated `meta` for the join operation - that might potentially be less expensive than dropping a column?~~

EDIT:

After some thought, it seems like adjusting `meta` to match the cross join result (i.e. inserting the `common` column) would generally be better than dropping the `common` column for every single partition cross join (1 relatively small assign operation versus N x M drop operations for number of partitions).