### PR TITLE
Fix use of row UDFs at intermediate query stages

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -964,9 +964,7 @@ class Context:
         schema = self.schema[schema_name]
 
         if not aggregation:
-            f = UDF(f, row_udf, return_type)
-            nm = [i[0] for i in parameters]
-            f._names = nm
+            f = UDF(f, row_udf, parameters, return_type)
         lower_name = name.lower()
         if lower_name in schema.functions:
             if replace:

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -326,7 +326,9 @@ class Context:
             f (:obj:`Callable`): The function to register
             name (:obj:`str`): Under which name should the new function be addressable in SQL
             parameters (:obj:`List[Tuple[str, type]]`): A list ot tuples of parameter name and parameter type.
-                Use `numpy dtypes <https://numpy.org/doc/stable/reference/arrays.dtypes.html>`_ if possible.
+                Use `numpy dtypes <https://numpy.org/doc/stable/reference/arrays.dtypes.html>`_ if possible. This
+                function is sensitive to the order of specified parameters when `row_udf=True`, and it is assumed
+                that column arguments are specified in order, followed by scalar arguments.
             return_type (:obj:`type`): The return type of the function
             replace (:obj:`bool`): If `True`, do not raise an error if a function with the same name is already
             present; instead, replace the original function. Default is `False`.

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -965,7 +965,8 @@ class Context:
 
         if not aggregation:
             f = UDF(f, row_udf, return_type)
-
+            nm = [i[0] for i in parameters]
+            f._names = nm
         lower_name = name.lower()
         if lower_name in schema.functions:
             if replace:

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -215,6 +215,7 @@ class UDF:
             df = column_args[0].to_frame()
             for col in column_args[1:]:
                 df[col.name] = col
+            df.columns = self._names
             result = df.apply(
                 self.func, axis=1, args=tuple(scalar_args), meta=self.meta
             ).astype(self.meta[1])

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -215,8 +215,8 @@ class UDF:
                 else:
                     scalar_args.append(operand)
 
-            df = column_args[0].to_frame()
-            for name, col in zip(self.names, column_args):
+            df = column_args[0].to_frame(self.names[0])
+            for name, col in zip(self.names[1:], column_args[1:]):
                 df[name] = col
 
             result = df.apply(

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -183,7 +183,7 @@ class DataContainer:
 
 
 class UDF:
-    def __init__(self, func, row_udf: bool, return_type=None):
+    def __init__(self, func, row_udf: bool, params, return_type=None):
         """
         Helper class that handles different types of UDFs and manages
         how they should be mapped to dask operations. Two versions of
@@ -195,6 +195,8 @@ class UDF:
         """
         self.row_udf = row_udf
         self.func = func
+
+        self.names = [param[0] for param in params]
 
         if return_type is None:
             # These UDFs go through apply and without providing
@@ -212,10 +214,11 @@ class UDF:
                     column_args.append(operand)
                 else:
                     scalar_args.append(operand)
+            
             df = column_args[0].to_frame()
-            for col in column_args[1:]:
-                df[col.name] = col
-            df.columns = self._names
+            for name, col in zip(self.names, column_args):
+                df[name] = col
+            
             result = df.apply(
                 self.func, axis=1, args=tuple(scalar_args), meta=self.meta
             ).astype(self.meta[1])

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -214,11 +214,11 @@ class UDF:
                     column_args.append(operand)
                 else:
                     scalar_args.append(operand)
-            
+
             df = column_args[0].to_frame()
             for name, col in zip(self.names, column_args):
                 df[name] = col
-            
+
             result = df.apply(
                 self.func, axis=1, args=tuple(scalar_args), meta=self.meta
             ).astype(self.meta[1])

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -38,6 +38,19 @@ def df_simple():
 
 
 @pytest.fixture()
+def df_wide():
+    return pd.DataFrame(
+        {
+            "a": [0, 1, 2],
+            "b": [3, 4, 5],
+            "c": [6, 7, 8],
+            "d": [9, 10, 11],
+            "e": [12, 13, 14],
+        }
+    )
+
+
+@pytest.fixture()
 def df():
     np.random.seed(42)
     return pd.DataFrame(
@@ -126,6 +139,7 @@ def gpu_datetime_table(datetime_table):
 @pytest.fixture()
 def c(
     df_simple,
+    df_wide,
     df,
     user_table_1,
     user_table_2,
@@ -142,6 +156,7 @@ def c(
 ):
     dfs = {
         "df_simple": df_simple,
+        "df_wide": df_wide,
         "df": df,
         "user_table_1": user_table_1,
         "user_table_2": user_table_2,

--- a/tests/integration/test_function.py
+++ b/tests/integration/test_function.py
@@ -4,7 +4,7 @@ import operator
 import dask.dataframe as dd
 import numpy as np
 import pytest
-from pandas.testing import assert_frame_equal, assert_series_equal
+from pandas.testing import assert_frame_equal
 
 
 def test_custom_function(c, df):
@@ -26,7 +26,7 @@ def test_custom_function(c, df):
 
 def test_custom_function_row(c, df):
     def f(row):
-        return row["a"] ** 2
+        return row["x"] ** 2
 
     c.register_function(f, "f", [("x", np.float64)], np.float64, row_udf=True)
 
@@ -55,11 +55,10 @@ def test_custom_function_any_colnames(colnames, df_wide, c):
 
     return_df = c.sql(f"SELECT F({colname_x},{colname_y}) FROM df_wide")
 
-    return_df = return_df.compute()
     expect = df_wide[colname_x] + df_wide[colname_y]
-    got = return_df[return_df.columns[0]]
+    got = return_df.iloc[:, 0]
 
-    assert_series_equal(expect, got, check_names=False)
+    dd.assert_eq(expect, got, check_names=False)
 
 
 @pytest.mark.parametrize(
@@ -68,7 +67,7 @@ def test_custom_function_any_colnames(colnames, df_wide, c):
 )
 def test_custom_function_row_return_types(c, df, retty):
     def f(row):
-        return row["a"] ** 2
+        return row["x"] ** 2
 
     if retty is None:
         with pytest.raises(ValueError):

--- a/tests/integration/test_show.py
+++ b/tests/integration/test_show.py
@@ -35,6 +35,7 @@ def test_tables(c):
             "Table": [
                 "df",
                 "df_simple",
+                "df_wide",
                 "user_table_1",
                 "user_table_2",
                 "long_table",
@@ -47,6 +48,7 @@ def test_tables(c):
             else [
                 "df",
                 "df_simple",
+                "df_wide",
                 "user_table_1",
                 "user_table_2",
                 "long_table",


### PR DESCRIPTION
Row UDFs in `dask-sql` are analogous to the functions expected by `pandas.DataFrame.apply` an expect a row of data containing all the scalars in a single row. The UDF accesses these scalars from the row via the corresponding column labels within the function:

```python
def f(row):
    x = row['a'] * 2
    y = row['b']
    return x - y
```

This works fine if the dataframe that calls the `apply` from dask in the end actually contains columns named `a` and `b`. This is however likely only the case for simple queries and fails if any columns are aliased during more complex operations, such as joins. 

This PR proposes to solve the problem by retaining the names of the original variables the function was registered with and reapplying them to the data later, just before calling `apply`. 