### PR TITLE
Fix logic for unary join operands like `IS NOT NULL`

### DIFF
--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -237,7 +237,10 @@ class DaskJoinPlugin(BaseRelPlugin):
         self, join_condition: "org.apache.calcite.rex.RexCall"
     ) -> Tuple[List[str], List[str], List["org.apache.calcite.rex.RexCall"]]:
 
-        if isinstance(join_condition, org.apache.calcite.rex.RexLiteral):
+        if isinstance(
+            join_condition,
+            (org.apache.calcite.rex.RexLiteral, org.apache.calcite.rex.RexInputRef),
+        ):
             return [], [], [join_condition]
         elif not isinstance(join_condition, org.apache.calcite.rex.RexCall):
             raise NotImplementedError("Can not understand join condition.")

--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -259,15 +259,11 @@ class DaskJoinPlugin(BaseRelPlugin):
             filter_condition = []
 
             for operand in operands:
-                if isinstance(operand, org.apache.calcite.rex.RexCall):
-                    try:
-                        lhs_on_part, rhs_on_part = self._extract_lhs_rhs(operand)
-                        lhs_on.append(lhs_on_part)
-                        rhs_on.append(rhs_on_part)
-                        continue
-                    except AssertionError:
-                        pass
-
+                try:
+                    lhs_on_part, rhs_on_part = self._extract_lhs_rhs(operand)
+                    lhs_on.append(lhs_on_part)
+                    rhs_on.append(rhs_on_part)
+                except AssertionError:
                     filter_condition.append(operand)
 
             if lhs_on and rhs_on:
@@ -276,6 +272,8 @@ class DaskJoinPlugin(BaseRelPlugin):
         return [], [], [join_condition]
 
     def _extract_lhs_rhs(self, rex):
+        assert isinstance(rex, org.apache.calcite.rex.RexCall)
+
         operator_name = str(rex.getOperator().getName())
         assert operator_name == "="
 

--- a/tests/integration/test_join.py
+++ b/tests/integration/test_join.py
@@ -212,6 +212,24 @@ def test_conditional_join(c):
     assert_eq(actual_df, expected_df, check_index=False, check_dtype=False)
 
 
+def test_join_on_unary_cond_only(c):
+    df1 = pd.DataFrame({"a": [1, 2, 2, 5, 6], "b": ["w", "x", "y", None, "z"]})
+    df2 = pd.DataFrame({"c": [None, 3, 2, 5], "d": ["h", "i", "j", "k"]})
+
+    c.create_table("df1", df1)
+    c.create_table("df2", df2)
+
+    df1 = df1.assign(common=1)
+    df2 = df2.assign(common=1)
+
+    expected_df = df1.merge(df2, on="common").drop(columns="common")
+    expected_df = expected_df[~pd.isnull(expected_df.b)]
+
+    actual_df = c.sql("SELECT * FROM df1 INNER JOIN df2 ON b IS NOT NULL")
+
+    assert_eq(actual_df, expected_df, check_index=False, check_dtype=False)
+
+
 def test_join_case_projection_subquery():
     c = Context()
 

--- a/tests/integration/test_join.py
+++ b/tests/integration/test_join.py
@@ -193,14 +193,14 @@ def test_conditional_join(c):
     df2 = pd.DataFrame({"c": [None, 3, 2, 5], "d": ["h", "i", "j", "k"]})
 
     expected_df = pd.merge(df1, df2, how="inner", left_on=["a"], right_on=["c"])
-    expected_df = expected_df[~pd.isnull(expected_df.b)][["a"]]
+    expected_df = expected_df[~pd.isnull(expected_df.b)]
 
     c.create_table("df1", df1)
     c.create_table("df2", df2)
 
     actual_df = c.sql(
         """
-    SELECT a FROM df1
+    SELECT * FROM df1
     INNER JOIN df2 ON
     (
         a = c


### PR DESCRIPTION
In #366, we attempted to add in logic for unary join operands (such as `IS NOT NULL`). Unbeknownst to us, the added tests didn't actually ensure that this logic was working properly.

This PR alters the test to directly test that this logic is working, and makes some changes to the parsing of join operands so that `RexInputRefs` are correctly parsed as filters.

cc @jdye64 