### PR TITLE
Add jsonschema to ci testing

### DIFF
--- a/continuous_integration/environment-3.10-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk11-dev.yaml
@@ -14,6 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
+- jsonschema>=4.4.0
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0

--- a/continuous_integration/environment-3.10-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk8-dev.yaml
@@ -14,6 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
+- jsonschema>=4.4.0
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -14,6 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
+- jsonschema>=4.4.0
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0

--- a/continuous_integration/environment-3.8-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk8-dev.yaml
@@ -14,6 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
+- jsonschema>=4.4.0
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -14,6 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
+- jsonschema>=4.4.0
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -14,6 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
+- jsonschema>=4.4.0
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0

--- a/dask_sql/sql-schema.yaml
+++ b/dask_sql/sql-schema.yaml
@@ -28,6 +28,6 @@ properties:
               Whether sql identifiers are considered case sensitive while parsing.
 
       predicate_pushdown:
-        type: bool
+        type: boolean
         description: |
           Whether to try pushing down filter predicates into IO (when possible).


### PR DESCRIPTION
Adds `jsonschema` to ci to enable config schema testing and minor fix to `predicate_pushdown` schema.