### PR TITLE
Update versions of Java dependencies

### DIFF
--- a/planner/pom.xml
+++ b/planner/pom.xml
@@ -95,7 +95,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
-			<version>2.10.0</version>
+			<version>2.13.2</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -112,7 +112,7 @@
 		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
-			<version>2.4.0</version>
+			<version>2.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.yahoo.datasketches</groupId>
@@ -142,7 +142,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.11.0</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
This Pr address a part of #438 by updating the packages to newer versions which don't have any known cves at this time. 