### PR TITLE
Remove null-handling in `_join_on_columns`

### DIFF
--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -208,23 +208,6 @@ class DaskJoinPlugin(BaseRelPlugin):
             for i, index in enumerate(rhs_on)
         }
 
-        # SQL compatibility: when joining on columns that
-        # contain NULLs, pandas will actually happily
-        # keep those NULLs. That is however not compatible with
-        # SQL, so we get rid of them here
-        if join_type in ["inner", "right"]:
-            df_lhs_filter = reduce(
-                operator.and_,
-                [~df_lhs_renamed.iloc[:, index].isna() for index in lhs_on],
-            )
-            df_lhs_renamed = df_lhs_renamed[df_lhs_filter]
-        if join_type in ["inner", "left"]:
-            df_rhs_filter = reduce(
-                operator.and_,
-                [~df_rhs_renamed.iloc[:, index].isna() for index in rhs_on],
-            )
-            df_rhs_renamed = df_rhs_renamed[df_rhs_filter]
-
         df_lhs_with_tmp = df_lhs_renamed.assign(**lhs_columns_to_add)
         df_rhs_with_tmp = df_rhs_renamed.assign(**rhs_columns_to_add)
         added_columns = list(lhs_columns_to_add.keys())


### PR DESCRIPTION
Removes the implicit `isna` filtering happening on join columns in a standard join operation, implementing the suggestion made in #424