### PR TITLE
Add latest dask-ml to upstream testing

### DIFF
--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -87,10 +87,11 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           echo "JAVA_HOME=${{ env.CONDA }}\envs\dask-sql\Library" >> $GITHUB_ENV
-      - name: Install upstream dev Dask
+      - name: Install upstream dev Dask / dask-ml
         run: |
           python -m pip install --no-deps git+https://github.com/dask/dask
           python -m pip install --no-deps git+https://github.com/dask/distributed
+          python -m pip install --no-deps git+https://github.com/dask/dask-ml
       - name: Test with pytest
         if: success()
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,11 +107,12 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           echo "JAVA_HOME=${{ env.CONDA }}\envs\dask-sql\Library" >> $GITHUB_ENV
-      - name: Optionally install upstream dev Dask
+      - name: Optionally install upstream dev Dask / dask-ml
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
           python -m pip install --no-deps git+https://github.com/dask/dask
           python -m pip install --no-deps git+https://github.com/dask/distributed
+          python -m pip install --no-deps git+https://github.com/dask/dask-ml
       - name: Test with pytest
         run: |
           pytest --junitxml=junit/test-results.xml --cov-report=xml -n auto tests --dist loadfile
@@ -159,11 +160,12 @@ jobs:
           which python
           pip list
           mamba list
-      - name: Optionally install upstream dev Dask
+      - name: Optionally install upstream dev Dask / dask-ml
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
           python -m pip install --no-deps git+https://github.com/dask/dask
           python -m pip install --no-deps git+https://github.com/dask/distributed
+          python -m pip install --no-deps git+https://github.com/dask/dask-ml
       - name: run a dask cluster
         run: |
           docker-compose -f .github/docker-compose.yaml up -d
@@ -209,11 +211,12 @@ jobs:
           which python
           pip list
           mamba list
-      - name: Optionally install upstream dev Dask
+      - name: Optionally install upstream dev Dask / dask-ml
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
           python -m pip install --no-deps git+https://github.com/dask/dask
           python -m pip install --no-deps git+https://github.com/dask/distributed
+          python -m pip install --no-deps git+https://github.com/dask/dask-ml
       - name: Try to import dask-sql
         run: |
           python -c "import dask_sql; print('ok')"


### PR DESCRIPTION
Adds an install of the latest dask-ml to our upstream testing, which should enable us to test out fixes in / breakage caused by dask-ml.

cc @ayushdg 