### PR TITLE
Use `dev` images for independent cluster testing

### DIFF
--- a/.github/docker-compose.yaml
+++ b/.github/docker-compose.yaml
@@ -12,6 +12,7 @@ services:
         image: daskdev/dask:dev
         command: dask-worker dask-scheduler:8786
         environment:
+            USE_MAMBA: "true"
             EXTRA_CONDA_PACKAGES: "pyarrow>1.0.0"  # required for parquet IO
         volumes:
             - /tmp:/tmp

--- a/.github/docker-compose.yaml
+++ b/.github/docker-compose.yaml
@@ -3,13 +3,13 @@ version: '3'
 services:
     dask-scheduler:
         container_name: dask-scheduler
-        image: daskdev/dask:latest
+        image: daskdev/dask:dev
         command: dask-scheduler
         ports:
             - "8786:8786"
     dask-worker:
         container_name: dask-worker
-        image: daskdev/dask:latest
+        image: daskdev/dask:dev
         command: dask-worker dask-scheduler:8786
         environment:
             EXTRA_CONDA_PACKAGES: "pyarrow>1.0.0"  # required for parquet IO

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,7 +174,7 @@ jobs:
           docker-compose -f .github/docker-compose.yaml up -d
 
           # Wait for installation
-          sleep 40
+          sleep 10
 
           docker logs dask-scheduler
           docker logs dask-worker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,9 +173,6 @@ jobs:
         run: |
           docker-compose -f .github/docker-compose.yaml up -d
 
-          # Wait for installation
-          sleep 10
-
           docker logs dask-scheduler
           docker logs dask-worker
       - name: Test with pytest while running an independent dask cluster

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,6 +173,9 @@ jobs:
         run: |
           docker-compose -f .github/docker-compose.yaml up -d
 
+          # periodically ping logs until a connection has been established; assume failure after 2 minutes
+          timeout 2m bash -c 'until docker logs dask-worker 2>&1 | grep -q "Starting established connection"; do sleep 1; done'
+
           docker logs dask-scheduler
           docker logs dask-worker
       - name: Test with pytest while running an independent dask cluster


### PR DESCRIPTION
Following up on https://github.com/dask/dask-docker/pull/228, this PR switches our independent cluster testing to use Dask's `dev` images, which represent the latest changes to the dask-docker repo. This should reduce the lag between new features/fixes in the images becoming available to us, while also functioning as downstream testing for dask-docker.

I've also gone ahead and enabled `USE_MAMBA`, which should greatly improve the speed that the containers start up - though I'm still considering if there's a better way of ensuring that the containers are running rather than just calling `sleep`.