### PR TITLE
Add handling for cuDF-backed tables in `dask-sql-server`

### DIFF
--- a/dask_sql/server/responses.py
+++ b/dask_sql/server/responses.py
@@ -77,6 +77,8 @@ class DataResults(QueryResults):
 
     @staticmethod
     def get_data_description(df):
+        if hasattr(df, "to_pandas"):
+            df = df.to_pandas()
         return [
             DataResults.convert_row(row)
             for row in df.itertuples(index=False, name=None)


### PR DESCRIPTION
This should unblock failures when serving cuDF-backed tables using `dask-sql-server`, but is not really ideal as it forces a host synchronization whenever we need to return a query result; a more ideal long term solution would be to explore server options that allow us to return results per-column instead of per-row (i.e. iterating over columns instead of rows, which can't be done in cuDF).

cc @bryevdv this should resolve the failures we discussed and allow for some deeper exploration of Superset

xref #310