### PR TITLE
Circumvent deep copy of context in `PredictModelPlugin`

### DIFF
--- a/dask_sql/physical/rel/custom/predict.py
+++ b/dask_sql/physical/rel/custom/predict.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import uuid
 from typing import TYPE_CHECKING
@@ -88,8 +87,7 @@ class PredictModelPlugin(BaseRelPlugin):
             else:  # pragma: no cover
                 continue
 
-        tmp_context = copy.deepcopy(context)
-        tmp_context.create_table(temporary_table, predicted_df)
+        context.create_table(temporary_table, predicted_df)
 
         sql_ns = org.apache.calcite.sql
         pos = sql.getParserPosition()
@@ -112,8 +110,9 @@ class PredictModelPlugin(BaseRelPlugin):
             None,  # hints
         )
 
-        sql_outer_query = tmp_context._to_sql_string(outer_select)
-        df = tmp_context.sql(sql_outer_query)
+        sql_outer_query = context._to_sql_string(outer_select)
+        df = context.sql(sql_outer_query)
+        context.drop_table(temporary_table)
 
         cc = ColumnContainer(df.columns)
         dc = DataContainer(df, cc)

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -26,8 +26,11 @@ def check_trained_model(c, model_name=None):
         )
         """
 
+    tables_before = c.schema["root"].tables.keys()
     result_df = c.sql(sql).compute()
 
+    # assert that there are no additional tables in context from prediction
+    assert tables_before == c.schema["root"].tables.keys()
     assert "target" in result_df.columns
     assert len(result_df["target"]) > 0
 


### PR DESCRIPTION
Closes #332

It looks like the relatively expensive deep copy of the context done in `PredictModelPlugin` should be circumvented by simply adding the temporary table we create to the original context and dropping it before returning; this also unblocks usage with multi-GPU cuML models.

cc @VibhuJawa 