### PR TITLE
Add testing for Python 3.9

### DIFF
--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         java: [8, 11]
         os: [ubuntu-latest, windows-latest]
-        python: [3.7, 3.8]
+        python: [3.7, 3.8, 3.9]
     outputs:
       artifacts_availability: ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
       matrix:
         java: [8, 11]
         os: [ubuntu-latest, windows-latest]
-        python: [3.7, 3.8]
+        python: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -1,0 +1,42 @@
+name: dask-sql
+channels:
+- conda-forge
+- defaults
+dependencies:
+- adagio>=0.2.3
+- antlr4-python3-runtime>=4.9.2
+- black=19.10b0
+- ciso8601>=2.2.0
+- dask-ml>=1.7.0
+- dask>=2021.10.0
+- fastapi>=0.61.1
+- fs>=2.4.11
+- intake>=0.6.0
+- isort=5.7.0
+- jpype1>=1.0.2
+- lightgbm>=3.2.1
+- maven>=3.6.0
+- mlflow>=1.19.0
+- mock>=4.0.3
+- nest-asyncio>=1.4.3
+- openjdk=11
+- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pip=20.2.4
+- pre-commit>=2.11.1
+- prompt_toolkit>=3.0.8
+- psycopg2>=2.9.1
+- pyarrow>=0.15.1
+- pygments>=2.7.1
+- pyhive>=0.6.4
+- pytest-cov>=2.10.1
+- pytest-xdist
+- pytest>=6.0.1
+- python=3.9
+- scikit-learn>=0.24.2
+- sphinx>=3.2.1
+- tpot>=0.11.7
+- triad>=0.5.4
+- tzlocal>=2.1
+- uvicorn>=0.11.3
+- pip:
+  - fugue[sql]>=0.5.3

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -1,0 +1,42 @@
+name: dask-sql
+channels:
+- conda-forge
+- defaults
+dependencies:
+- adagio>=0.2.3
+- antlr4-python3-runtime>=4.9.2
+- black=19.10b0
+- ciso8601>=2.2.0
+- dask-ml>=1.7.0
+- dask>=2021.10.0
+- fastapi>=0.61.1
+- fs>=2.4.11
+- intake>=0.6.0
+- isort=5.7.0
+- jpype1>=1.0.2
+- lightgbm>=3.2.1
+- maven>=3.6.0
+- mlflow>=1.19.0
+- mock>=4.0.3
+- nest-asyncio>=1.4.3
+- openjdk=8
+- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pip=20.2.4
+- pre-commit>=2.11.1
+- prompt_toolkit>=3.0.8
+- psycopg2>=2.9.1
+- pyarrow>=0.15.1
+- pygments>=2.7.1
+- pyhive>=0.6.4
+- pytest-cov>=2.10.1
+- pytest-xdist
+- pytest>=6.0.1
+- python=3.9
+- scikit-learn>=0.24.2
+- sphinx>=3.2.1
+- tpot>=0.11.7
+- triad>=0.5.4
+- tzlocal>=2.1
+- uvicorn>=0.11.3
+- pip:
+  - fugue[sql]>=0.5.3


### PR DESCRIPTION
Add Python 3.9 to the stable / upstream testing matrices - interested in if there is any blocker to getting this running