### PR TITLE
Improve code for getting column name from expression

### DIFF
--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -63,7 +63,7 @@ impl PyExpr {
         }
     }
 
-    fn _column_name(&self, plan: LogicalPlan) -> String {
+    fn _column_name(&self, plan: LogicalPlan) -> Result<String> {
         let field = expr_to_field(&self.expr, &plan).unwrap();
         field.unqualified_column().name.clone()
     }

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -65,7 +65,7 @@ impl PyExpr {
 
     fn _column_name(&self, plan: LogicalPlan) -> Result<String> {
         let field = expr_to_field(&self.expr, &plan)?;
-        field.unqualified_column().name.clone()
+        Ok(field.unqualified_column().name.clone())
     }
 }
 
@@ -175,7 +175,7 @@ impl PyExpr {
 
     /// Python friendly shim code to get the name of a column referenced by an expression
     pub fn column_name(&self, mut plan: logical::PyLogicalPlan) -> String {
-        self._column_name(plan.current_node())
+        self._column_name(plan.current_node()).unwrap()
     }
 
     /// Gets the operands for a BinaryExpr call

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -64,7 +64,7 @@ impl PyExpr {
     }
 
     fn _column_name(&self, plan: LogicalPlan) -> Result<String> {
-        let field = expr_to_field(&self.expr, &plan).unwrap();
+        let field = expr_to_field(&self.expr, &plan)?;
         field.unqualified_column().name.clone()
     }
 }

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -15,6 +15,7 @@ pub use datafusion_expr::LogicalPlan;
 
 use datafusion::prelude::Column;
 
+use crate::sql::exceptions::py_runtime_err;
 use datafusion::common::DFField;
 use datafusion::logical_plan::exprlist_to_fields;
 use std::sync::Arc;
@@ -174,8 +175,9 @@ impl PyExpr {
     }
 
     /// Python friendly shim code to get the name of a column referenced by an expression
-    pub fn column_name(&self, mut plan: logical::PyLogicalPlan) -> String {
-        self._column_name(plan.current_node()).unwrap()
+    pub fn column_name(&self, mut plan: logical::PyLogicalPlan) -> PyResult<String> {
+        self._column_name(plan.current_node())
+            .map_err(|e| py_runtime_err(e))
     }
 
     /// Gets the operands for a BinaryExpr call

--- a/dask_planner/src/sql/exceptions.rs
+++ b/dask_planner/src/sql/exceptions.rs
@@ -6,3 +6,7 @@ create_exception!(rust, ParsingException, pyo3::exceptions::PyException);
 pub fn py_type_err(e: DataFusionError) -> PyErr {
     PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!("{:?}", e))
 }
+
+pub fn py_runtime_err(e: DataFusionError) -> PyErr {
+    PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("{:?}", e))
+}


### PR DESCRIPTION
This improves `PyExpr::_column_name` to delegate to DataFusion to build a name for an expression. This code does not appear to be widely used in the tests though so it is hard to tell if this change meets all requirements.