### PR TITLE
Update conditions for `apply_sort` fast codepath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ htmlcov/
 coverage.xml
 *.cover
 .pytest_cache/
+.hypothesis/
 
 # Jupyter Notebook
 .ipynb_checkpoints

--- a/dask_sql/physical/utils/sort.py
+++ b/dask_sql/physical/utils/sort.py
@@ -33,8 +33,8 @@ def apply_sort(
     if len(sort_columns) == 1 or (
         dask_cudf is not None
         and isinstance(df, dask_cudf.DataFrame)
-        and (not any(sort_ascending) or all(sort_ascending))
-        and (not any(sort_null_first) or all(sort_null_first))
+        and len(set(sort_ascending)) == 1
+        and len(set(sort_null_first)) == 1
     ):
         try:
             return df.sort_values(

--- a/dask_sql/physical/utils/sort.py
+++ b/dask_sql/physical/utils/sort.py
@@ -30,11 +30,9 @@ def apply_sort(
 
     # dask single-column / dask-cudf multi-column sort_values
     # supports only single ascending and single null position:
-    if (
-        (
-            (dask_cudf is not None and isinstance(df, dask_cudf.DataFrame))
-            or len(sort_columns) == 1
-        )
+    if len(sort_columns) == 1 or (
+        dask_cudf is not None
+        and isinstance(df, dask_cudf.DataFrame)
         and (not any(sort_ascending) or all(sort_ascending))
         and (not any(sort_null_first) or all(sort_null_first))
     ):


### PR DESCRIPTION
With `ascending` and `na_position` support now working for both Dask and Dask-cuDF, we can now use the fast `apply_sort` codepath for:

- All single column sorts (CPU and GPU)
- Multi-column sorts where `sort_ascending` and `sort_null_first` are homogeneous lists (GPU only)