### PR TITLE
Parse ROWS as tuples in SQL kwargs

### DIFF
--- a/dask_sql/utils.py
+++ b/dask_sql/utils.py
@@ -210,6 +210,7 @@ def convert_sql_kwargs(
                 "ARRAY": list,
                 "MAP": lambda x: dict(zip(x[::2], x[1::2])),
                 "MULTISET": set,
+                "ROW": tuple,
             }
 
             operator = operator_mapping[str(value.getOperator())]


### PR DESCRIPTION
Allows us to pass tuples into SQL kwargs (such as in `CREATE TABLE ... WITH (...)` statements), which can be used in kwargs just as `filters` for `read_*` functions