### PR TITLE
[WIP] Attempt to resolve gpuCI breakage

### DIFF
--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -41,13 +41,13 @@ gpuci_logger "Activate conda env"
 conda activate dask_sql
 
 gpuci_logger "Install dask"
-python -m pip install git+https://github.com/dask/dask
+python -m pip install git+https://github.com/dask/dask --use-feature=2020-resolver
 
 gpuci_logger "Install distributed"
-python -m pip install git+https://github.com/dask/distributed
+python -m pip install git+https://github.com/dask/distributed --use-feature=2020-resolver
 
 gpuci_logger "Install dask-sql"
-pip install -e ".[dev]"
+python -m pip install -e ".[dev]"
 python setup.py java
 
 gpuci_logger "Check Python version"

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -1,22 +1,18 @@
 import os
 import tempfile
 
+import cudf
 import dask.dataframe as dd
+
+# importing to check for JVM segfault
+import dask_cudf  # noqa: F401
 import numpy as np
 import pandas as pd
 import pytest
 from dask.datasets import timeseries
 from dask.distributed import Client
+from dask_cuda import LocalCUDACluster  # noqa: F401
 from pandas.testing import assert_frame_equal
-
-try:
-    import cudf
-
-    # importing to check for JVM segfault
-    import dask_cudf  # noqa: F401
-    from dask_cuda import LocalCUDACluster  # noqa: F401
-except ImportError:
-    cudf = None
 
 
 @pytest.fixture()


### PR DESCRIPTION
Not exactly sure what's causing the gpuCI failures yet, but I do notice the following popping up in our `pip install` logs:

```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

dask-cudf 22.2.0a0+103.g83adc4b6cf requires cupy-cuda115, which is not installed.
```

I am going to try out the new `pip` resolver to see what happens there.