### PR TITLE
Reduce crate dependencies

### DIFF
--- a/dask_planner/Cargo.toml
+++ b/dask_planner/Cargo.toml
@@ -13,10 +13,8 @@ tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"
 rand = "0.7"
 pyo3 = { version = "0.16", features = ["extension-module", "abi3", "abi3-py38"] }
 datafusion = { git="https://github.com/apache/arrow-datafusion/", rev = "0ce942aa014c29d6b43ac9251b8406a9a18a8022" }
-datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "0ce942aa014c29d6b43ac9251b8406a9a18a8022" }
 uuid = { version = "0.8", features = ["v4"] }
 mimalloc = { version = "*", default-features = false }
-sqlparser = "0.14.0"
 parking_lot = "0.12"
 async-trait = "0.1.41"
 

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -7,11 +7,11 @@ use std::convert::{From, Into};
 use datafusion::error::{DataFusionError, Result};
 
 use datafusion::arrow::datatypes::DataType;
-use datafusion_expr::{lit, BuiltinScalarFunction, Expr};
+use datafusion::logical_expr::{lit, BuiltinScalarFunction, Expr};
 
 use datafusion::scalar::ScalarValue;
 
-pub use datafusion_expr::LogicalPlan;
+pub use datafusion::logical_expr::LogicalPlan;
 
 use datafusion::prelude::Column;
 

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -12,11 +12,11 @@ use crate::sql::exceptions::ParsingException;
 use datafusion::arrow::datatypes::{Field, Schema};
 use datafusion::catalog::{ResolvedTableReference, TableReference};
 use datafusion::error::DataFusionError;
+use datafusion::logical_expr::ScalarFunctionImplementation;
 use datafusion::physical_plan::udaf::AggregateUDF;
 use datafusion::physical_plan::udf::ScalarUDF;
 use datafusion::sql::parser::DFParser;
 use datafusion::sql::planner::{ContextProvider, SqlToRel};
-use datafusion_expr::ScalarFunctionImplementation;
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/dask_planner/src/sql/logical.rs
+++ b/dask_planner/src/sql/logical.rs
@@ -8,7 +8,7 @@ mod filter;
 mod join;
 pub mod projection;
 
-pub use datafusion_expr::LogicalPlan;
+pub use datafusion::logical_expr::LogicalPlan;
 
 use datafusion::common::Result;
 use datafusion::prelude::Column;

--- a/dask_planner/src/sql/logical/aggregate.rs
+++ b/dask_planner/src/sql/logical/aggregate.rs
@@ -1,7 +1,7 @@
 use crate::expression::PyExpr;
 
-use datafusion_expr::{logical_plan::Aggregate, Expr};
-pub use datafusion_expr::{logical_plan::JoinType, LogicalPlan};
+use datafusion::logical_expr::{logical_plan::Aggregate, Expr};
+pub use datafusion::logical_expr::{logical_plan::JoinType, LogicalPlan};
 
 use pyo3::prelude::*;
 

--- a/dask_planner/src/sql/logical/filter.rs
+++ b/dask_planner/src/sql/logical/filter.rs
@@ -1,7 +1,7 @@
 use crate::expression::PyExpr;
 
-use datafusion_expr::logical_plan::Filter;
-pub use datafusion_expr::LogicalPlan;
+use datafusion::logical_expr::logical_plan::Filter;
+pub use datafusion::logical_expr::LogicalPlan;
 
 use pyo3::prelude::*;
 

--- a/dask_planner/src/sql/logical/join.rs
+++ b/dask_planner/src/sql/logical/join.rs
@@ -1,7 +1,7 @@
 use crate::sql::column;
 
-use datafusion_expr::logical_plan::Join;
-pub use datafusion_expr::{logical_plan::JoinType, LogicalPlan};
+use datafusion::logical_expr::logical_plan::Join;
+pub use datafusion::logical_expr::{logical_plan::JoinType, LogicalPlan};
 
 use pyo3::prelude::*;
 

--- a/dask_planner/src/sql/logical/projection.rs
+++ b/dask_planner/src/sql/logical/projection.rs
@@ -1,7 +1,7 @@
 use crate::expression::PyExpr;
 
-pub use datafusion_expr::LogicalPlan;
-use datafusion_expr::{logical_plan::Projection, Expr};
+pub use datafusion::logical_expr::LogicalPlan;
+use datafusion::logical_expr::{logical_plan::Projection, Expr};
 
 use pyo3::prelude::*;
 

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -9,8 +9,8 @@ use async_trait::async_trait;
 use datafusion::arrow::datatypes::{DataType, Field, SchemaRef};
 pub use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
+use datafusion::logical_expr::{Expr, LogicalPlan, TableSource};
 use datafusion::physical_plan::{empty::EmptyExec, project_schema, ExecutionPlan};
-use datafusion_expr::{Expr, LogicalPlan, TableSource};
 
 use pyo3::prelude::*;
 


### PR DESCRIPTION
This is a just a minor cleanup of the declared dependencies:

- We do not use `sqlparser` directory so that is removed
- We do not need to depend on `datafusion_expr` since that crate is re-exported in the `datafusion` crate