### PR TITLE
Unrestrict `conda-build` version used for nightly builds

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          mamba install boa conda-verify "conda<4.11"
+          mamba install boa conda-verify
 
           which python
           pip list


### PR DESCRIPTION
Originally we restricted `conda-build` because of issues when trying to import a previously vendored module (see https://github.com/conda/conda-build/issues/4333). This has since been patched in `4.11` and a new release capturing the fixes is imminent.

This unpins `conda-build`, which should no longer cause failure for `>=4.11`.