### PR TITLE
[WIP] Refactor ConfigContainer to use dask config

### DIFF
--- a/dask_sql/__init__.py
+++ b/dask_sql/__init__.py
@@ -1,3 +1,4 @@
+from . import config
 from ._version import get_version
 from .cmd import cmd_loop
 from .context import Context

--- a/dask_sql/config.py
+++ b/dask_sql/config.py
@@ -1,0 +1,14 @@
+import os
+
+import dask
+import yaml
+
+fn = os.path.join(os.path.dirname(__file__), "sql.yaml")
+
+with open(fn) as f:
+    defaults = yaml.safe_load(f)
+
+dask.config.update_defaults(defaults)
+dask.config.ensure_file(source=fn, comment=True)
+
+config = dask.config.get("sql")

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 
 import dask.dataframe as dd
 import pandas as pd
+from dask import config as dask_config
 from dask.base import optimize
 from dask.distributed import Client
 
@@ -419,6 +420,7 @@ class Context:
         return_futures: bool = True,
         dataframes: Dict[str, Union[dd.DataFrame, pd.DataFrame]] = None,
         gpu: bool = False,
+        config_options: Dict[str, Any] = None,
     ) -> Union[dd.DataFrame, pd.DataFrame]:
         """
         Query the registered tables with the given SQL.
@@ -446,36 +448,39 @@ class Context:
                 to register before executing this query
             gpu (:obj:`bool`): Whether or not to load the additional Dask or pandas dataframes (if any) on GPU;
                 requires cuDF / dask-cuDF if enabled. Defaults to False.
+            config_options (:obj:`Dict[str,Any]`): Specific configuration options to pass during
+                query execution
 
         Returns:
             :obj:`dask.dataframe.DataFrame`: the created data frame of this query.
 
         """
-        if dataframes is not None:
-            for df_name, df in dataframes.items():
-                self.create_table(df_name, df, gpu=gpu)
+        with dask_config.set(config_options):
+            if dataframes is not None:
+                for df_name, df in dataframes.items():
+                    self.create_table(df_name, df, gpu=gpu)
 
-        rel, select_names, _ = self._get_ral(sql)
+            rel, select_names, _ = self._get_ral(sql)
 
-        dc = RelConverter.convert(rel, context=self)
+            dc = RelConverter.convert(rel, context=self)
 
-        if dc is None:
-            return
+            if dc is None:
+                return
 
-        if select_names:
-            # Rename any columns named EXPR$* to a more human readable name
-            cc = dc.column_container
-            cc = cc.rename(
-                {
-                    df_col: select_name
-                    for df_col, select_name in zip(cc.columns, select_names)
-                }
-            )
-            dc = DataContainer(dc.df, cc)
+            if select_names:
+                # Rename any columns named EXPR$* to a more human readable name
+                cc = dc.column_container
+                cc = cc.rename(
+                    {
+                        df_col: select_name
+                        for df_col, select_name in zip(cc.columns, select_names)
+                    }
+                )
+                dc = DataContainer(dc.df, cc)
 
-        df = dc.assign()
-        if not return_futures:
-            df = df.compute()
+            df = dc.assign()
+            if not return_futures:
+                df = df.compute()
 
         return df
 
@@ -587,9 +592,7 @@ class Context:
         self.schema[schema_name].models[model_name.lower()] = (model, training_columns)
 
     def set_config(
-        self,
-        config_options: Union[Tuple[str, Any], Dict[str, Any]],
-        schema_name: str = None,
+        self, config_options: Dict[str, Any],
     ):
         """
         Add configuration options to a schema.
@@ -616,40 +619,7 @@ class Context:
                 )
 
         """
-        schema_name = schema_name or self.schema_name
-        self.schema[schema_name].config.set_config(config_options)
-
-    def drop_config(
-        self, config_strs: Union[str, List[str]], schema_name: str = None,
-    ):
-        """
-        Drop user set configuration options from schema
-
-        Args:
-            config_strs (:obj:`str` or :obj:`List[str]`): config key or keys to drop
-            schema_name (:obj:`str`): Optionally select schema for dropping configs
-
-        Example:
-            .. code-block:: python
-
-                from dask_sql import Context
-
-                c = Context()
-                c.set_config(
-                    {
-                        "dask.groupby.aggregate.split_out": 2,
-                        "dask.groupby.aggregate.split_every": 4,
-                    }
-                )
-                c.drop_config(
-                    [
-                        "dask.groupby.aggregate.split_out",
-                        "dask.groupby.aggregate.split_every",
-                    ]
-                )
-        """
-        schema_name = schema_name or self.schema_name
-        self.schema[schema_name].config.drop_config(config_strs)
+        dask_config.set(config_options)
 
     def ipython_magic(self, auto_include=False):  # pragma: no cover
         """
@@ -846,11 +816,7 @@ class Context:
         )
 
         # True if the SQL query should be case sensitive and False otherwise
-        case_sensitive = (
-            self.schema[self.schema_name]
-            .config.get_config_by_prefix("dask.sql.identifier.case.sensitive")
-            .get("dask.sql.identifier.case.sensitive", True)
-        )
+        case_sensitive = dask_config.get("sql.identifier.case-sensitive", default=True)
 
         generator_builder = RelationalAlgebraGeneratorBuilder(
             self.schema_name, case_sensitive

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -251,7 +251,6 @@ class SchemaContainer:
         self.models: Dict[str, Tuple[Any, List[str]]] = {}
         self.functions: Dict[str, UDF] = {}
         self.function_lists: List[FunctionDescription] = []
-        self.config: ConfigContainer = ConfigContainer()
 
 
 class ConfigContainer:

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Tuple
 
 import dask.dataframe as dd
 import pandas as pd
+from dask import config as dask_config
 
 try:
     import dask_cudf
@@ -231,15 +232,8 @@ class DaskAggregatePlugin(BaseRelPlugin):
         for col in group_columns:
             collected_aggregations[None].append((col, col, "first"))
 
-        groupby_agg_options = context.schema[
-            context.schema_name
-        ].config.get_config_by_prefix("dask.groupby.aggregate")
-        # Update the config string to only include the actual param value
-        # i.e. dask.groupby.aggregate.split_out -> split_out
-        for config_key in list(groupby_agg_options.keys()):
-            groupby_agg_options[
-                config_key.rpartition(".")[2]
-            ] = groupby_agg_options.pop(config_key)
+        groupby_agg_options = dask_config.get("sql.groupby")
+
         # Now we can go ahead and use these grouped aggregations
         # to perform the actual aggregation
         # It is very important to start with the non-filtered entry.

--- a/dask_sql/sql.yaml
+++ b/dask_sql/sql.yaml
@@ -1,0 +1,7 @@
+sql:
+  groupby:
+    split_out: 1
+    split_every: null
+
+  identifier:
+    case_sensitive: True


### PR DESCRIPTION
This PR removes `ConfigContainer` and utilities to modify them as added in #286 in favor of using upstream Dask's [config](https://docs.dask.org/en/stable/configuration.html#configuration) module and the flexibility it provides. 

Key Changes:
- Config options are no longer schema specific. Users can either modify/provide a set of configurations that apply globally across all operations or specify config options on a per query basis.
- The keywords used for different configuration options are being renamed to be more in line with the dask config pattern. All config options for dask-sql start with the prefix `sql`.
  - eg: `dask.groupby.aggregate.split_out` renamed to `sql.groupby.split_out`

Functionality Enabled:
- Users can provide dask-sql configurations in yaml files, as environment variables or any other way dask supports and will become a part of the global dask config which can be consumed by any Dask-project that uses `dask.config`.
- Users can specify configuration options on a per-query basis by using `context.sql({"query_string"},config_options={options})`.

Checklist:
- [ ] Add new config features
- [ ] Remove the usage of ConfigContainer in favor of `dask_sql.config`
- [ ] Add tests for config
- [ ] Update setup to ensure the yaml files are packaged properly