### PR TITLE
Remove some logger / deprecation warnings

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -721,7 +721,7 @@ class Context:
             java_schema = DaskSchema(schema_name)
 
             if not schema.tables:
-                logger.warning("No tables are registered.")
+                logger.debug("No tables are registered.")
 
             for name, dc in schema.tables.items():
                 row_count = (

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import logging
-import warnings
 from typing import Any, Callable, Dict, List, Tuple, Union
 
 import dask.dataframe as dd
@@ -201,10 +200,6 @@ class Context:
             **kwargs: Additional arguments for specific formats. See :ref:`data_input` for more information.
 
         """
-        if "file_format" in kwargs:  # pragma: no cover
-            warnings.warn("file_format is renamed to format", DeprecationWarning)
-            format = kwargs.pop("file_format")
-
         schema_name = schema_name or self.schema_name
 
         dc = InputUtil.to_dc(
@@ -218,16 +213,6 @@ class Context:
         self.schema[schema_name].tables[table_name.lower()] = dc
         if statistics:
             self.schema[schema_name].statistics[table_name.lower()] = statistics
-
-    def register_dask_table(self, df: dd.DataFrame, name: str, *args, **kwargs):
-        """
-        Outdated version of :func:`create_table()`.
-        """
-        warnings.warn(
-            "register_dask_table is deprecated, use the more general create_table instead.",
-            DeprecationWarning,
-        )
-        return self.create_table(name, df, *args, **kwargs)
 
     def drop_table(self, table_name: str, schema_name: str = None):
         """

--- a/dask_sql/java.py
+++ b/dask_sql/java.py
@@ -8,6 +8,7 @@ to the jar file in the package resources.
 import logging
 import os
 import platform
+import warnings
 
 import jpype
 import pkg_resources
@@ -35,9 +36,10 @@ def _set_or_check_java_home():
     elif (
         os.path.normpath(os.environ["JAVA_HOME"]) != correct_java_path
     ):  # pragma: no cover
-        logger.warning(
+        warnings.warn(
             "You are running in a conda environment, but the JAVA_PATH is not using it. "
-            f"If this is by mistake, set $JAVA_HOME to {correct_java_path}, instead of {os.environ['JAVA_HOME']}."
+            f"If this is by mistake, set $JAVA_HOME to {correct_java_path}, instead of {os.environ['JAVA_HOME']}.",
+            RuntimeWarning,
         )
 
 

--- a/dask_sql/java.py
+++ b/dask_sql/java.py
@@ -8,7 +8,6 @@ to the jar file in the package resources.
 import logging
 import os
 import platform
-import warnings
 
 import jpype
 import pkg_resources
@@ -36,7 +35,7 @@ def _set_or_check_java_home():
     elif (
         os.path.normpath(os.environ["JAVA_HOME"]) != correct_java_path
     ):  # pragma: no cover
-        warnings.warn(
+        logger.warning(
             "You are running in a conda environment, but the JAVA_PATH is not using it. "
             f"If this is by mistake, set $JAVA_HOME to {correct_java_path}, instead of {os.environ['JAVA_HOME']}."
         )

--- a/dask_sql/physical/rel/logical/filter.py
+++ b/dask_sql/physical/rel/logical/filter.py
@@ -24,7 +24,7 @@ def filter_or_scalar(df: dd.DataFrame, filter_condition: Union[np.bool_, dd.Seri
     if np.isscalar(filter_condition):
         if not filter_condition:  # pragma: no cover
             # empty dataset
-            logger.warning("Join condition is always false - returning empty dataset")
+            logger.debug("Join condition is always false - returning empty dataset")
             return df.head(0, compute=False)
         else:
             return df

--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -1,6 +1,5 @@
 import logging
 import operator
-import warnings
 from functools import reduce
 from typing import TYPE_CHECKING, List, Tuple
 
@@ -150,9 +149,8 @@ class DaskJoinPlugin(BaseRelPlugin):
             divisions = [None] * (len(dsk) + 1)
             df = dd.DataFrame(graph, name, meta=meta, divisions=divisions)
 
-            warnings.warn(
-                "Need to do a cross-join, which is typically very resource heavy",
-                ResourceWarning,
+            logger.warning(
+                "Need to do a cross-join, which is typically very resource heavy"
             )
 
         # 6. So the next step is to make sure

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -255,7 +255,7 @@ def test_like(c, input_table, gpu, request):
     dd.assert_eq(df, string_table)
 
     string_table2 = xd.DataFrame({"b": ["a", "b", None, pd.NA, float("nan")]})
-    c.create_table(string_table2, "string_table2")
+    c.create_table("string_table2", string_table2)
     df = c.sql(
         """
         SELECT * FROM string_table2
@@ -513,7 +513,7 @@ def test_date_functions(c):
     date = datetime(2021, 10, 3, 15, 53, 42, 47)
 
     df = dd.from_pandas(pd.DataFrame({"d": [date]}), npartitions=1)
-    c.create_table(df, "df")
+    c.create_table("df", df)
 
     df = c.sql(
         """

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -255,7 +255,7 @@ def test_like(c, input_table, gpu, request):
     dd.assert_eq(df, string_table)
 
     string_table2 = xd.DataFrame({"b": ["a", "b", None, pd.NA, float("nan")]})
-    c.register_table(string_table2, "string_table2")
+    c.create_table(string_table2, "string_table2")
     df = c.sql(
         """
         SELECT * FROM string_table2
@@ -513,7 +513,7 @@ def test_date_functions(c):
     date = datetime(2021, 10, 3, 15, 53, 42, 47)
 
     df = dd.from_pandas(pd.DataFrame({"d": [date]}), npartitions=1)
-    c.register_table(df, "df")
+    c.create_table(df, "df")
 
     df = c.sql(
         """

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -255,7 +255,7 @@ def test_like(c, input_table, gpu, request):
     dd.assert_eq(df, string_table)
 
     string_table2 = xd.DataFrame({"b": ["a", "b", None, pd.NA, float("nan")]})
-    c.register_dask_table(dd.from_pandas(string_table2, npartitions=1), "string_table2")
+    c.register_table(string_table2, "string_table2")
     df = c.sql(
         """
         SELECT * FROM string_table2
@@ -513,7 +513,7 @@ def test_date_functions(c):
     date = datetime(2021, 10, 3, 15, 53, 42, 47)
 
     df = dd.from_pandas(pd.DataFrame({"d": [date]}), npartitions=1)
-    c.register_dask_table(df, "df")
+    c.register_table(df, "df")
 
     df = c.sql(
         """

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,5 +1,3 @@
-import warnings
-
 import dask.dataframe as dd
 import pandas as pd
 import pytest
@@ -32,25 +30,6 @@ def test_add_remove_tables(gpu):
 
     c.create_table("table", [data_frame], gpu=gpu)
     assert "table" in c.schema[c.schema_name].tables
-
-
-@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
-def test_deprecation_warning(gpu):
-    c = Context()
-    data_frame = dd.from_pandas(pd.DataFrame(), npartitions=1)
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-
-        c.register_dask_table(data_frame, "table", gpu=gpu)
-
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
-
-    assert "table" in c.schema[c.schema_name].tables
-
-    c.drop_table("table")
-    assert "table" not in c.schema[c.schema_name].tables
 
 
 @pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])


### PR DESCRIPTION
Closes #391 

This PR switches around some of the `logger` / `warnings` in an effort to make warnings less intrusive to users, while also removing some deprecation code that is pretty old and likely isn't encountered anymore.

Side note - is anyone actively using the logging functionality here? If not, maybe it would just be better to remove the majority of the debugging logs from the code altogether, and just stick to `warnings.warn` for the few cases where we actually need to warn the user of something? cc @jdye64 as I know you were doing some work with the logging