### PR TITLE
Relax `jsonschema` testing dependency

### DIFF
--- a/continuous_integration/environment-3.10-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk11-dev.yaml
@@ -14,7 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
-- jsonschema>=4.4.0
+- jsonschema
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0

--- a/continuous_integration/environment-3.10-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk8-dev.yaml
@@ -14,7 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
-- jsonschema>=4.4.0
+- jsonschema
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -14,7 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
-- jsonschema>=4.4.0
+- jsonschema
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0

--- a/continuous_integration/environment-3.8-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk8-dev.yaml
@@ -14,7 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
-- jsonschema>=4.4.0
+- jsonschema
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -14,7 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
-- jsonschema>=4.4.0
+- jsonschema
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0
@@ -39,5 +39,6 @@ dependencies:
 - triad>=0.5.4
 - tzlocal>=2.1
 - uvicorn>=0.11.3
+- cfn-lint>=0.4.0
 - pip:
   - fugue[sql]>=0.5.3

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -14,7 +14,7 @@ dependencies:
 - intake>=0.6.0
 - isort=5.7.0
 - jpype1>=1.0.2
-- jsonschema>=4.4.0
+- jsonschema
 - lightgbm>=3.2.1
 - maven>=3.6.0
 - mlflow>=1.19.0


### PR DESCRIPTION
This matches up with Dask's `jsonschema` specification for testing, and unblocks creating a cuDF / dask-sql dev environment, which got blocked with https://github.com/rapidsai/cudf/pull/10769