### PR TITLE
Add handling for newer `prompt_toolkit` versions in cmd tests

### DIFF
--- a/dask_sql/_compat.py
+++ b/dask_sql/_compat.py
@@ -1,6 +1,12 @@
 import pandas as pd
+import prompt_toolkit
 from packaging.version import parse as parseVersion
 
 _pandas_version = parseVersion(pd.__version__)
+_prompt_toolkit_version = parseVersion(prompt_toolkit.__version__)
+
 FLOAT_NAN_IMPLEMENTED = _pandas_version >= parseVersion("1.2.0")
 INT_NAN_IMPLEMENTED = _pandas_version >= parseVersion("1.0.0")
+
+# TODO: remove if prompt-toolkit min version gets bumped
+PIPE_INPUT_CONTEXT_MANAGER = _prompt_toolkit_version >= parseVersion("3.0.29")

--- a/tests/integration/test_cmd.py
+++ b/tests/integration/test_cmd.py
@@ -1,22 +1,19 @@
-import prompt_toolkit
 import pytest
 from dask import config as dask_config
 from mock import MagicMock, patch
-from packaging.version import parse as parseVersion
 from prompt_toolkit.application import create_app_session
 from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 from prompt_toolkit.shortcuts import PromptSession
 
+from dask_sql._compat import PIPE_INPUT_CONTEXT_MANAGER
 from dask_sql.cmd import _meta_commands
-
-_prompt_toolkit_version = parseVersion(prompt_toolkit.__version__)
 
 
 @pytest.fixture(autouse=True, scope="function")
 def mock_prompt_input():
     # TODO: remove if prompt-toolkit min version gets bumped
-    if _prompt_toolkit_version >= parseVersion("3.0.29"):
+    if PIPE_INPUT_CONTEXT_MANAGER:
         with create_pipe_input() as pipe_input:
             with create_app_session(input=pipe_input, output=DummyOutput()):
                 yield pipe_input

--- a/tests/integration/test_cmd.py
+++ b/tests/integration/test_cmd.py
@@ -1,6 +1,8 @@
+import prompt_toolkit
 import pytest
 from dask import config as dask_config
 from mock import MagicMock, patch
+from packaging.version import parse as parseVersion
 from prompt_toolkit.application import create_app_session
 from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.output import DummyOutput
@@ -8,15 +10,23 @@ from prompt_toolkit.shortcuts import PromptSession
 
 from dask_sql.cmd import _meta_commands
 
+_prompt_toolkit_version = parseVersion(prompt_toolkit.__version__)
+
 
 @pytest.fixture(autouse=True, scope="function")
 def mock_prompt_input():
-    pipe_input = create_pipe_input()
-    try:
-        with create_app_session(input=pipe_input, output=DummyOutput()):
-            yield pipe_input
-    finally:
-        pipe_input.close()
+    # TODO: remove if prompt-toolkit min version gets bumped
+    if _prompt_toolkit_version >= parseVersion("3.0.29"):
+        with create_pipe_input() as pipe_input:
+            with create_app_session(input=pipe_input, output=DummyOutput()):
+                yield pipe_input
+    else:
+        pipe_input = create_pipe_input()
+        try:
+            with create_app_session(input=pipe_input, output=DummyOutput()):
+                yield pipe_input
+        finally:
+            pipe_input.close()
 
 
 def _feed_cli_with_input(


### PR DESCRIPTION
With `prompt_toolkit>=3.0.29`, the use of `create_pipe_input` has changed, breaking our CI - this PR does a check on the version of this package, using the new `create_pipe_input` behavior if it is 3.0.29 and above, reverting to the old behavior otherwise.