### PR TITLE
Switch `github-script` action to v3

### DIFF
--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -107,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Report failures
-        uses: actions/github-script@v5
+        uses: actions/github-script@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
It looks like upstream testing failures still fail to open an issue:

https://github.com/dask-contrib/dask-sql/runs/4915948884?check_suite_focus=true

Comparing our upstream testing workflow to [dask-ml's](https://github.com/dask/dask-ml/blob/main/.github/workflows/upstream.yml), the only difference I can see is that their `github-script` action uses v5 instead of v3; hopefully switching to that should resolve things here.