### PR TITLE
Set max pin on antlr4-python-runtime 

### DIFF
--- a/continuous_integration/environment-3.10-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk11-dev.yaml
@@ -4,7 +4,7 @@ channels:
 - nodefaults
 dependencies:
 - adagio>=0.2.3
-- antlr4-python3-runtime>=4.9.2
+- antlr4-python3-runtime>=4.9.2, <4.10.0 # Max pin until https://github.com/fugue-project/fugue/issues/318 is resolved
 - black=22.3.0
 - ciso8601>=2.2.0
 - dask-ml>=2022.1.22

--- a/continuous_integration/environment-3.10-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk8-dev.yaml
@@ -4,7 +4,7 @@ channels:
 - nodefaults
 dependencies:
 - adagio>=0.2.3
-- antlr4-python3-runtime>=4.9.2
+- antlr4-python3-runtime>=4.9.2, <4.10.0 # Max pin until https://github.com/fugue-project/fugue/issues/318 is resolved
 - black=22.3.0
 - ciso8601>=2.2.0
 - dask-ml>=2022.1.22

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -4,7 +4,7 @@ channels:
 - nodefaults
 dependencies:
 - adagio>=0.2.3
-- antlr4-python3-runtime>=4.9.2
+- antlr4-python3-runtime>=4.9.2, <4.10.0 # Max pin until https://github.com/fugue-project/fugue/issues/318 is resolved
 - black=22.3.0
 - ciso8601>=2.2.0
 - dask-ml>=2022.1.22

--- a/continuous_integration/environment-3.8-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk8-dev.yaml
@@ -4,7 +4,7 @@ channels:
 - nodefaults
 dependencies:
 - adagio>=0.2.3
-- antlr4-python3-runtime>=4.9.2
+- antlr4-python3-runtime>=4.9.2, <4.10.0 # Max pin until https://github.com/fugue-project/fugue/issues/318 is resolved
 - black=22.3.0
 - ciso8601>=2.2.0
 - dask-ml>=2022.1.22

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -4,7 +4,7 @@ channels:
 - nodefaults
 dependencies:
 - adagio>=0.2.3
-- antlr4-python3-runtime>=4.9.2
+- antlr4-python3-runtime>=4.9.2, <4.10.0 # Max pin until https://github.com/fugue-project/fugue/issues/318 is resolved
 - black=22.3.0
 - ciso8601>=2.2.0
 - dask-ml>=2022.1.22

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -4,7 +4,7 @@ channels:
 - nodefaults
 dependencies:
 - adagio>=0.2.3
-- antlr4-python3-runtime>=4.9.2
+- antlr4-python3-runtime>=4.9.2, <4.10.0 # Max pin until https://github.com/fugue-project/fugue/issues/318 is resolved
 - black=22.3.0
 - ciso8601>=2.2.0
 - dask-ml>=2022.1.22


### PR DESCRIPTION
Fixes #455 by setting a max version on `antlr4-python-runtime` since the latest `4.10` release doesn't work cleanly with `fugue`. 
Should unblock CI