### PR TITLE
Don't persist dataframes before applying offset / limit

### DIFF
--- a/dask_sql/physical/rel/logical/limit.py
+++ b/dask_sql/physical/rel/logical/limit.py
@@ -58,7 +58,6 @@ class DaskLimitPlugin(BaseRelPlugin):
         we need to pass the partition number to the selection
         function, which is not possible with normal "map_partitions".
         """
-        df = df.persist()
         if not offset:
             # We do a (hopefully) very quick check: if the first partition
             # is already enough, we will just use this


### PR DESCRIPTION
Should address the persisting of entire dataframes in `SELECT ... LIMIT` statements observed in #385 