### PR TITLE
Add metadata for wrap_fit when using GPU dataframes

### DIFF
--- a/dask_sql/physical/rel/custom/create_model.py
+++ b/dask_sql/physical/rel/custom/create_model.py
@@ -153,22 +153,21 @@ class CreateModelPlugin(BaseRelPlugin):
         select_query = context._to_sql_string(select)
         training_df = context.sql(select_query)
 
-        try:
-            import cudf
-            import dask_cudf
-
-            if isinstance(training_df, dask_cudf.DataFrame):
-                meta = cudf.Series([1])
-            else:
-                meta = None
-        except ImportError:
-            meta = None
-
         if wrap_predict:
             try:
                 from dask_ml.wrappers import ParallelPostFit
             except ImportError:  # pragma: no cover
                 raise ValueError("Wrapping requires dask-ml to be installed.")
+
+            meta = None
+            try:
+                import cudf
+                import dask_cudf
+
+                if isinstance(training_df, dask_cudf.DataFrame):
+                    meta = cudf.Series([1])
+            except ImportError:
+                pass
 
             model = ParallelPostFit(estimator=model, predict_meta=meta)
 

--- a/dask_sql/physical/rel/custom/create_model.py
+++ b/dask_sql/physical/rel/custom/create_model.py
@@ -170,7 +170,7 @@ class CreateModelPlugin(BaseRelPlugin):
             except ImportError:  # pragma: no cover
                 raise ValueError("Wrapping requires dask-ml to be installed.")
 
-            model = ParallelPostFit(estimator=model, meta=meta)
+            model = ParallelPostFit(estimator=model, predict_meta=meta)
 
         if target_column:
             non_target_columns = [


### PR DESCRIPTION
Enables using `CREATE MODEL` with gpu dataframes and `wrap_fit=True`. Depends on dask-ml/#862.