### PR TITLE
Only use session-wide `client` fixture for independent cluster testing

### DIFF
--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -19,6 +19,9 @@ except ImportError:
     cudf = None
     LocalCUDACluster = None
 
+# check if we want to connect to an independent cluster
+SCHEDULER_ADDR = os.getenv("DASK_SQL_TEST_SCHEDULER", None)
+
 
 @pytest.fixture()
 def timeseries_df(c):
@@ -297,9 +300,16 @@ def gpu_client(gpu_cluster):
             yield client
 
 
-@pytest.fixture(scope="session", autouse=True)
+# if connecting to an independent cluster, use a session-wide
+# client for all computations. otherwise, only connect to a client
+# when specified.
+@pytest.fixture(
+    scope="function" if SCHEDULER_ADDR is None else "session",
+    autouse=False if SCHEDULER_ADDR is None else True,
+)
 def client():
-    yield Client(address=os.getenv("DASK_SQL_TEST_SCHEDULER", None))
+    with Client(address=SCHEDULER_ADDR) as client:
+        yield client
 
 
 skip_if_external_scheduler = pytest.mark.skipif(


### PR DESCRIPTION
With https://github.com/dask-contrib/dask-sql/pull/437, we changed the behavior of the `client` fixture so that during testing, we would _always_ connect to a CPU cluster that was maintained through the entire testing session. This seems to be causing breakage for gpuCI testing, which can be seen in https://github.com/dask-contrib/dask-sql/pull/432.

To unblock the gpuCI work, this PR returns the `client` fixture roughly to how it was before:

- if `DASK_SQL_TEST_SCHEDULER` isn't specified, a client + cluster will only be started on demand - otherwise, things will generally run locally on a synchronous scheduler
- if `DASK_SQL_TEST_SCHEDULER` is specified, a client will be connected to the external cluster and maintained for the entire testing session (to make sure even tests that don't directly access the client can still run successfully on it)

cc @galipremsagar 