### PR TITLE
Add substr tests

### DIFF
--- a/dask_sql/_compat.py
+++ b/dask_sql/_compat.py
@@ -1,7 +1,6 @@
-from distutils.version import LooseVersion
-
 import pandas as pd
+from packaging.version import parse as parseVersion
 
-_pandas_version = LooseVersion(pd.__version__)
-FLOAT_NAN_IMPLEMENTED = _pandas_version >= LooseVersion("1.2.0")
-INT_NAN_IMPLEMENTED = _pandas_version >= LooseVersion("1.0.0")
+_pandas_version = parseVersion(pd.__version__)
+FLOAT_NAN_IMPLEMENTED = _pandas_version >= parseVersion("1.2.0")
+INT_NAN_IMPLEMENTED = _pandas_version >= parseVersion("1.0.0")

--- a/tests/integration/test_postgres.py
+++ b/tests/integration/test_postgres.py
@@ -248,6 +248,7 @@ def test_string_operations(assert_query_gives_same_result):
             SUBSTRING(s FROM 10),
             SUBSTRING(s FROM 2),
             SUBSTRING(s FROM 2 FOR 2),
+            SUBSTR(s,2,2),
             INITCAP(s),
             INITCAP(UPPER(s)),
             INITCAP(LOWER(s))

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -464,9 +464,10 @@ def test_string_functions(c, gpu):
             SUBSTRING(a FROM 10) AS p,
             SUBSTRING(a FROM 2) AS q,
             SUBSTRING(a FROM 2 FOR 2) AS r,
-            INITCAP(a) AS s,
-            INITCAP(UPPER(a)) AS t,
-            INITCAP(LOWER(a)) AS u
+            SUBSTR(a, 3, 6) AS s,
+            INITCAP(a) AS t,
+            INITCAP(UPPER(a)) AS u,
+            INITCAP(LOWER(a)) AS v
         FROM
             {input_table}
         """
@@ -496,9 +497,10 @@ def test_string_functions(c, gpu):
             "p": ["string"],
             "q": [" normal string"],
             "r": [" n"],
-            "s": ["A Normal String"],
+            "s": ["normal"],
             "t": ["A Normal String"],
             "u": ["A Normal String"],
+            "v": ["A Normal String"],
         }
     )
 


### PR DESCRIPTION
As discussed in #258 it seems like `SUBSTR` is indeed supported and the error was most likely due to case sensitivity. 

This PR adds a couple of test cases for `SUBSTR` since only `SUBSTRING` was covered. 


Also a minor change that replaces the use of now deprecated `distutils.version.LooseVersion` with `packaging.version.Version`