### PR TITLE
Resolve gpuCI workflow failures

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -55,7 +55,7 @@ jobs:
           echo NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-10} >> $GITHUB_ENV
 
       - name: Update RAPIDS version
-        uses: jacobtomlinson/gha-find-replace@2
+        uses: jacobtomlinson/gha-find-replace@v2
         with:
           include: 'continuous_integration\/gpuci\/axis\.yaml'
           find: "${{ env.RAPIDS_VER }}"


### PR DESCRIPTION
We erroneously set `gha-find-replace` to version `2` instead of `v2` - this should resolve the failures caused by that.