### PR TITLE
Optimize fast codepath for applying limits

### DIFF
--- a/dask_sql/physical/rel/logical/limit.py
+++ b/dask_sql/physical/rel/logical/limit.py
@@ -59,9 +59,13 @@ class DaskLimitPlugin(BaseRelPlugin):
         function, which is not possible with normal "map_partitions".
         """
         if not offset:
-            # We do a (hopefully) very quick check: if the first partition
-            # is already enough, we will just use this
-            first_partition_length = len(df.partitions[0])
+            # get length of first nonempty partition
+            for partition in df.partitions:
+                first_partition_length = len(partition)
+                if first_partition_length:
+                    break
+
+            # if this partition contains the requested data, return
             if first_partition_length >= end:
                 return df.head(end, compute=False)
 

--- a/dask_sql/physical/rel/logical/limit.py
+++ b/dask_sql/physical/rel/logical/limit.py
@@ -59,15 +59,16 @@ class DaskLimitPlugin(BaseRelPlugin):
         function, which is not possible with normal "map_partitions".
         """
         if not offset:
-            # get length of first nonempty partition
+            # compute the number of partitions that need to be persisted in head
+            npartitions = 0
+            nrows = 0
             for partition in df.partitions:
-                first_partition_length = len(partition)
-                if first_partition_length:
+                npartitions += 1
+                nrows += len(partition)
+                if nrows >= end:
                     break
 
-            # if this partition contains the requested data, return
-            if first_partition_length >= end:
-                return df.head(end, compute=False)
+            return df.head(end, npartitions=npartitions, compute=False)
 
         # First, we need to find out which partitions we want to use.
         # Therefore we count the total number of entries

--- a/dask_sql/physical/rel/logical/limit.py
+++ b/dask_sql/physical/rel/logical/limit.py
@@ -58,17 +58,9 @@ class DaskLimitPlugin(BaseRelPlugin):
         we need to pass the partition number to the selection
         function, which is not possible with normal "map_partitions".
         """
+        # lazily return a simple head operation if possible
         if not offset:
-            # compute the number of partitions that need to be persisted in head
-            npartitions = 0
-            nrows = 0
-            for partition in df.partitions:
-                npartitions += 1
-                nrows += len(partition)
-                if nrows >= end:
-                    break
-
-            return df.head(end, npartitions=npartitions, compute=False)
+            return df.head(end, npartitions=-1, compute=False)
 
         # First, we need to find out which partitions we want to use.
         # Therefore we count the total number of entries


### PR DESCRIPTION
Often, we will specify a `LIMIT` on the result of a complex query, which can potentially leave us with a Dask dataframe with several empty partitions (in my case, I encountered this with cross-join operations). In these cases, checking the length of the dataframe's first partition doesn't really give us a good idea of if we can apply a `LIMIT` on the dataframe with minimal persists using `head()`, as the first partition actually containing data could be the Nth partition of the dataframe.

This PR resolves this by expanding the partition length check to grab the length of the first _nonempty_ partition; this new check ideally shouldn't result in any significant extra persists, as the only additional dataframes we are loading into memory are empty.

cc @ayushdg @randerzander 