### PR TITLE
Add Java source code to source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include dask_sql *.yaml
+recursive-include planner *
 
 include versioneer.py
 include dask_sql/_version.py


### PR DESCRIPTION
This should resolve the build issues we've been seeing in https://github.com/conda-forge/dask-sql-feedstock/pull/36 due to the Java source not being included in the tars on PyPI

cc @ayushdg 