### PR TITLE
Pin pandas dependency to 1.2

### DIFF
--- a/continuous_integration/environment-3.7-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk11-dev.yaml
@@ -20,7 +20,7 @@ dependencies:
 - mock>=4.0.3
 - nest-asyncio>=1.4.3
 - openjdk=11
-- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pandas=1.2  # below 1.0, there were no nullable ext. types
 - pip=20.2.4
 - pre-commit>=2.11.1
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/environment-3.7-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk8-dev.yaml
@@ -20,7 +20,7 @@ dependencies:
 - mock>=4.0.3
 - nest-asyncio>=1.4.3
 - openjdk=8
-- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pandas=1.2  # below 1.0, there were no nullable ext. types
 - pip=20.2.4
 - pre-commit>=2.11.1
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -20,7 +20,7 @@ dependencies:
 - mock>=4.0.3
 - nest-asyncio>=1.4.3
 - openjdk=11
-- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pandas=1.2  # below 1.0, there were no nullable ext. types
 - pip=20.2.4
 - pre-commit>=2.11.1
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/environment-3.8-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk8-dev.yaml
@@ -20,7 +20,7 @@ dependencies:
 - mock>=4.0.3
 - nest-asyncio>=1.4.3
 - openjdk=8
-- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pandas=1.2  # below 1.0, there were no nullable ext. types
 - pip=20.2.4
 - pre-commit>=2.11.1
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -20,7 +20,7 @@ dependencies:
 - mock>=4.0.3
 - nest-asyncio>=1.4.3
 - openjdk=11
-- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pandas=1.2  # below 1.0, there were no nullable ext. types
 - pip=20.2.4
 - pre-commit>=2.11.1
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -20,7 +20,7 @@ dependencies:
 - mock>=4.0.3
 - nest-asyncio>=1.4.3
 - openjdk=8
-- pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+- pandas=1.2  # below 1.0, there were no nullable ext. types
 - pip=20.2.4
 - pre-commit>=2.11.1
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python
     - dask >=2021.11.1
-    - pandas >=1.0.0
+    - pandas 1.2
     - jpype1 >=1.0.2
     - openjdk >=8
     - fastapi >=0.61.1

--- a/docker/conda.txt
+++ b/docker/conda.txt
@@ -1,6 +1,6 @@
 python>=3.7
 dask>=2021.11.1
-pandas>=1.0.0  # below 1.0, there were no nullable ext. types
+pandas=1.2  # below 1.0, there were no nullable ext. types
 jpype1>=1.0.2
 openjdk>=8
 maven>=3.6.0

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     setup_requires=["setuptools_scm"] + sphinx_requirements,
     install_requires=[
         "dask[dataframe,distributed]>=2021.11.1",
-        "pandas=1.2",  # below 1.0, there were no nullable ext. types
+        "pandas==1.2",  # below 1.0, there were no nullable ext. types
         "jpype1>=1.0.2",
         "fastapi>=0.61.1",
         "uvicorn>=0.11.3",

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     setup_requires=["setuptools_scm"] + sphinx_requirements,
     install_requires=[
         "dask[dataframe,distributed]>=2021.11.1",
-        "pandas>=1.0.0",  # below 1.0, there were no nullable ext. types
+        "pandas=1.2",  # below 1.0, there were no nullable ext. types
         "jpype1>=1.0.2",
         "fastapi>=0.61.1",
         "uvicorn>=0.11.3",

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     setup_requires=["setuptools_scm"] + sphinx_requirements,
     install_requires=[
         "dask[dataframe,distributed]>=2021.11.1",
-        "pandas==1.2",  # below 1.0, there were no nullable ext. types
+        "pandas==1.2.5",  # below 1.0, there were no nullable ext. types
         "jpype1>=1.0.2",
         "fastapi>=0.61.1",
         "uvicorn>=0.11.3",


### PR DESCRIPTION
This should resolve the nightly test failures observed in:

https://github.com/dask-contrib/dask-sql/actions/runs/1737510437