### PR TITLE
Bump pre-release package versions to be greater than stable releases

### DIFF
--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -1,5 +1,7 @@
 {% set name = "dask-sql" %}
-{% set version = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev') + environ.get('VERSION_SUFFIX', '') %}
+{% set major_minor_patch = environ.get('GIT_DESCRIBE_TAG', '0.0.0.dev').split('.') %}
+{% set new_patch = major_minor_patch[2] | int + 1 %}
+{% set version = (major_minor_patch[:2] + [new_patch]) | join('.') + environ.get('VERSION_SUFFIX', '') %}
 
 
 package:


### PR DESCRIPTION
Following up on https://github.com/dask/dask/pull/8728 and https://github.com/dask/distributed/pull/5816, this PR makes it so nightly builds will always be one patch version ahead of the stable release, which should make conda see them as newer than the stable package (currently they are interpreted as "older" alpha builds)