### PR TITLE
Bump gpuCI `CUDA_VER` to 11.5

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -2,7 +2,7 @@ PYTHON_VER:
 - "3.8"
 
 CUDA_VER:
-- "11.2"
+- "11.5"
 
 LINUX_VER:
 - ubuntu18.04


### PR DESCRIPTION
Bumps the CUDA / CUDA toolkit versions of gpuCI to match up with the latest version used in RAPIDS projects; depends on https://github.com/rapidsai/dask-build-environment/pull/24