### PR TITLE
Use `build_ext`/`install_lib` subclasses to build external java

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           pip list
           conda list
       - name: Build jar
-        run: python setup.py java
+        run: python setup.py build_ext
       - name: Build and publish package
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,10 @@ jobs:
           which python
           pip list
           conda list
-      - name: Build jar
-        run: python setup.py build_ext
-      - name: Build and publish package
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+      - name: Publish package
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/*
+        run: twine upload dist/*

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -32,7 +32,7 @@ jobs:
           environment-file: continuous_integration/environment-3.8-jdk11-dev.yaml
       - name: Install dependencies and build the jar
         run: |
-          python setup.py java
+          python setup.py build_ext
       - name: Upload the jar
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
           environment-file: continuous_integration/environment-3.8-jdk11-dev.yaml
       - name: Build the jar
         run: |
-          python setup.py java
+          python setup.py build_ext
       - name: Upload the jar
         uses: actions/upload-artifact@v1
         with:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ After that, you can install the package in development mode
 
     pip install -e ".[dev]"
 
-To compile the Java classes (at the beginning or after changes), run
+To recompile the Java classes after changes have been made to the source contained in `planner/`, run
 
     python setup.py build_ext
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ After that, you can install the package in development mode
 
 To compile the Java classes (at the beginning or after changes), run
 
-    python setup.py java
+    python setup.py build_ext
 
 This repository uses [pre-commit](https://pre-commit.com/) hooks. To install them, call
 

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -48,7 +48,7 @@ python -m pip install git+https://github.com/dask/distributed
 
 gpuci_logger "Install dask-sql"
 pip install -e ".[dev]"
-python setup.py java
+python setup.py build_ext
 
 gpuci_logger "Check Python version"
 python --version

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -48,7 +48,6 @@ python -m pip install git+https://github.com/dask/distributed
 
 gpuci_logger "Install dask-sql"
 pip install -e ".[dev]"
-python setup.py build_ext
 
 gpuci_logger "Check Python version"
 python --version

--- a/continuous_integration/recipe/build.sh
+++ b/continuous_integration/recipe/build.sh
@@ -1,3 +1,0 @@
-# This assumes the script is executed from the root of the repo directory
-$PYTHON setup.py build_ext
-$PYTHON -m pip install . --no-deps -vv

--- a/continuous_integration/recipe/build.sh
+++ b/continuous_integration/recipe/build.sh
@@ -1,3 +1,3 @@
 # This assumes the script is executed from the root of the repo directory
-$PYTHON setup.py java
+$PYTHON setup.py build_ext
 $PYTHON -m pip install . --no-deps -vv

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -16,8 +16,7 @@ build:
     - dask-sql-server = dask_sql.server.app:main
     - dask-sql = dask_sql.cmd:main
   string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-  script_env:
-    - PYTHON
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     - dask-sql-server = dask_sql.server.app:main
     - dask-sql = dask_sql.cmd:main
   string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --global-option=build_ext --no-deps -vv
 
 requirements:
   build:

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     - dask-sql-server = dask_sql.server.app:main
     - dask-sql = dask_sql.cmd:main
   string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
-  script: {{ PYTHON }} -m pip install . --global-option=build_ext --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:

--- a/docker/main.dockerfile
+++ b/docker/main.dockerfile
@@ -21,16 +21,12 @@ RUN conda config --add channels conda-forge \
     "intake>=0.6.0" \
     && conda clean -ay
 
-# Build the java libraries
+# install dask-sql
 COPY setup.py /opt/dask_sql/
 COPY setup.cfg /opt/dask_sql/
 COPY versioneer.py /opt/dask_sql/
 COPY .git /opt/dask_sql/.git
 COPY planner /opt/dask_sql/planner
-RUN cd /opt/dask_sql/ \
-    && python setup.py build_ext
-
-# Install the python library
 COPY dask_sql /opt/dask_sql/dask_sql
 RUN cd /opt/dask_sql/ \
     && pip install -e .

--- a/docker/main.dockerfile
+++ b/docker/main.dockerfile
@@ -28,7 +28,7 @@ COPY versioneer.py /opt/dask_sql/
 COPY .git /opt/dask_sql/.git
 COPY planner /opt/dask_sql/planner
 RUN cd /opt/dask_sql/ \
-    && python setup.py java
+    && python setup.py build_ext
 
 # Install the python library
 COPY dask_sql /opt/dask_sql/dask_sql

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -101,7 +101,7 @@ To compile the Java classes (at the beginning or after changes), run
 
 .. code-block:: bash
 
-    python setup.py java
+    python setup.py build_ext
 
 You can run the tests (after installation) with
 

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,10 @@ import subprocess
 import sys
 
 from setuptools import find_packages, setup
+from setuptools.command.build_ext import build_ext as build_ext_orig
+from setuptools.extension import Extension
 
 import versioneer
-
-cmdclass = versioneer.get_cmdclass()
-build_ext_orig = cmdclass["build_ext"]
-build_py_orig = cmdclass["build_py"]
 
 
 class build_ext(build_ext_orig):
@@ -29,12 +27,6 @@ class build_ext(build_ext_orig):
         os.makedirs("dask_sql/jar", exist_ok=True)
         shutil.copy("planner/target/DaskSQL.jar", "dask_sql/jar/DaskSQL.jar")
 
-
-class build_py(build_py_orig):
-    """Simple override of versioneer's build_py command to build/copy jar first"""
-
-    def run(self):
-        build_ext.run(build_ext)
         super().run()
 
 
@@ -46,8 +38,8 @@ if os.path.exists("README.md"):
 needs_sphinx = "build_sphinx" in sys.argv
 sphinx_requirements = ["sphinx>=3.2.1", "sphinx_rtd_theme"] if needs_sphinx else []
 
+cmdclass = versioneer.get_cmdclass()
 cmdclass["build_ext"] = build_ext
-cmdclass["build_py"] = build_py
 
 setup(
     name="dask_sql",
@@ -61,6 +53,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(include=["dask_sql", "dask_sql.*"]),
     package_data={"dask_sql": ["jar/DaskSQL.jar"]},
+    ext_modules=[Extension("", sources=[])],  # forces build_ext to run on install
     python_requires=">=3.8",
     setup_requires=sphinx_requirements,
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -1,44 +1,28 @@
-import distutils
 import os
 import shutil
 import subprocess
 import sys
 
 from setuptools import find_packages, setup
+from setuptools.command.build_ext import build_ext as build_ext_orig
 
 import versioneer
 
 
-class MavenCommand(distutils.cmd.Command):
-    """Run the maven build command"""
-
-    description = "run the mvn install command"
-    user_options = []
-
-    def initialize_options(self):
-        """No options"""
-        pass
-
-    def finalize_options(self):
-        """No options"""
-        pass
+class build_ext(build_ext_orig):
+    """Build the external Java libraries"""
 
     def run(self):
         """Run the mvn installation command"""
-        # We need to explicitely specify the full path to mvn
-        # for Windows
         maven_command = shutil.which("mvn")
         if not maven_command:
             raise OSError(
                 "Can not find the mvn (maven) binary. Make sure to install maven before building the jar."
             )
         command = [maven_command, "clean", "install", "-f", "pom.xml"]
-        self.announce(f"Running command: {' '.join(command)}", level=distutils.log.INFO)
 
         subprocess.check_call(command, cwd="planner")
 
-        # Copy the artifact. We could also make maven do that,
-        # but in this way we have full control from python
         os.makedirs("dask_sql/jar", exist_ok=True)
         shutil.copy("planner/target/DaskSQL.jar", "dask_sql/jar/DaskSQL.jar")
 
@@ -52,7 +36,7 @@ needs_sphinx = "build_sphinx" in sys.argv
 sphinx_requirements = ["sphinx>=3.2.1", "sphinx_rtd_theme"] if needs_sphinx else []
 
 cmdclass = versioneer.get_cmdclass()
-cmdclass["java"] = MavenCommand
+cmdclass["build_ext"] = build_ext
 
 setup(
     name="dask_sql",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,8 @@ class build_ext(build_ext_orig):
         os.makedirs("dask_sql/jar", exist_ok=True)
         shutil.copy("planner/target/DaskSQL.jar", "dask_sql/jar/DaskSQL.jar")
 
+        super().run()
+
 
 long_description = ""
 if os.path.exists("README.md"):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ class build_ext(build_ext_orig):
         os.makedirs("dask_sql/jar", exist_ok=True)
         shutil.copy("planner/target/DaskSQL.jar", "dask_sql/jar/DaskSQL.jar")
 
-        super().run()
+        build_ext_orig.run(self)
 
 
 long_description = ""

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,9 @@ class install_lib(install_lib_orig):
         # remove java source as it doesn't need to be packaged
         shutil.rmtree(os.path.join(self.build_dir, "planner"))
 
-        # copy jar to source directory so dask-sql can be imported from there
-        self.copy_tree(os.path.join(self.build_dir, "dask_sql/jar"), "dask_sql/jar")
+        # copy jar to source directory for RTD builds to API docs build correctly
+        if os.environ.get("READTHEDOCS", False):
+            self.copy_tree(os.path.join(self.build_dir, "dask_sql/jar"), "dask_sql/jar")
 
 
 long_description = ""

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import sys
 
 from setuptools import find_packages, setup
 from setuptools.command.build_ext import build_ext as build_ext_orig
+from setuptools.extension import Extension
 
 import versioneer
 
@@ -52,6 +53,7 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(include=["dask_sql", "dask_sql.*"]),
     package_data={"dask_sql": ["jar/DaskSQL.jar"]},
+    ext_modules=[Extension("", sources=[])],  # forces build_ext to run on install
     python_requires=">=3.8",
     setup_requires=sphinx_requirements,
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,12 @@ import subprocess
 import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.build_ext import build_ext as build_ext_orig
-from setuptools.extension import Extension
 
 import versioneer
+
+cmdclass = versioneer.get_cmdclass()
+build_ext_orig = cmdclass["build_ext"]
+build_py_orig = cmdclass["build_py"]
 
 
 class build_ext(build_ext_orig):
@@ -27,6 +29,12 @@ class build_ext(build_ext_orig):
         os.makedirs("dask_sql/jar", exist_ok=True)
         shutil.copy("planner/target/DaskSQL.jar", "dask_sql/jar/DaskSQL.jar")
 
+
+class build_py(build_py_orig):
+    """Simple override of versioneer's build_py command to build/copy jar first"""
+
+    def run(self):
+        build_ext.run(build_ext)
         super().run()
 
 
@@ -38,8 +46,8 @@ if os.path.exists("README.md"):
 needs_sphinx = "build_sphinx" in sys.argv
 sphinx_requirements = ["sphinx>=3.2.1", "sphinx_rtd_theme"] if needs_sphinx else []
 
-cmdclass = versioneer.get_cmdclass()
 cmdclass["build_ext"] = build_ext
+cmdclass["build_py"] = build_py
 
 setup(
     name="dask_sql",
@@ -53,7 +61,6 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(include=["dask_sql", "dask_sql.*"]),
     package_data={"dask_sql": ["jar/DaskSQL.jar"]},
-    ext_modules=[Extension("", sources=[])],  # forces build_ext to run on install
     python_requires=">=3.8",
     setup_requires=sphinx_requirements,
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class install_lib(install_lib_orig):
         shutil.rmtree(os.path.join(self.build_dir, "planner"))
 
         # copy jar to source directory for RTD builds to API docs build correctly
-        if os.environ.get("READTHEDOCS", False):
+        if os.environ.get("READTHEDOCS", "False") == "True":
             self.copy_tree(os.path.join(self.build_dir, "dask_sql/jar"), "dask_sql/jar")
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ class install_lib(install_lib_orig):
         # remove java source as it doesn't need to be packaged
         shutil.rmtree(os.path.join(self.build_dir, "planner"))
 
+        # copy jar to source directory so dask-sql can be imported from there
+        self.copy_tree(os.path.join(self.build_dir, "dask_sql/jar"), "dask_sql/jar")
+
 
 long_description = ""
 if os.path.exists("README.md"):


### PR DESCRIPTION
This PR switches out the `MavenCommand` building our external Java for subclasses of `build_ext` and `install_lib`; this means that it will be run implicitly in commands like `pip install .`, which should also resolve issues with RTD not successfully building the package in #401

Closes #400

cc @jakirkham 