### PR TITLE
Bump dask pinning to 2021.10.0

### DIFF
--- a/continuous_integration/environment-3.7-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk11-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask>=2.19.0,!=2021.3.0  # dask 2021.3.0 makes dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+- dask>=2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.7-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk11-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask>=2021.10.0
+- dask==2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.7-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk11-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask==2021.10.0
+- dask>=2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.7-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk8-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask>=2.19.0,!=2021.3.0  # dask 2021.3.0 makes dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+- dask>=2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.7-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk8-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask>=2021.10.0
+- dask==2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.7-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk8-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask==2021.10.0
+- dask>=2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask>=2.19.0,!=2021.3.0  # dask 2021.3.0 makes dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+- dask>=2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask>=2021.10.0
+- dask==2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask==2021.10.0
+- dask>=2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.8-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk8-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask>=2.19.0,!=2021.3.0  # dask 2021.3.0 makes dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+- dask>=2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.8-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk8-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask>=2021.10.0
+- dask==2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.8-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk8-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=1.7.0
-- dask==2021.10.0
+- dask>=2021.10.0
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools_scm
   run:
     - python >=3.6
-    - dask >=2021.10.0
+    - dask ==2021.10.0
     - pandas >=1.0.0
     - jpype1 >=1.0.2
     - openjdk >=8

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools_scm
   run:
     - python >=3.6
-    - dask >=2.19.0,!=2021.3.0
+    - dask >=2021.10.0
     - pandas >=1.0.0
     - jpype1 >=1.0.2
     - openjdk >=8

--- a/docker/conda.txt
+++ b/docker/conda.txt
@@ -1,6 +1,5 @@
 python>=3.7
-dask>=2.19.0,!=2021.3.0  # dask 2021.3.0 makes
-                         # dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+dask>=2021.10.0
 pandas>=1.0.0  # below 1.0, there were no nullable ext. types
 jpype1>=1.0.2
 openjdk>=8

--- a/docker/conda.txt
+++ b/docker/conda.txt
@@ -1,5 +1,5 @@
 python>=3.7
-dask==2021.10.0
+dask>=2021.10.0
 pandas>=1.0.0  # below 1.0, there were no nullable ext. types
 jpype1>=1.0.2
 openjdk>=8

--- a/docker/conda.txt
+++ b/docker/conda.txt
@@ -1,5 +1,5 @@
 python>=3.7
-dask>=2021.10.0
+dask==2021.10.0
 pandas>=1.0.0  # below 1.0, there were no nullable ext. types
 jpype1>=1.0.2
 openjdk>=8

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,7 @@ setup(
     python_requires=">=3.6",
     setup_requires=["setuptools_scm"] + sphinx_requirements,
     install_requires=[
-        "dask[dataframe,distributed]>=2.19.0,!=2021.3.0",  # dask 2021.3.0 makes
-        # dask-ml fail (see https://github.com/dask/dask-ml/issues/803)
+        "dask[dataframe,distributed]>=2021.10.0",
         "pandas>=1.0.0",  # below 1.0, there were no nullable ext. types
         "jpype1>=1.0.2",
         "fastapi>=0.61.1",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     python_requires=">=3.6",
     setup_requires=["setuptools_scm"] + sphinx_requirements,
     install_requires=[
-        "dask[dataframe,distributed]>=2021.10.0",
+        "dask[dataframe,distributed]==2021.10.0",
         "pandas>=1.0.0",  # below 1.0, there were no nullable ext. types
         "jpype1>=1.0.2",
         "fastapi>=0.61.1",


### PR DESCRIPTION
This is a follow up for #255 that ensures that we have the required sorting updates in Dask to sort columns with null values. Note that we will need to mirror this change for the Conda feedstock recipe.