### PR TITLE
Stop using `defaults` channel in dev environments

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -30,6 +30,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: 3.8
+          channel-priority: strict
       - name: Install dependencies
         run: |
           mamba install boa conda-verify

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
-          python-version: 3.8
+          python-version: "3.8"
           channel-priority: strict
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: 3.8
+          channel-priority: strict
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.8-jdk11-dev.yaml
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
-          python-version: 3.8
+          python-version: "3.8"
           channel-priority: strict
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.8-jdk11-dev.yaml

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
-          python-version: 3.8
+          python-version: "3.8"
           channel-priority: strict
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         java: [8, 11]
         os: [ubuntu-latest, windows-latest]
-        python: [3.7, 3.8, 3.9]
+        python: ["3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -27,6 +27,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: 3.8
+          channel-priority: strict
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.8-jdk11-dev.yaml
       - name: Install dependencies and build the jar
@@ -68,6 +69,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: ${{ matrix.python }}
+          channel-priority: strict
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
       - name: Download the pre-build jar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,8 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
-          python-version: 3.8
+          python-version: "3.8"
+          channel-priority: strict
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.8-jdk11-dev.yaml
       - name: Build the jar
@@ -76,7 +77,7 @@ jobs:
       matrix:
         java: [8, 11]
         os: [ubuntu-latest, windows-latest]
-        python: [3.7, 3.8, 3.9]
+        python: ["3.7", "3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
       - name: Cache local Maven repository
@@ -90,6 +91,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: ${{ matrix.python }}
+          channel-priority: strict
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
       - name: Download the pre-build jar
@@ -145,7 +147,8 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
-          python-version: 3.8
+          python-version: "3.8"
+          channel-priority: strict
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.8-jdk11-dev.yaml
       - name: Download the pre-build jar
@@ -195,10 +198,10 @@ jobs:
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.8
+          python-version: "3.8"
           mamba-version: "*"
           channels: conda-forge,defaults
-          channel-priority: true
+          channel-priority: strict
       - name: Download the pre-build jar
         uses: actions/download-artifact@v1
         with:

--- a/continuous_integration/environment-3.7-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk11-dev.yaml
@@ -1,6 +1,7 @@
 name: dask-sql
 channels:
 - conda-forge
+- nodefaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2

--- a/continuous_integration/environment-3.7-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.7-jdk8-dev.yaml
@@ -1,6 +1,7 @@
 name: dask-sql
 channels:
 - conda-forge
+- nodefaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -1,6 +1,7 @@
 name: dask-sql
 channels:
 - conda-forge
+- nodefaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2

--- a/continuous_integration/environment-3.8-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk8-dev.yaml
@@ -1,6 +1,7 @@
 name: dask-sql
 channels:
 - conda-forge
+- nodefaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -1,6 +1,7 @@
 name: dask-sql
 channels:
 - conda-forge
+- nodefaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -1,6 +1,7 @@
 name: dask-sql
 channels:
 - conda-forge
+- nodefaults
 dependencies:
 - adagio>=0.2.3
 - antlr4-python3-runtime>=4.9.2


### PR DESCRIPTION
This was initially done in https://github.com/dask-contrib/dask-sql/pull/383 but breaking it off into its own PR since that won't be merged in until Dask deprecates 3.7