### PR TITLE
Triage gpuCI ML failures

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -8,6 +8,6 @@ LINUX_VER:
 - ubuntu18.04
 
 RAPIDS_VER:
-- "22.02"
+- "22.04"
 
 excludes:

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -13,7 +13,8 @@ try:
     import cuml
     import dask_cudf
     import xgboost
-except ImportError:
+except ImportError as e:
+    raise e
     cuml = None
     xgboost = None
     dask_cudf = None


### PR DESCRIPTION
Looks like gpuCI is failing on the ML tests - seems like it's probably because we're failing to import a library properly