### PR TITLE
Bump DataFusion version

### DIFF
--- a/dask_planner/Cargo.toml
+++ b/dask_planner/Cargo.toml
@@ -12,8 +12,8 @@ rust-version = "1.59"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 rand = "0.7"
 pyo3 = { version = "0.15", features = ["extension-module", "abi3", "abi3-py38"] }
-datafusion = { git="https://github.com/apache/arrow-datafusion/", rev = "583b4ab8dfe6148a7387841d112dd50b1151f6fb" }
-datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "583b4ab8dfe6148a7387841d112dd50b1151f6fb" }
+datafusion = { git="https://github.com/apache/arrow-datafusion/", rev = "23f1c77569d1f3b0ff42ade56f9b2afb53d44292" }
+datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "23f1c77569d1f3b0ff42ade56f9b2afb53d44292" }
 uuid = { version = "0.8", features = ["v4"] }
 mimalloc = { version = "*", default-features = false }
 sqlparser = "0.14.0"

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -6,13 +6,11 @@ use pyo3::{basic::CompareOp, prelude::*, PyNumberProtocol, PyObjectProtocol};
 use std::convert::{From, Into};
 
 use datafusion::arrow::datatypes::DataType;
-use datafusion::logical_plan::{col, lit, Expr};
+use datafusion_expr::{col, lit, BuiltinScalarFunction, Expr};
 
 use datafusion::scalar::ScalarValue;
 
-pub use datafusion::logical_plan::plan::LogicalPlan;
-
-use datafusion::logical_expr::BuiltinScalarFunction;
+pub use datafusion_expr::LogicalPlan;
 
 /// An PyExpr that can be used on a DataFrame
 #[pyclass(name = "Expression", module = "datafusion", subclass)]

--- a/dask_planner/src/sql/logical.rs
+++ b/dask_planner/src/sql/logical.rs
@@ -4,7 +4,7 @@ mod filter;
 mod join;
 pub mod projection;
 
-pub use datafusion::logical_plan::plan::LogicalPlan;
+pub use datafusion_expr::LogicalPlan;
 
 use datafusion::prelude::Column;
 

--- a/dask_planner/src/sql/logical/aggregate.rs
+++ b/dask_planner/src/sql/logical/aggregate.rs
@@ -1,8 +1,7 @@
 use crate::expression::PyExpr;
-use datafusion::logical_plan::Expr;
 
-use datafusion::logical_plan::plan::Aggregate;
-pub use datafusion::logical_plan::plan::{JoinType, LogicalPlan};
+use datafusion_expr::{logical_plan::Aggregate, Expr};
+pub use datafusion_expr::{logical_plan::JoinType, LogicalPlan};
 
 use pyo3::prelude::*;
 

--- a/dask_planner/src/sql/logical/filter.rs
+++ b/dask_planner/src/sql/logical/filter.rs
@@ -1,7 +1,7 @@
 use crate::expression::PyExpr;
 
-use datafusion::logical_plan::plan::Filter;
-pub use datafusion::logical_plan::plan::LogicalPlan;
+use datafusion_expr::logical_plan::Filter;
+pub use datafusion_expr::LogicalPlan;
 
 use pyo3::prelude::*;
 

--- a/dask_planner/src/sql/logical/join.rs
+++ b/dask_planner/src/sql/logical/join.rs
@@ -1,5 +1,4 @@
 use crate::sql::column;
-use crate::sql::table;
 
 use datafusion_expr::logical_plan::Join;
 pub use datafusion_expr::{logical_plan::JoinType, LogicalPlan};
@@ -17,28 +16,12 @@ impl PyJoin {
     #[pyo3(name = "getJoinConditions")]
     pub fn join_conditions(&mut self) -> PyResult<Vec<(column::PyColumn, column::PyColumn)>> {
         let lhs_table_name: String = match &*self.join.left {
-            LogicalPlan::TableScan(_table_scan) => {
-                let tbl: String = _table_scan
-                    .source
-                    .as_any()
-                    .downcast_ref::<table::DaskTableProvider>()
-                    .unwrap()
-                    .table_name();
-                tbl
-            }
+            LogicalPlan::TableScan(scan) => scan.table_name.clone(),
             _ => panic!("lhs Expected TableScan but something else was received!"),
         };
 
         let rhs_table_name: String = match &*self.join.right {
-            LogicalPlan::TableScan(_table_scan) => {
-                let tbl: String = _table_scan
-                    .source
-                    .as_any()
-                    .downcast_ref::<table::DaskTableProvider>()
-                    .unwrap()
-                    .table_name();
-                tbl
-            }
+            LogicalPlan::TableScan(scan) => scan.table_name.clone(),
             _ => panic!("rhs Expected TableScan but something else was received!"),
         };
 

--- a/dask_planner/src/sql/logical/join.rs
+++ b/dask_planner/src/sql/logical/join.rs
@@ -1,8 +1,8 @@
 use crate::sql::column;
 use crate::sql::table;
 
-use datafusion::logical_plan::plan::Join;
-pub use datafusion::logical_plan::plan::{JoinType, LogicalPlan};
+use datafusion_expr::logical_plan::Join;
+pub use datafusion_expr::{logical_plan::JoinType, LogicalPlan};
 
 use pyo3::prelude::*;
 

--- a/dask_planner/src/sql/logical/projection.rs
+++ b/dask_planner/src/sql/logical/projection.rs
@@ -1,9 +1,7 @@
 use crate::expression::PyExpr;
 
-pub use datafusion::logical_plan::plan::LogicalPlan;
-use datafusion::logical_plan::plan::Projection;
-
-use datafusion::logical_plan::Expr;
+pub use datafusion_expr::LogicalPlan;
+use datafusion_expr::{logical_plan::Projection, Expr};
 
 use pyo3::prelude::*;
 


### PR DESCRIPTION
This PR updates the DataFusion dependency to pick up the work in https://github.com/apache/arrow-datafusion/pull/2294 which moved the logical plan into the `datafusion_expr` crate and also introduced a `TableSource` trait which is used in the logical plan instead of the `TableProvider` trait, which is for physical plans.

I also removed some downcast code that is no longer necessary now that `TableScan` contains the real table name and not the aliased name, which is what led to this downcast code being added as a workaround.