### PR TITLE
xfail failing model tests

### DIFF
--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -165,6 +165,9 @@ def test_clustering_and_prediction(c, training_df):
     check_trained_model(c)
 
 
+@pytest.mark.xfail(
+    reason="Upstream breakage in dask needs to be fixed by next dask-ml release"
+)
 def test_iterative_and_prediction(c, training_df):
     c.sql(
         """
@@ -184,6 +187,9 @@ def test_iterative_and_prediction(c, training_df):
     check_trained_model(c)
 
 
+@pytest.mark.xfail(
+    reason="Upstream breakage in dask needs to be fixed by next dask-ml release"
+)
 def test_show_models(c, training_df):
     c.sql(
         """


### PR DESCRIPTION
Until another version of dask-ml is released, `test_iterative_and_prediction` and `test_show_models` will fail due to the breakage discussed in https://github.com/dask/dask-ml/issues/894; this PR xfails those tests to unblock CI for now until that new version is out, after which we will want to bump our dask-ml dependency.