### PR TITLE
Add support for Expr::Sort in expr_to_field

### DIFF
--- a/dask_planner/Cargo.toml
+++ b/dask_planner/Cargo.toml
@@ -12,8 +12,8 @@ rust-version = "1.59"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 rand = "0.7"
 pyo3 = { version = "0.16", features = ["extension-module", "abi3", "abi3-py38"] }
-datafusion = { git="https://github.com/apache/arrow-datafusion/", rev = "5927bfceeba3a4eab7988289c674d925cc82ac05" }
-datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "5927bfceeba3a4eab7988289c674d925cc82ac05" }
+datafusion = { git="https://github.com/apache/arrow-datafusion/", rev = "0ce942aa014c29d6b43ac9251b8406a9a18a8022" }
+datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "0ce942aa014c29d6b43ac9251b8406a9a18a8022" }
 uuid = { version = "0.8", features = ["v4"] }
 mimalloc = { version = "*", default-features = false }
 sqlparser = "0.14.0"

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -471,8 +471,15 @@ impl PyExpr {
 
 /// Create a [DFField] representing an [Expr], given an input [LogicalPlan] to resolve against
 pub fn expr_to_field(expr: &Expr, input_plan: &LogicalPlan) -> Result<DFField> {
-    // TODO this is not the implementation that we really want and will be improved
-    // once some changes are made in DataFusion
-    let fields = exprlist_to_fields(&[expr.clone()], &input_plan.schema())?;
-    Ok(fields[0].clone())
+    match expr {
+        Expr::Sort { expr, .. } => {
+            // DataFusion does not support create_name for sort expressions (since they never
+            // appear in projections) so we just delegate to the contained expression instead
+            expr_to_field(expr, input_plan)
+        }
+        _ => {
+            let fields = exprlist_to_fields(&[expr.clone()], &input_plan)?;
+            Ok(fields[0].clone())
+        }
+    }
 }


### PR DESCRIPTION
This improves the `expr_to_field` function (used to get column names) to support `Expr::Sort`. It also updates the DataFusion version.