### PR TITLE
Fix pandas `BaseIndexer` import

### DIFF
--- a/dask_sql/physical/rel/logical/window.py
+++ b/dask_sql/physical/rel/logical/window.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-from pandas.core.window.indexers import BaseIndexer
+from pandas.api.indexers import BaseIndexer
 
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.java import org


### PR DESCRIPTION
In pandas 1.4.0, the `BaseIndexer` was relocated from `pandas.core.window.indexers` to `pandas.core.indexers.objects`, breaking CI as seen in https://github.com/dask-contrib/dask-sql/actions/runs/1737510437.

This PR fixes this import to use `pandas.api.indexers`, which should work for pandas versions both before and after this relocation.