### PR TITLE
Remove `defaults` channel from conda envs

### DIFF
--- a/continuous_integration/environment-3.7-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk11-dev.yaml
@@ -1,7 +1,6 @@
 name: dask-sql
 channels:
 - conda-forge
-- defaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2

--- a/continuous_integration/environment-3.7-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk8-dev.yaml
@@ -1,7 +1,6 @@
 name: dask-sql
 channels:
 - conda-forge
-- defaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -1,7 +1,6 @@
 name: dask-sql
 channels:
 - conda-forge
-- defaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2

--- a/continuous_integration/environment-3.8-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk8-dev.yaml
@@ -1,7 +1,6 @@
 name: dask-sql
 channels:
 - conda-forge
-- defaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -1,7 +1,6 @@
 name: dask-sql
 channels:
 - conda-forge
-- defaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -1,7 +1,6 @@
 name: dask-sql
 channels:
 - conda-forge
-- defaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2


### PR DESCRIPTION
As pointed out by @jakirkham, both Dask and RAPIDS have moved away from the `defaults` in CI in favor of `conda-forge`.

This PR removes the `defaults` channel from the conda environment files, so that all packages will get picked up from `conda-forge`.