### PR TITLE
Upgrade DataFusion version & support non-equijoin join conditions

### DIFF
--- a/dask_planner/Cargo.toml
+++ b/dask_planner/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.59"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 rand = "0.7"
 pyo3 = { version = "0.16", features = ["extension-module", "abi3", "abi3-py38"] }
-datafusion = { git="https://github.com/apache/arrow-datafusion/", rev = "78207f5092fc5204ecd791278d403dcb6f0ae683" }
+datafusion = { git="https://github.com/apache/arrow-datafusion/", rev = "bbb674a0bf16fb754afb7b6451d42061f23e96c8" }
 uuid = { version = "0.8", features = ["v4"] }
 mimalloc = { version = "*", default-features = false }
 parking_lot = "0.12"

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -16,8 +16,8 @@ use datafusion::logical_expr::LogicalPlan;
 use datafusion::prelude::Column;
 
 use crate::sql::exceptions::py_runtime_err;
-use datafusion::common::DFField;
-use datafusion::logical_plan::{exprlist_to_fields, DFSchema};
+use datafusion::common::{DFField, DFSchema};
+use datafusion::logical_expr::utils::exprlist_to_fields;
 use std::sync::Arc;
 
 /// An PyExpr that can be used on a DataFrame

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -13,9 +13,9 @@ use datafusion::arrow::datatypes::{Field, Schema};
 use datafusion::catalog::{ResolvedTableReference, TableReference};
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
-use datafusion::logical_expr::ScalarFunctionImplementation;
-use datafusion::physical_plan::udaf::AggregateUDF;
-use datafusion::physical_plan::udf::ScalarUDF;
+use datafusion::logical_expr::{
+    AggregateUDF, ScalarFunctionImplementation, ScalarUDF, TableSource,
+};
 use datafusion::sql::parser::DFParser;
 use datafusion::sql::planner::{ContextProvider, SqlToRel};
 
@@ -56,7 +56,7 @@ impl ContextProvider for DaskSQLContext {
     fn get_table_provider(
         &self,
         name: TableReference,
-    ) -> Result<Arc<dyn TableProvider>, DataFusionError> {
+    ) -> Result<Arc<dyn TableSource>, DataFusionError> {
         let reference: ResolvedTableReference =
             name.resolve(&self.default_catalog_name, &self.default_schema_name);
         match self.schemas.get(&self.default_schema_name) {

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -22,7 +22,7 @@ use datafusion::sql::planner::{ContextProvider, SqlToRel};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::sql::table::DaskTableProvider;
+use crate::sql::table::DaskTableSource;
 use pyo3::prelude::*;
 
 /// DaskSQLContext is main interface used for interacting with DataFusion to
@@ -77,9 +77,7 @@ impl ContextProvider for DaskSQLContext {
 
                 // If the Table is not found return None. DataFusion will handle the error propagation
                 match resp {
-                    Some(e) => Ok(Arc::new(DaskTableProvider::new(Arc::new(
-                        table::DaskTableSource::new(Arc::new(e)),
-                    )))),
+                    Some(e) => Ok(Arc::new(table::DaskTableSource::new(Arc::new(e)))),
                     None => Err(DataFusionError::Plan(format!(
                         "Table '{}.{}.{}' not found",
                         reference.catalog, reference.schema, reference.table

--- a/dask_planner/src/sql/logical/join.rs
+++ b/dask_planner/src/sql/logical/join.rs
@@ -25,13 +25,7 @@ impl PyJoin {
             .join
             .on
             .iter()
-            .map(|(l, r)| {
-                binary_expr(
-                    Expr::Column(l.clone()),
-                    Operator::Eq,
-                    Expr::Column(r.clone()),
-                )
-            })
+            .map(|(l, r)| Expr::Column(l.clone()).eq(Expr::Column(r.clone())))
             .collect();
 
         // other filter conditions

--- a/dask_planner/src/sql/logical/join.rs
+++ b/dask_planner/src/sql/logical/join.rs
@@ -1,9 +1,8 @@
 use crate::expression::PyExpr;
 use crate::sql::column;
 
-use datafusion::common::Column;
 use datafusion::logical_expr::{
-    and, binary_expr, col,
+    and, binary_expr,
     logical_plan::{Join, JoinType, LogicalPlan},
     Expr, Operator,
 };

--- a/dask_planner/src/sql/logical/join.rs
+++ b/dask_planner/src/sql/logical/join.rs
@@ -1,11 +1,12 @@
 use crate::expression::PyExpr;
 use crate::sql::column;
 
-use datafusion::physical_plan::expressions::Column;
-
-use datafusion::logical_expr::logical_plan::Join;
-use datafusion::logical_plan::{JoinType, LogicalPlan, Operator};
-use datafusion::prelude::{col, Expr};
+use datafusion::common::Column;
+use datafusion::logical_expr::{
+    col,
+    logical_plan::{Join, JoinType, LogicalPlan},
+    Expr, Operator,
+};
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -10,7 +10,6 @@ use datafusion::arrow::datatypes::{DataType, Field, SchemaRef};
 use datafusion::datasource::{TableProvider, TableType};
 use datafusion::error::DataFusionError;
 use datafusion::logical_expr::{Expr, LogicalPlan, TableSource};
-use datafusion::physical_plan::{empty::EmptyExec, project_schema, ExecutionPlan};
 
 use pyo3::prelude::*;
 
@@ -54,7 +53,7 @@ impl DaskTableProvider {
 
 /// Implement TableProvider, used for physical query plans and execution
 #[async_trait]
-impl TableProvider for DaskTableProvider {
+impl TableSource for DaskTableProvider {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -65,17 +64,6 @@ impl TableProvider for DaskTableProvider {
 
     fn table_type(&self) -> TableType {
         TableType::Base
-    }
-
-    async fn scan(
-        &self,
-        projection: &Option<Vec<usize>>,
-        _filters: &[Expr],
-        _limit: Option<usize>,
-    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-        // even though there is no data, projections apply
-        let projected_schema = project_schema(&self.source.schema, projection.as_ref())?;
-        Ok(Arc::new(EmptyExec::new(false, projected_schema)))
     }
 }
 

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -40,33 +40,6 @@ impl TableSource for DaskTableSource {
     }
 }
 
-/// DaskTable wrapper that is compatible with DataFusion physical query plans
-pub struct DaskTableProvider {
-    source: Arc<DaskTableSource>,
-}
-
-impl DaskTableProvider {
-    pub fn new(source: Arc<DaskTableSource>) -> Self {
-        Self { source }
-    }
-}
-
-/// Implement TableProvider, used for physical query plans and execution
-#[async_trait]
-impl TableSource for DaskTableProvider {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn schema(&self) -> SchemaRef {
-        self.source.schema.clone()
-    }
-
-    fn table_type(&self) -> TableType {
-        TableType::Base
-    }
-}
-
 #[pyclass(name = "DaskStatistics", module = "dask_planner", subclass)]
 #[derive(Debug, Clone)]
 pub struct DaskStatistics {


### PR DESCRIPTION
This PR upgrades to a recent version of DataFusion. There are two changes in DataFusion that had to be addressed here:

- `get_table_provider` now returns a logical `TableSource` instead of a physical `TableProvider`
- Joins now support filter conditions other than equi-join conditions

Changes in this PR:

- Remove `DaskTableProvider`
- Update `join_condition()` to handle all filter conditions