### PR TITLE
Disable CodeCov upload in tests on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,7 @@ jobs:
           name: pytest-results
           path: junit/test-results.xml
       - name: Upload coverage to Codecov
+        if: github.repository == 'dask-contrib/dask-sql'
         uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
In general we should be doing this, as this step would always fail if we run the PR testing on forks; this should make it easier to manage a RAPIDS fork of this repo with minimal changes