### PR TITLE
Disable SQL server functionality

### DIFF
--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -15,7 +15,8 @@ build:
   number: {{ GIT_DESCRIBE_NUMBER }}
   noarch: python
   entry_points:
-    - dask-sql-server = dask_sql.server.app:main
+    # TODO: re-enable server once CVEs are resolved
+    # - dask-sql-server = dask_sql.server.app:main
     - dask-sql = dask_sql.cmd:main
   string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script: {{ PYTHON }} -m pip install . --no-deps -vv
@@ -45,7 +46,8 @@ test:
     - dask_sql
   commands:
     - pip check
-    - dask-sql-server --help
+    # TODO: re-enable server once CVEs are resolved
+    # - dask-sql-server --help
     - dask-sql --help
   requires:
     - pip

--- a/dask_sql/__init__.py
+++ b/dask_sql/__init__.py
@@ -3,9 +3,12 @@ from ._version import get_versions
 from .cmd import cmd_loop
 from .context import Context
 from .datacontainer import Statistics
-from .server.app import run_server
+
+# from .server.app import run_server
 
 __version__ = get_versions()["version"]
 del get_versions
 
-__all__ = [__version__, cmd_loop, Context, run_server, Statistics]
+# TODO: re-enable server once CVEs are resolved
+# __all__ = [__version__, cmd_loop, Context, run_server, Statistics]
+__all__ = [__version__, cmd_loop, Context, Statistics]

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -656,9 +656,6 @@ class Context:
             port (:obj:`int`): The port to listen on (defaults to 8080)
             log_level: (:obj:`str`): The log level of the server and dask-sql
         """
-        # TODO: re-enable server once CVEs are resolved
-        raise NotImplementedError
-
         from dask_sql.server.app import run_server
 
         self.stop_server()
@@ -675,9 +672,6 @@ class Context:
         """
         Stop a SQL server started by ``run_server``.
         """
-        # TODO: re-enable server once CVEs are resolved
-        raise NotImplementedError
-
         if self.sql_server is not None:
             loop = asyncio.get_event_loop()
             assert loop

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -656,10 +656,13 @@ class Context:
             port (:obj:`int`): The port to listen on (defaults to 8080)
             log_level: (:obj:`str`): The log level of the server and dask-sql
         """
+        # TODO: re-enable server once CVEs are resolved
+        raise NotImplementedError
+
         from dask_sql.server.app import run_server
 
         self.stop_server()
-        self.server = run_server(
+        self.sql_server = run_server(
             context=self,
             client=client,
             host=host,
@@ -672,6 +675,9 @@ class Context:
         """
         Stop a SQL server started by ``run_server``.
         """
+        # TODO: re-enable server once CVEs are resolved
+        raise NotImplementedError
+
         if self.sql_server is not None:
             loop = asyncio.get_event_loop()
             assert loop

--- a/dask_sql/server/app.py
+++ b/dask_sql/server/app.py
@@ -276,6 +276,9 @@ def _init_app(
     context: Context = None,
     client: dask.distributed.Client = None,
 ):
+    # TODO: re-enable server once CVEs are resolved
+    raise NotImplementedError
+
     app.c = context or Context()
     app.future_list = {}
 

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -3,6 +3,10 @@
 SQL Server
 ==========
 
+.. warning::
+
+    ``dask-sql``'s SQL server functionality is currently exploitable and has been disable until the exposed vulnerabilites can be resolve.
+
 ``dask-sql`` comes with a small test implementation for a SQL server.
 Instead of rebuilding a full ODBC driver, we re-use the `presto wire protocol <https://github.com/prestodb/presto/wiki/HTTP-Protocol>`_.
 

--- a/docs/source/server.rst
+++ b/docs/source/server.rst
@@ -5,7 +5,7 @@ SQL Server
 
 .. warning::
 
-    ``dask-sql``'s SQL server functionality is currently exploitable and has been disable until the exposed vulnerabilites can be resolve.
+    ``dask-sql``'s SQL server functionality is currently exploitable and has been disabled until the exposed vulnerabilities can be resolved.
 
 ``dask-sql`` comes with a small test implementation for a SQL server.
 Instead of rebuilding a full ODBC driver, we re-use the `presto wire protocol <https://github.com/prestodb/presto/wiki/HTTP-Protocol>`_.

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,8 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            "dask-sql-server = dask_sql.server.app:main",
+            # TODO: re-enable server once CVEs are resolved
+            # "dask-sql-server = dask_sql.server.app:main",
             "dask-sql = dask_sql.cmd:main",
         ]
     },

--- a/tests/integration/test_cve_fix.py
+++ b/tests/integration/test_cve_fix.py
@@ -1,0 +1,13 @@
+import pytest
+
+from dask_sql.server.app import _init_app
+
+
+def test_run_server_disabled(c):
+    with pytest.raises(NotImplementedError):
+        c.run_server()
+
+
+def test_init_app_disabled():
+    with pytest.raises(NotImplementedError):
+        _init_app()

--- a/tests/integration/test_cve_fix.py
+++ b/tests/integration/test_cve_fix.py
@@ -1,6 +1,7 @@
 import pytest
 
-from dask_sql.server.app import _init_app
+from dask_sql import Context
+from dask_sql.server.app import _init_app, app
 
 
 def test_run_server_disabled(c):
@@ -9,5 +10,7 @@ def test_run_server_disabled(c):
 
 
 def test_init_app_disabled():
+    c = Context()
+    c.sql("SELECT 1 + 1").compute()
     with pytest.raises(NotImplementedError):
-        _init_app()
+        _init_app(app, c)

--- a/tests/integration/test_jdbc.py
+++ b/tests/integration/test_jdbc.py
@@ -7,6 +7,11 @@ from dask_sql import Context
 from dask_sql.server.app import _init_app, app
 from dask_sql.server.presto_jdbc import create_meta_data
 
+# TODO: re-enable server once CVEs are resolved
+pytest.skip(
+    "SQL server is disabled until related CVEs are resolved", allow_module_level=True
+)
+
 # needed for the testclient
 pytest.importorskip("requests")
 

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -5,6 +5,11 @@ import pytest
 from dask_sql import Context
 from dask_sql.server.app import _init_app, app
 
+# TODO: re-enable server once CVEs are resolved
+pytest.skip(
+    "SQL server is disabled until related CVEs are resolved", allow_module_level=True
+)
+
 # needed for the testclient
 pytest.importorskip("requests")
 


### PR DESCRIPTION
Given the CVEs in #438, it is insecure right now to cut a release with SQL server functionality, where a user would be able to exploit them.

This PR disables the SQL server implementation. which should make things secure until the remaining CVEs are addressed.