### PR TITLE
Provide `meta` to result of complex `_apply_offset`

### DIFF
--- a/dask_sql/physical/rel/logical/limit.py
+++ b/dask_sql/physical/rel/logical/limit.py
@@ -103,4 +103,6 @@ class DaskLimitPlugin(BaseRelPlugin):
 
         # (b) Now we just need to apply the function on every partition
         # We do this via the delayed interface, which seems the easiest one.
-        return map_on_partition_index(df, select_from_to, partition_borders)
+        return map_on_partition_index(
+            df, select_from_to, partition_borders, meta=df._meta
+        )

--- a/dask_sql/physical/utils/map.py
+++ b/dask_sql/physical/utils/map.py
@@ -7,9 +7,11 @@ import dask.dataframe as dd
 def map_on_partition_index(
     df: dd.DataFrame, f: Callable, *args: Any, **kwargs: Any
 ) -> dd.DataFrame:
+    meta = kwargs.pop("meta", None)
     return dd.from_delayed(
         [
             dask.delayed(f)(partition, partition_number, *args, **kwargs)
             for partition_number, partition in enumerate(df.partitions)
-        ]
+        ],
+        meta=meta,
     )


### PR DESCRIPTION
In `_apply_offset`, we sometimes use `dd.from_delayed()` to construct the resulting dataframe, but do not explicitly pass a `meta`. This means that in some cases, we end up implicitly changing the `meta` of the input dataframe, which can cause issues later on if it doesn't match up with the computed dataframe (the cause of the test failures in #408).

This PR passes the input dataframe's `meta` to `dd.from_delayed()` so that it is preserved through the operation.