### PR TITLE
Use non-default scheduler port for independent cluster tests

### DIFF
--- a/.github/docker-compose.yaml
+++ b/.github/docker-compose.yaml
@@ -1,17 +1,20 @@
-# Docker-compose setup used during tests
-version: '3'
+# independent cluster setup used during tests
+version: "3.1"
+
 services:
-    dask-scheduler:
-        container_name: dask-scheduler
-        image: daskdev/dask:latest
-        command: dask-scheduler
-        ports:
-            - "8786:8786"
-        environment:
-            EXTRA_CONDA_PACKAGES: "pandas>=1.3 numpy=1.20.2 -c conda-forge"
-    dask-worker:
-        container_name: dask-worker
-        image: daskdev/dask:latest
-        command: dask-worker dask-scheduler:8786
-        environment:
-            EXTRA_CONDA_PACKAGES: "pandas>=1.3 numpy=1.20.2 -c conda-forge"
+  scheduler:
+    container_name: scheduler
+    image: daskdev/dask:latest
+    hostname: scheduler
+    ports:
+      - "2158:2158"
+    environment:
+      - EXTRA_CONDA_PACKAGES="pandas>=1.0.0"
+    command: ["dask-scheduler", "--port", "2158"]
+
+  worker:
+    container_name: worker
+    image: daskdev/dask:latest
+    environment:
+      - EXTRA_CONDA_PACKAGES="pandas>=1.0.0"
+    command: ["dask-worker", "tcp://scheduler:2158"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,13 +176,13 @@ jobs:
           # Wait for installation
           sleep 40
 
-          docker logs dask-scheduler
-          docker logs dask-worker
+          docker logs scheduler
+          docker logs worker
       - name: Test with pytest while running an independent dask cluster
         run: |
           pytest tests
         env:
-          DASK_SQL_TEST_SCHEDULER: tcp://127.0.0.1:8786
+          DASK_SQL_TEST_SCHEDULER: tcp://127.0.0.1:2158
 
   import:
     name: "Test importing with bare requirements"

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 
-pytest_plugins = ["distributed.utils_test", "tests.integration.fixtures"]
+pytest_plugins = ["tests.integration.fixtures", "distributed.utils_test"]
 
 
 def pytest_addoption(parser):

--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -4,10 +4,8 @@ import pytest
 from pandas.testing import assert_frame_equal
 
 import dask_sql
-from tests.integration.fixtures import skip_if_external_scheduler
 
 
-@skip_if_external_scheduler
 @pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
 def test_create_from_csv(c, df, temporary_data_file, gpu):
     df.to_csv(temporary_data_file, index=False)
@@ -66,7 +64,6 @@ def test_cluster_memory(client, c, df, gpu):
     assert_frame_equal(df, return_df)
 
 
-@skip_if_external_scheduler
 @pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
 def test_create_from_csv_persist(c, df, temporary_data_file, gpu):
     df.to_csv(temporary_data_file, index=False)
@@ -159,7 +156,6 @@ def test_create_from_query(c, df):
     assert_frame_equal(df, return_df)
 
 
-@skip_if_external_scheduler
 @pytest.mark.parametrize(
     "gpu",
     [


### PR DESCRIPTION
The test failures in #402 imply that we might not be using an independent cluster in our cluster testing; in particular, one of the tests failed because `triad` was unavailable, which shouldn't be in the Dask cluster generated by our [docker-compose file](https://github.com/dask-contrib/dask-sql/blob/main/.github/docker-compose.yaml).

What I think might be happening is that we're accidentally connecting to a cluster generated through the test fixtures (maybe `distributed.utils_test`?) on the default IP / port; to test this theory, this PR serves the independent scheduler on a random port to avoid potential collisions - if this results in failures, we can resolve them here. 