### PR TITLE
Generalize table check in `_get_tables_from_stack`

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -882,7 +882,7 @@ class Context:
             for var_name, variable in frame_info.frame.f_locals.items():
                 if var_name.startswith("_"):
                     continue
-                if not isinstance(variable, (pd.DataFrame, dd.DataFrame)):
+                if not dd.utils.is_dataframe_like(variable):
                     continue
 
                 # only set them if not defined in an inner context

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -168,19 +168,7 @@ def test_input_types(temporary_data_file, gpu):
 
 
 @pytest.mark.parametrize(
-    "gpu",
-    [
-        False,
-        pytest.param(
-            True,
-            marks=(
-                pytest.mark.gpu,
-                pytest.mark.xfail(
-                    reason="GPU tables aren't picked up by _get_tables_from_stack"
-                ),
-            ),
-        ),
-    ],
+    "gpu", [False, pytest.param(True, marks=pytest.mark.gpu),],
 )
 def test_tables_from_stack(gpu):
     c = Context()


### PR DESCRIPTION
Allows us to remove xfail from the GPU case in `test_tables_from_stack`