### PR TITLE
Minor code cleanup in row_type()

### DIFF
--- a/dask_planner/src/sql/exceptions.rs
+++ b/dask_planner/src/sql/exceptions.rs
@@ -1,3 +1,8 @@
-use pyo3::create_exception;
+use datafusion::error::DataFusionError;
+use pyo3::{create_exception, PyErr};
 
 create_exception!(rust, ParsingException, pyo3::exceptions::PyException);
+
+pub fn py_type_err(e: DataFusionError) -> PyErr {
+    PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!("{:?}", e))
+}

--- a/dask_planner/src/sql/types/rel_data_type_field.rs
+++ b/dask_planner/src/sql/types/rel_data_type_field.rs
@@ -1,7 +1,7 @@
 use crate::sql::types::DaskTypeMap;
 use crate::sql::types::SqlTypeName;
 
-use datafusion::error::DataFusionError;
+use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_plan::{DFField, DFSchema};
 
 use std::fmt;
@@ -19,7 +19,7 @@ pub struct RelDataTypeField {
 
 // Functions that should not be presented to Python are placed here
 impl RelDataTypeField {
-    pub fn from(field: DFField, schema: DFSchema) -> Result<RelDataTypeField, DataFusionError> {
+    pub fn from(field: &DFField, schema: &DFSchema) -> Result<RelDataTypeField> {
         Ok(RelDataTypeField {
             name: field.name().clone(),
             data_type: DaskTypeMap {


### PR DESCRIPTION
I was getting up to speed with the `dask-sql` code and took the opportunity to make the `row_type()` method more functional and removed some unnecessary clones and pass fields and schemas by reference instead.

I also removed the `unwrap()` and have it returning a `PyErr` instead, although there are no tests for this but the existing test still pass.
