### PR TITLE
[REVIEW] Add support for `UNION`

### DIFF
--- a/dask_planner/src/sql/logical.rs
+++ b/dask_planner/src/sql/logical.rs
@@ -6,6 +6,7 @@ mod aggregate;
 mod explain;
 mod filter;
 mod join;
+mod union;
 pub mod projection;
 mod sort;
 
@@ -78,6 +79,11 @@ impl PyLogicalPlan {
         to_py_plan(self.current_node.as_ref())
     }
 
+    /// LogicalPlan::Union as PyUnion
+    pub fn union(&self) -> PyResult<union::PyUnion> {
+        to_py_plan(self.current_node.as_ref())
+    }
+
     /// LogicalPlan::Projection as PyProjection
     pub fn projection(&self) -> PyResult<projection::PyProjection> {
         to_py_plan(self.current_node.as_ref())
@@ -132,6 +138,7 @@ impl PyLogicalPlan {
             LogicalPlan::Aggregate(_aggregate) => "Aggregate",
             LogicalPlan::Sort(_sort) => "Sort",
             LogicalPlan::Join(_join) => "Join",
+            LogicalPlan::Union(_union) => "Union",
             LogicalPlan::CrossJoin(_cross_join) => "CrossJoin",
             LogicalPlan::Repartition(_repartition) => "Repartition",
             LogicalPlan::Union(_union) => "Union",

--- a/dask_planner/src/sql/logical.rs
+++ b/dask_planner/src/sql/logical.rs
@@ -138,7 +138,6 @@ impl PyLogicalPlan {
             LogicalPlan::Aggregate(_aggregate) => "Aggregate",
             LogicalPlan::Sort(_sort) => "Sort",
             LogicalPlan::Join(_join) => "Join",
-            LogicalPlan::Union(_union) => "Union",
             LogicalPlan::CrossJoin(_cross_join) => "CrossJoin",
             LogicalPlan::Repartition(_repartition) => "Repartition",
             LogicalPlan::Union(_union) => "Union",

--- a/dask_planner/src/sql/logical.rs
+++ b/dask_planner/src/sql/logical.rs
@@ -6,12 +6,12 @@ mod aggregate;
 mod cross_join;
 mod explain;
 mod filter;
-mod union;
 mod join;
 mod limit;
 mod offset;
 pub mod projection;
 mod sort;
+mod union;
 
 use datafusion::logical_expr::LogicalPlan;
 

--- a/dask_planner/src/sql/logical/union.rs
+++ b/dask_planner/src/sql/logical/union.rs
@@ -1,6 +1,5 @@
-
 use datafusion::logical_expr::logical_plan::Union;
-pub use datafusion::logical_expr::{LogicalPlan};
+pub use datafusion::logical_expr::LogicalPlan;
 
 use pyo3::prelude::*;
 
@@ -19,7 +18,6 @@ impl PyUnion {
         println!("{:?}", self.union.alias);
         Ok(false)
     }
-    
 }
 
 impl TryFrom<LogicalPlan> for PyUnion {

--- a/dask_planner/src/sql/logical/union.rs
+++ b/dask_planner/src/sql/logical/union.rs
@@ -1,0 +1,29 @@
+
+use datafusion::logical_expr::logical_plan::Union;
+pub use datafusion::logical_expr::{LogicalPlan};
+
+use pyo3::prelude::*;
+
+#[pyclass(name = "Union", module = "dask_planner", subclass)]
+#[derive(Clone)]
+pub struct PyUnion {
+    union: Union,
+}
+
+#[pymethods]
+impl PyUnion {
+    #[pyo3(name = "all")]
+    pub fn all(&mut self) -> PyResult<bool> {
+        Ok(false)
+    }
+    
+}
+
+impl From<LogicalPlan> for PyUnion {
+    fn from(logical_plan: LogicalPlan) -> PyUnion {
+        match logical_plan {
+            LogicalPlan::Union(union) => PyUnion { union },
+            _ => panic!("something went wrong here"),
+        }
+    }
+}

--- a/dask_planner/src/sql/logical/union.rs
+++ b/dask_planner/src/sql/logical/union.rs
@@ -1,6 +1,7 @@
 use datafusion::logical_expr::logical_plan::Union;
 pub use datafusion::logical_expr::LogicalPlan;
 
+use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;
 
 #[pyclass(name = "Union", module = "dask_planner", subclass)]
@@ -11,13 +12,12 @@ pub struct PyUnion {
 
 #[pymethods]
 impl PyUnion {
-    #[pyo3(name = "all")]
-    pub fn all(&mut self) -> PyResult<bool> {
-        println!("{:?}", self.union.inputs[0]);
-        println!("{:?}", self.union.schema.metadata());
-        println!("{:?}", self.union.alias);
-        Ok(false)
-    }
+    // TODO: Implement this method once DataFusion can
+    // clearly distinguish UNION vs UNION ALL
+    // #[pyo3(name = "all")]
+    // pub fn all(&mut self) -> PyResult<bool> {
+    //     Ok(false)
+    // }
 }
 
 impl TryFrom<LogicalPlan> for PyUnion {
@@ -26,7 +26,7 @@ impl TryFrom<LogicalPlan> for PyUnion {
     fn try_from(logical_plan: LogicalPlan) -> Result<Self, Self::Error> {
         match logical_plan {
             LogicalPlan::Union(union) => Ok(PyUnion { union }),
-            _ => panic!("something went wrong here"),
+            _ => Err(py_type_err("unexpected plan")),
         }
     }
 }

--- a/dask_planner/src/sql/logical/union.rs
+++ b/dask_planner/src/sql/logical/union.rs
@@ -14,6 +14,9 @@ pub struct PyUnion {
 impl PyUnion {
     #[pyo3(name = "all")]
     pub fn all(&mut self) -> PyResult<bool> {
+        println!("{:?}", self.union.inputs[0]);
+        println!("{:?}", self.union.schema.metadata());
+        println!("{:?}", self.union.alias);
         Ok(false)
     }
     

--- a/dask_planner/src/sql/logical/union.rs
+++ b/dask_planner/src/sql/logical/union.rs
@@ -22,10 +22,12 @@ impl PyUnion {
     
 }
 
-impl From<LogicalPlan> for PyUnion {
-    fn from(logical_plan: LogicalPlan) -> PyUnion {
+impl TryFrom<LogicalPlan> for PyUnion {
+    type Error = PyErr;
+
+    fn try_from(logical_plan: LogicalPlan) -> Result<Self, Self::Error> {
         match logical_plan {
-            LogicalPlan::Union(union) => PyUnion { union },
+            LogicalPlan::Union(union) => Ok(PyUnion { union }),
             _ => panic!("something went wrong here"),
         }
     }

--- a/dask_sql/physical/rel/convert.py
+++ b/dask_sql/physical/rel/convert.py
@@ -55,7 +55,6 @@ class RelConverter(Pluggable):
         node_type = rel.get_current_node_type()
 
         try:
-            # import pdb;pdb.set_trace()
             plugin_instance = cls.get_plugin(node_type)
             logger.debug(
                 f"Processing REL {rel} using {plugin_instance.__class__.__name__}..."

--- a/dask_sql/physical/rel/convert.py
+++ b/dask_sql/physical/rel/convert.py
@@ -50,6 +50,7 @@ class RelConverter(Pluggable):
         node_type = rel.get_current_node_type()
 
         try:
+            # import pdb;pdb.set_trace()
             plugin_instance = cls.get_plugin(node_type)
         except KeyError:  # pragma: no cover
             raise NotImplementedError(

--- a/dask_sql/physical/rel/logical/union.py
+++ b/dask_sql/physical/rel/logical/union.py
@@ -35,7 +35,6 @@ class DaskUnionPlugin(BaseRelPlugin):
         # Late import to remove cycling dependency
         from dask_sql.physical.rel.convert import RelConverter
 
-        # import pdb;pdb.set_trace()
         objs_dc = [
             RelConverter.convert(input_rel, context) for input_rel in rel.get_inputs()
         ]

--- a/dask_sql/physical/rel/logical/union.py
+++ b/dask_sql/physical/rel/logical/union.py
@@ -7,7 +7,7 @@ from dask_sql.physical.rel.base import BaseRelPlugin
 
 if TYPE_CHECKING:
     import dask_sql
-    from dask_sql.java import org
+    from dask_planner.rust import LogicalPlan
 
 
 class DaskUnionPlugin(BaseRelPlugin):
@@ -16,10 +16,10 @@ class DaskUnionPlugin(BaseRelPlugin):
     It just concatonates the two data frames.
     """
 
-    class_name = "com.dask.sql.nodes.DaskUnion"
+    class_name = "Union"
 
     def convert(
-        self, rel: "org.apache.calcite.rel.RelNode", context: "dask_sql.Context"
+        self, rel: "LogicalPlan", context: "dask_sql.Context"
     ) -> DataContainer:
         first_dc, second_dc = self.assert_inputs(rel, 2, context)
 
@@ -56,11 +56,11 @@ class DaskUnionPlugin(BaseRelPlugin):
         first_df = first_dc.assign()
         second_df = second_dc.assign()
 
-        self.check_columns_from_row_type(first_df, rel.getExpectedInputRowType(0))
-        self.check_columns_from_row_type(second_df, rel.getExpectedInputRowType(1))
+        self.check_columns_from_row_type(first_df, rel.getRowType())
+        self.check_columns_from_row_type(second_df, rel.getRowType())
 
         df = dd.concat([first_df, second_df])
-
+        # import pdb;pdb.set_trace()
         if not rel.all:
             df = df.drop_duplicates()
 

--- a/dask_sql/physical/rel/logical/union.py
+++ b/dask_sql/physical/rel/logical/union.py
@@ -9,6 +9,17 @@ if TYPE_CHECKING:
     import dask_sql
     from dask_planner.rust import LogicalPlan
 
+def _extract_df(obj_cc, obj_df, output_field_names):
+    # For concatenating, they should have exactly the same fields
+    assert len(obj_cc.columns) == len(output_field_names)
+    obj_cc = obj_cc.rename(
+        columns={
+            col: output_col
+            for col, output_col in zip(obj_cc.columns, output_field_names)
+        }
+    )
+    obj_dc = DataContainer(obj_df, obj_cc)
+    return obj_dc.assign()
 
 class DaskUnionPlugin(BaseRelPlugin):
     """
@@ -21,48 +32,23 @@ class DaskUnionPlugin(BaseRelPlugin):
     def convert(
         self, rel: "LogicalPlan", context: "dask_sql.Context"
     ) -> DataContainer:
-        first_dc, second_dc = self.assert_inputs(rel, 2, context)
+        # Late import to remove cycling dependency
+        from dask_sql.physical.rel.convert import RelConverter
 
-        first_df = first_dc.df
-        first_cc = first_dc.column_container
+        objs_dc = [RelConverter.convert(input_rel, context) for input_rel in rel.get_inputs()]
 
-        second_df = second_dc.df
-        second_cc = second_dc.column_container
+        objs_df = [obj.df for obj in objs_dc]
+        objs_cc = [obj.column_container for obj in objs_dc]
 
-        # For concatenating, they should have exactly the same fields
+        
         output_field_names = [str(x) for x in rel.getRowType().getFieldNames()]
-        assert len(first_cc.columns) == len(output_field_names)
-        first_cc = first_cc.rename(
-            columns={
-                col: output_col
-                for col, output_col in zip(first_cc.columns, output_field_names)
-            }
-        )
-        first_dc = DataContainer(first_df, first_cc)
+        obj_dfs = []
+        for i, obj_df in enumerate(objs_df):
+            obj_dfs.append(_extract_df(obj_cc=objs_cc[i], obj_df=obj_df, output_field_names=output_field_names))
 
-        assert len(second_cc.columns) == len(output_field_names)
-        second_cc = second_cc.rename(
-            columns={
-                col: output_col
-                for col, output_col in zip(second_cc.columns, output_field_names)
-            }
-        )
-        second_dc = DataContainer(second_df, second_cc)
+        _ = [self.check_columns_from_row_type(df, rel.getRowType()) for df in obj_dfs]
 
-        # To concat the to dataframes, we need to make sure the
-        # columns actually have the specified names in the
-        # column containers
-        # Otherwise the concat won't work
-        first_df = first_dc.assign()
-        second_df = second_dc.assign()
-
-        self.check_columns_from_row_type(first_df, rel.getRowType())
-        self.check_columns_from_row_type(second_df, rel.getRowType())
-
-        df = dd.concat([first_df, second_df])
-        # import pdb;pdb.set_trace()
-        if not rel.all:
-            df = df.drop_duplicates()
+        df = dd.concat(obj_dfs)
 
         cc = ColumnContainer(df.columns)
         cc = self.fix_column_to_row_type(cc, rel.getRowType())

--- a/tests/integration/test_compatibility.py
+++ b/tests/integration/test_compatibility.py
@@ -897,9 +897,6 @@ def test_nested_query():
     )
 
 
-@pytest.mark.skip(
-    reason="WIP DataFusion - https://github.com/dask-contrib/dask-sql/issues/470"
-)
 def test_union():
     a = make_rand_df(30, b=(int, 10), c=(str, 10))
     b = make_rand_df(80, b=(int, 50), c=(str, 50))
@@ -961,9 +958,6 @@ def test_union():
 #     )
 
 
-@pytest.mark.skip(
-    reason="WIP DataFusion - https://github.com/dask-contrib/dask-sql/issues/470"
-)
 def test_with():
     a = make_rand_df(30, a=(int, 10), b=(str, 10))
     b = make_rand_df(80, ax=(int, 10), bx=(str, 10))

--- a/tests/integration/test_union.py
+++ b/tests/integration/test_union.py
@@ -35,7 +35,7 @@ def test_union_all(c, df):
     assert_eq(result_df, expected_df, check_index=False)
 
 
-# @pytest.mark.skip(reason="WIP DataFusion")
+@pytest.mark.skip(reason="WIP DataFusion")
 def test_union_mixed(c, df, long_table):
     result_df = c.sql(
         """

--- a/tests/integration/test_union.py
+++ b/tests/integration/test_union.py
@@ -4,7 +4,6 @@ import pytest
 from tests.utils import assert_eq
 
 
-# @pytest.mark.skip(reason="WIP DataFusion")
 def test_union_not_all(c, df):
     result_df = c.sql(
         """
@@ -19,7 +18,6 @@ def test_union_not_all(c, df):
     assert_eq(result_df, df, check_index=False)
 
 
-# @pytest.mark.skip(reason="WIP DataFusion")
 def test_union_all(c, df):
     result_df = c.sql(
         """

--- a/tests/integration/test_union.py
+++ b/tests/integration/test_union.py
@@ -4,7 +4,7 @@ import pytest
 from tests.utils import assert_eq
 
 
-@pytest.mark.skip(reason="WIP DataFusion")
+# @pytest.mark.skip(reason="WIP DataFusion")
 def test_union_not_all(c, df):
     result_df = c.sql(
         """
@@ -19,7 +19,7 @@ def test_union_not_all(c, df):
     assert_eq(result_df, df, check_index=False)
 
 
-@pytest.mark.skip(reason="WIP DataFusion")
+# @pytest.mark.skip(reason="WIP DataFusion")
 def test_union_all(c, df):
     result_df = c.sql(
         """

--- a/tests/integration/test_union.py
+++ b/tests/integration/test_union.py
@@ -35,7 +35,7 @@ def test_union_all(c, df):
     assert_eq(result_df, expected_df, check_index=False)
 
 
-@pytest.mark.skip(reason="WIP DataFusion")
+# @pytest.mark.skip(reason="WIP DataFusion")
 def test_union_mixed(c, df, long_table):
     result_df = c.sql(
         """


### PR DESCRIPTION
Fixes: #470

This PR adds `UNION` support in `dask-sql` which uses `datafusion`'s `union` logic.