### PR TITLE
Pin dask/distributed versions for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     python_requires=">=3.6",
     setup_requires=["setuptools_scm"] + sphinx_requirements,
     install_requires=[
-        "dask[dataframe,distributed]>=2021.11.1",
+        "dask[dataframe,distributed]>=2021.11.1,<=2022.01.0",
         "pandas>=1.0.0",  # below 1.0, there were no nullable ext. types
         "jpype1>=1.0.2",
         "fastapi>=0.61.1",


### PR DESCRIPTION
Restricts the max version of dask/distributed to the latest stable release, in preparation for a new dask-sql release