### PR TITLE
Add workflow to keep `datafusion-sql-planner` branch up to date

### DIFF
--- a/.github/workflows/datafusion-sync.yml
+++ b/.github/workflows/datafusion-sync.yml
@@ -1,0 +1,30 @@
+name: Keep datafusion branch up to date
+on:
+  push:
+    branches:
+      - main
+
+# When this workflow is queued, automatically cancel any previous running
+# or pending jobs
+concurrency:
+  group: datafusion-sync
+  cancel-in-progress: true
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    if: github.repository == 'dask-contrib/dask-sql'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FROM_BRANCH: main
+          TO_BRANCH: datafusion-sql-planner


### PR DESCRIPTION
Adds a workflow that, on all merges to `main`, will open a PR attempting to merge these changes into `datafusion-sql-planner`.

Ideally, we would want these PRs to be automatically merged on a series of conditions (no merge conflicts, all tests passing, etc.) but for now we can start with this and iterate once things are working.