### PR TITLE
Generalize dtype check in `python_to_sql_type`

### DIFF
--- a/dask_sql/mappings.py
+++ b/dask_sql/mappings.py
@@ -88,11 +88,11 @@ _SQL_TO_PYTHON_FRAMES = {
 def python_to_sql_type(python_type):
     """Mapping between python and SQL types."""
 
-    if hasattr(python_type, "type"):
-        python_type = python_type.type
-
     if pd.api.types.is_datetime64tz_dtype(python_type):
         return SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+
+    if hasattr(python_type, "type"):
+        python_type = python_type.type
 
     try:
         return _PYTHON_TO_SQL[python_type]

--- a/dask_sql/mappings.py
+++ b/dask_sql/mappings.py
@@ -37,6 +37,7 @@ _PYTHON_TO_SQL = {
     pd.BooleanDtype(): SqlTypeName.BOOLEAN,
     np.object_: SqlTypeName.VARCHAR,
     pd.StringDtype(): SqlTypeName.VARCHAR,
+    str: SqlTypeName.VARCHAR,
     np.datetime64: SqlTypeName.TIMESTAMP,
 }
 

--- a/dask_sql/mappings.py
+++ b/dask_sql/mappings.py
@@ -86,7 +86,7 @@ _SQL_TO_PYTHON_FRAMES = {
 def python_to_sql_type(python_type):
     """Mapping between python and SQL types."""
 
-    if isinstance(python_type, np.dtype):
+    if hasattr(python_type, "type"):
         python_type = python_type.type
 
     if pd.api.types.is_datetime64tz_dtype(python_type):

--- a/dask_sql/mappings.py
+++ b/dask_sql/mappings.py
@@ -18,22 +18,32 @@ _PYTHON_TO_SQL = {
     np.float64: SqlTypeName.DOUBLE,
     np.float32: SqlTypeName.FLOAT,
     np.int64: SqlTypeName.BIGINT,
+    pd.Int64Dtype(): SqlTypeName.BIGINT,
     np.int32: SqlTypeName.INTEGER,
+    pd.Int32Dtype(): SqlTypeName.INTEGER,
     np.int16: SqlTypeName.SMALLINT,
+    pd.Int16Dtype(): SqlTypeName.SMALLINT,
     np.int8: SqlTypeName.TINYINT,
+    pd.Int8Dtype(): SqlTypeName.TINYINT,
     np.uint64: SqlTypeName.BIGINT,
+    pd.UInt64Dtype(): SqlTypeName.BIGINT,
     np.uint32: SqlTypeName.INTEGER,
+    pd.UInt32Dtype(): SqlTypeName.INTEGER,
     np.uint16: SqlTypeName.SMALLINT,
+    pd.UInt16Dtype(): SqlTypeName.SMALLINT,
     np.uint8: SqlTypeName.TINYINT,
+    pd.UInt8Dtype(): SqlTypeName.TINYINT,
     np.bool8: SqlTypeName.BOOLEAN,
+    pd.BooleanDtype(): SqlTypeName.BOOLEAN,
     np.object_: SqlTypeName.VARCHAR,
+    pd.StringDtype(): SqlTypeName.VARCHAR,
     str: SqlTypeName.VARCHAR,
     np.datetime64: SqlTypeName.TIMESTAMP,
 }
 
 if FLOAT_NAN_IMPLEMENTED:  # pragma: no cover
     _PYTHON_TO_SQL.update(
-        {np.float64: SqlTypeName.FLOAT, np.float32: SqlTypeName.FLOAT}
+        {pd.Float32Dtype(): SqlTypeName.FLOAT, pd.Float64Dtype(): SqlTypeName.FLOAT}
     )
 
 # Default mapping between SQL types and python types

--- a/dask_sql/mappings.py
+++ b/dask_sql/mappings.py
@@ -18,32 +18,22 @@ _PYTHON_TO_SQL = {
     np.float64: SqlTypeName.DOUBLE,
     np.float32: SqlTypeName.FLOAT,
     np.int64: SqlTypeName.BIGINT,
-    pd.Int64Dtype(): SqlTypeName.BIGINT,
     np.int32: SqlTypeName.INTEGER,
-    pd.Int32Dtype(): SqlTypeName.INTEGER,
     np.int16: SqlTypeName.SMALLINT,
-    pd.Int16Dtype(): SqlTypeName.SMALLINT,
     np.int8: SqlTypeName.TINYINT,
-    pd.Int8Dtype(): SqlTypeName.TINYINT,
     np.uint64: SqlTypeName.BIGINT,
-    pd.UInt64Dtype(): SqlTypeName.BIGINT,
     np.uint32: SqlTypeName.INTEGER,
-    pd.UInt32Dtype(): SqlTypeName.INTEGER,
     np.uint16: SqlTypeName.SMALLINT,
-    pd.UInt16Dtype(): SqlTypeName.SMALLINT,
     np.uint8: SqlTypeName.TINYINT,
-    pd.UInt8Dtype(): SqlTypeName.TINYINT,
     np.bool8: SqlTypeName.BOOLEAN,
-    pd.BooleanDtype(): SqlTypeName.BOOLEAN,
     np.object_: SqlTypeName.VARCHAR,
-    pd.StringDtype(): SqlTypeName.VARCHAR,
     str: SqlTypeName.VARCHAR,
     np.datetime64: SqlTypeName.TIMESTAMP,
 }
 
 if FLOAT_NAN_IMPLEMENTED:  # pragma: no cover
     _PYTHON_TO_SQL.update(
-        {pd.Float32Dtype(): SqlTypeName.FLOAT, pd.Float64Dtype(): SqlTypeName.FLOAT}
+        {np.float64: SqlTypeName.FLOAT, np.float32: SqlTypeName.FLOAT}
     )
 
 # Default mapping between SQL types and python types

--- a/dask_sql/mappings.py
+++ b/dask_sql/mappings.py
@@ -35,9 +35,9 @@ _PYTHON_TO_SQL = {
     pd.UInt8Dtype(): SqlTypeName.TINYINT,
     np.bool8: SqlTypeName.BOOLEAN,
     pd.BooleanDtype(): SqlTypeName.BOOLEAN,
-    np.object_: SqlTypeName.VARCHAR,
-    pd.StringDtype(): SqlTypeName.VARCHAR,
     str: SqlTypeName.VARCHAR,
+    pd.StringDtype(): SqlTypeName.VARCHAR,
+    np.object_: SqlTypeName.VARCHAR,
     np.datetime64: SqlTypeName.TIMESTAMP,
 }
 


### PR DESCRIPTION
Chatting with @DaceT exposed that `python_to_sql_type` only has handling for pandas / numpy types, which can cause issues when attempting to read in a table with a cuDF dtype, like so:

```python
import cudf

from dask_sql import Context

c = Context()
cdf = cudf.datasets.timeseries()

c.create_table("tble", cdf)
result = c.sql("""SELECT timestamp FROM cdf""") 
result.compute()
```

```
TypeError: unhashable type: 'CategoricalDtype'
```

A pretty simple workaround for this is generalizing the column dtype check so that instead of checking for a `np.dtype`, we check if the Python type is "dtype-like".

Interested in if there's a trivial util function like `is_dataframe_like` for dtypes?