### PR TITLE
Bump dask dependency to `>=2021.11.1,<=2021.11.2`

### DIFF
--- a/continuous_integration/environment-3.7-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk11-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=2021.11.16
-- dask>=2021.10.0
+- dask>=2021.11.1
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.7-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk8-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=2021.11.16
-- dask>=2021.10.0
+- dask>=2021.11.1
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=2021.11.16
-- dask>=2021.10.0
+- dask>=2021.11.1
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.8-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk8-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=2021.11.16
-- dask>=2021.10.0
+- dask>=2021.11.1
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=2021.11.16
-- dask>=2021.10.0
+- dask>=2021.11.1
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -8,7 +8,7 @@ dependencies:
 - black=19.10b0
 - ciso8601>=2.2.0
 - dask-ml>=2021.11.16
-- dask>=2021.10.0
+- dask>=2021.11.1
 - fastapi>=0.61.1
 - fs>=2.4.11
 - intake>=0.6.0

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - setuptools-scm
   run:
     - python
-    - dask >=2021.10.0
+    - dask >=2021.11.1
     - pandas >=1.0.0
     - jpype1 >=1.0.2
     - openjdk >=8

--- a/docker/conda.txt
+++ b/docker/conda.txt
@@ -1,5 +1,5 @@
 python>=3.7
-dask>=2021.10.0
+dask>=2021.11.1
 pandas>=1.0.0  # below 1.0, there were no nullable ext. types
 jpype1>=1.0.2
 openjdk>=8

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     python_requires=">=3.6",
     setup_requires=["setuptools_scm"] + sphinx_requirements,
     install_requires=[
-        "dask[dataframe,distributed]>=2021.10.0",
+        "dask[dataframe,distributed]>=2021.11.1,<=2021.11.2",
         "pandas>=1.0.0",  # below 1.0, there were no nullable ext. types
         "jpype1>=1.0.2",
         "fastapi>=0.61.1",


### PR DESCRIPTION
In preparation for our next release which will be packaged alongside RAPIDS 21.12, this PR bumps our Dask dependency to match up with that of dask-cudf. Note that we should be safe to remove the upper bound on this dependency once the release is cut and published.

cc @randerzander @jakirkham 