### PR TITLE
Update docs theme 

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,6 +1,6 @@
 sphinx>=4.0.0
 sphinx-tabs
-dask-sphinx-theme>=2.0.3
+dask-sphinx-theme>=3.0.0
 dask>=2022.3.0
 pandas>=1.0.0
 fugue>=0.5.3


### PR DESCRIPTION
Dask.org has gone live with a new design (see https://github.com/dask/community/issues/220). This PR is to update the `dask-sphinx-theme` (see https://github.com/dask/dask-sphinx-theme/pull/67)

cc @jacobtomlinson @jsignell