### PR TITLE
Only use the specific DataFusion crates that we need

### DIFF
--- a/dask_planner/Cargo.toml
+++ b/dask_planner/Cargo.toml
@@ -12,7 +12,11 @@ rust-version = "1.59"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 rand = "0.7"
 pyo3 = { version = "0.16", features = ["extension-module", "abi3", "abi3-py38"] }
-datafusion = { git="https://github.com/apache/arrow-datafusion/", rev = "bbb674a0bf16fb754afb7b6451d42061f23e96c8" }
+arrow = { version = "15.0.0", features = ["prettyprint"] }
+datafusion-sql = { git="https://github.com/apache/arrow-datafusion/", rev = "bbb674a0bf16fb754afb7b6451d42061f23e96c8" }
+datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "bbb674a0bf16fb754afb7b6451d42061f23e96c8" }
+datafusion-common = { git="https://github.com/apache/arrow-datafusion/", rev = "bbb674a0bf16fb754afb7b6451d42061f23e96c8" }
+datafusion-optimizer = { git="https://github.com/apache/arrow-datafusion/", rev = "bbb674a0bf16fb754afb7b6451d42061f23e96c8" }
 uuid = { version = "0.8", features = ["v4"] }
 mimalloc = { version = "*", default-features = false }
 parking_lot = "0.12"

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -1,23 +1,11 @@
+use crate::sql::exceptions::py_runtime_err;
 use crate::sql::logical;
 use crate::sql::types::RexType;
-
+use arrow::datatypes::DataType;
+use datafusion_common::{Column, DFField, DFSchema, Result, ScalarValue};
+use datafusion_expr::{lit, utils::exprlist_to_fields, BuiltinScalarFunction, Expr, LogicalPlan};
 use pyo3::prelude::*;
 use std::convert::From;
-
-use datafusion::error::Result;
-
-use datafusion::arrow::datatypes::DataType;
-use datafusion::logical_expr::{lit, BuiltinScalarFunction, Expr};
-
-use datafusion::scalar::ScalarValue;
-
-use datafusion::logical_expr::LogicalPlan;
-
-use datafusion::prelude::Column;
-
-use crate::sql::exceptions::py_runtime_err;
-use datafusion::common::{DFField, DFSchema};
-use datafusion::logical_expr::utils::exprlist_to_fields;
 use std::sync::Arc;
 
 /// An PyExpr that can be used on a DataFrame

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -10,15 +10,16 @@ pub mod types;
 
 use crate::sql::exceptions::{OptimizationException, ParsingException};
 
-use datafusion::arrow::datatypes::{Field, Schema};
-use datafusion::catalog::{ResolvedTableReference, TableReference};
-use datafusion::error::DataFusionError;
-use datafusion::logical_expr::{
-    AggregateUDF, ScalarFunctionImplementation, ScalarUDF, TableSource,
+use arrow::datatypes::{Field, Schema};
+use datafusion_common::DataFusionError;
+use datafusion_expr::{
+    AggregateUDF, LogicalPlan, PlanVisitor, ScalarFunctionImplementation, ScalarUDF, TableSource,
 };
-use datafusion::logical_plan::{LogicalPlan, PlanVisitor};
-use datafusion::sql::parser::DFParser;
-use datafusion::sql::planner::{ContextProvider, SqlToRel};
+use datafusion_sql::{
+    parser::DFParser,
+    planner::{ContextProvider, SqlToRel},
+    ResolvedTableReference, TableReference,
+};
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -34,7 +35,7 @@ use pyo3::prelude::*;
 /// ```
 /// use datafusion::prelude::*;
 ///
-/// # use datafusion::error::Result;
+/// # use datafusion_common::Result;
 /// # #[tokio::main]
 /// # async fn main() -> Result<()> {
 /// let mut ctx = DaskSQLContext::new();
@@ -101,7 +102,7 @@ impl ContextProvider for DaskSQLContext {
         unimplemented!("RUST: get_aggregate_meta is not yet implemented for DaskSQLContext");
     }
 
-    fn get_variable_type(&self, _: &[String]) -> Option<datafusion::arrow::datatypes::DataType> {
+    fn get_variable_type(&self, _: &[String]) -> Option<arrow::datatypes::DataType> {
         unimplemented!("RUST: get_variable_type is not yet implemented for DaskSQLContext")
     }
 }

--- a/dask_planner/src/sql/column.rs
+++ b/dask_planner/src/sql/column.rs
@@ -1,4 +1,4 @@
-use datafusion::prelude::Column;
+use datafusion_common::Column;
 
 use pyo3::prelude::*;
 

--- a/dask_planner/src/sql/exceptions.rs
+++ b/dask_planner/src/sql/exceptions.rs
@@ -1,4 +1,4 @@
-use datafusion::error::DataFusionError;
+use datafusion_common::DataFusionError;
 use pyo3::{create_exception, PyErr};
 use std::fmt::Debug;
 

--- a/dask_planner/src/sql/logical.rs
+++ b/dask_planner/src/sql/logical.rs
@@ -13,11 +13,8 @@ pub mod projection;
 mod sort;
 mod union;
 
-use datafusion::logical_expr::LogicalPlan;
-
-use datafusion::common::{DataFusionError, Result};
-use datafusion::logical_plan::DFSchemaRef;
-use datafusion::prelude::Column;
+use datafusion_common::{Column, DFSchemaRef, DataFusionError, Result};
+use datafusion_expr::LogicalPlan;
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/logical/aggregate.rs
+++ b/dask_planner/src/sql/logical/aggregate.rs
@@ -1,7 +1,7 @@
 use crate::expression::PyExpr;
 
-use datafusion::logical_expr::LogicalPlan;
-use datafusion::logical_expr::{logical_plan::Aggregate, Expr};
+use datafusion_expr::LogicalPlan;
+use datafusion_expr::{logical_plan::Aggregate, Expr};
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/logical/aggregate.rs
+++ b/dask_planner/src/sql/logical/aggregate.rs
@@ -1,7 +1,6 @@
 use crate::expression::PyExpr;
 
-use datafusion_expr::LogicalPlan;
-use datafusion_expr::{logical_plan::Aggregate, Expr};
+use datafusion_expr::{logical_plan::Aggregate, Expr, LogicalPlan};
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/logical/cross_join.rs
+++ b/dask_planner/src/sql/logical/cross_join.rs
@@ -1,4 +1,4 @@
-use datafusion::logical_plan::{CrossJoin, LogicalPlan};
+use datafusion_expr::logical_plan::{CrossJoin, LogicalPlan};
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/logical/explain.rs
+++ b/dask_planner/src/sql/logical/explain.rs
@@ -1,5 +1,5 @@
 use crate::sql::exceptions::py_type_err;
-use datafusion::logical_expr::{logical_plan::Explain, LogicalPlan};
+use datafusion_expr::{logical_plan::Explain, LogicalPlan};
 use pyo3::prelude::*;
 
 #[pyclass(name = "Explain", module = "dask_planner", subclass)]

--- a/dask_planner/src/sql/logical/filter.rs
+++ b/dask_planner/src/sql/logical/filter.rs
@@ -1,7 +1,6 @@
 use crate::expression::PyExpr;
 
-use datafusion_expr::logical_plan::Filter;
-use datafusion_expr::LogicalPlan;
+use datafusion_expr::{logical_plan::Filter, LogicalPlan};
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/logical/filter.rs
+++ b/dask_planner/src/sql/logical/filter.rs
@@ -1,7 +1,7 @@
 use crate::expression::PyExpr;
 
-use datafusion::logical_expr::logical_plan::Filter;
-use datafusion::logical_expr::LogicalPlan;
+use datafusion_expr::logical_plan::Filter;
+use datafusion_expr::LogicalPlan;
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/logical/join.rs
+++ b/dask_planner/src/sql/logical/join.rs
@@ -1,7 +1,7 @@
 use crate::expression::PyExpr;
 use crate::sql::column;
 
-use datafusion::logical_expr::{
+use datafusion_expr::{
     and,
     logical_plan::{Join, JoinType, LogicalPlan},
     Expr,

--- a/dask_planner/src/sql/logical/limit.rs
+++ b/dask_planner/src/sql/logical/limit.rs
@@ -1,10 +1,10 @@
 use crate::expression::PyExpr;
 use crate::sql::exceptions::py_type_err;
 
-use datafusion::scalar::ScalarValue;
+use datafusion_common::ScalarValue;
 use pyo3::prelude::*;
 
-use datafusion::logical_expr::{logical_plan::Limit, Expr, LogicalPlan};
+use datafusion_expr::{logical_plan::Limit, Expr, LogicalPlan};
 
 #[pyclass(name = "Limit", module = "dask_planner", subclass)]
 #[derive(Clone)]

--- a/dask_planner/src/sql/logical/offset.rs
+++ b/dask_planner/src/sql/logical/offset.rs
@@ -1,10 +1,10 @@
 use crate::expression::PyExpr;
 use crate::sql::exceptions::py_type_err;
 
-use datafusion::scalar::ScalarValue;
+use datafusion_common::ScalarValue;
 use pyo3::prelude::*;
 
-use datafusion::logical_expr::{logical_plan::Offset, Expr, LogicalPlan};
+use datafusion_expr::{logical_plan::Offset, Expr, LogicalPlan};
 
 #[pyclass(name = "Offset", module = "dask_planner", subclass)]
 #[derive(Clone)]

--- a/dask_planner/src/sql/logical/projection.rs
+++ b/dask_planner/src/sql/logical/projection.rs
@@ -1,7 +1,7 @@
 use crate::expression::PyExpr;
 
-use datafusion::logical_expr::LogicalPlan;
-use datafusion::logical_expr::{logical_plan::Projection, Expr};
+use datafusion_expr::LogicalPlan;
+use datafusion_expr::{logical_plan::Projection, Expr};
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/logical/projection.rs
+++ b/dask_planner/src/sql/logical/projection.rs
@@ -1,7 +1,6 @@
 use crate::expression::PyExpr;
 
-use datafusion_expr::LogicalPlan;
-use datafusion_expr::{logical_plan::Projection, Expr};
+use datafusion_expr::{logical_plan::Projection, Expr, LogicalPlan};
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/logical/sort.rs
+++ b/dask_planner/src/sql/logical/sort.rs
@@ -1,7 +1,7 @@
 use crate::expression::PyExpr;
 
 use crate::sql::exceptions::py_type_err;
-use datafusion::logical_expr::{logical_plan::Sort, Expr, LogicalPlan};
+use datafusion_expr::{logical_plan::Sort, Expr, LogicalPlan};
 use pyo3::prelude::*;
 
 #[pyclass(name = "Sort", module = "dask_planner", subclass)]

--- a/dask_planner/src/sql/logical/union.rs
+++ b/dask_planner/src/sql/logical/union.rs
@@ -1,5 +1,5 @@
-use datafusion::logical_expr::logical_plan::Union;
-pub use datafusion::logical_expr::LogicalPlan;
+use datafusion_expr::logical_plan::Union;
+pub use datafusion_expr::LogicalPlan;
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/logical/union.rs
+++ b/dask_planner/src/sql/logical/union.rs
@@ -1,5 +1,4 @@
-use datafusion_expr::logical_plan::Union;
-pub use datafusion_expr::LogicalPlan;
+use datafusion_expr::{logical_plan::Union, LogicalPlan};
 
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;

--- a/dask_planner/src/sql/optimizer.rs
+++ b/dask_planner/src/sql/optimizer.rs
@@ -1,14 +1,11 @@
 use datafusion_common::DataFusionError;
 use datafusion_expr::LogicalPlan;
-use datafusion_optimizer::common_subexpr_eliminate::CommonSubexprEliminate;
-use datafusion_optimizer::eliminate_limit::EliminateLimit;
-use datafusion_optimizer::filter_push_down::FilterPushDown;
-use datafusion_optimizer::limit_push_down::LimitPushDown;
-use datafusion_optimizer::optimizer::OptimizerRule;
-use datafusion_optimizer::projection_push_down::ProjectionPushDown;
-use datafusion_optimizer::single_distinct_to_groupby::SingleDistinctToGroupBy;
-use datafusion_optimizer::subquery_filter_to_join::SubqueryFilterToJoin;
-use datafusion_optimizer::OptimizerConfig;
+use datafusion_optimizer::{
+    common_subexpr_eliminate::CommonSubexprEliminate, eliminate_limit::EliminateLimit,
+    filter_push_down::FilterPushDown, limit_push_down::LimitPushDown, optimizer::OptimizerRule,
+    projection_push_down::ProjectionPushDown, single_distinct_to_groupby::SingleDistinctToGroupBy,
+    subquery_filter_to_join::SubqueryFilterToJoin, OptimizerConfig,
+};
 
 /// Houses the optimization logic for Dask-SQL. This optimization controls the optimizations
 /// and their ordering in regards to their impact on the underlying `LogicalPlan` instance

--- a/dask_planner/src/sql/optimizer.rs
+++ b/dask_planner/src/sql/optimizer.rs
@@ -1,15 +1,14 @@
-use datafusion::error::DataFusionError;
-use datafusion::logical_expr::LogicalPlan;
-use datafusion::optimizer::eliminate_limit::EliminateLimit;
-use datafusion::optimizer::filter_push_down::FilterPushDown;
-use datafusion::optimizer::limit_push_down::LimitPushDown;
-use datafusion::optimizer::optimizer::OptimizerRule;
-use datafusion::optimizer::OptimizerConfig;
-
-use datafusion::optimizer::common_subexpr_eliminate::CommonSubexprEliminate;
-use datafusion::optimizer::projection_push_down::ProjectionPushDown;
-use datafusion::optimizer::single_distinct_to_groupby::SingleDistinctToGroupBy;
-use datafusion::optimizer::subquery_filter_to_join::SubqueryFilterToJoin;
+use datafusion_common::DataFusionError;
+use datafusion_expr::LogicalPlan;
+use datafusion_optimizer::common_subexpr_eliminate::CommonSubexprEliminate;
+use datafusion_optimizer::eliminate_limit::EliminateLimit;
+use datafusion_optimizer::filter_push_down::FilterPushDown;
+use datafusion_optimizer::limit_push_down::LimitPushDown;
+use datafusion_optimizer::optimizer::OptimizerRule;
+use datafusion_optimizer::projection_push_down::ProjectionPushDown;
+use datafusion_optimizer::single_distinct_to_groupby::SingleDistinctToGroupBy;
+use datafusion_optimizer::subquery_filter_to_join::SubqueryFilterToJoin;
+use datafusion_optimizer::OptimizerConfig;
 
 /// Houses the optimization logic for Dask-SQL. This optimization controls the optimizations
 /// and their ordering in regards to their impact on the underlying `LogicalPlan` instance

--- a/dask_planner/src/sql/statement.rs
+++ b/dask_planner/src/sql/statement.rs
@@ -1,4 +1,4 @@
-use datafusion::sql::parser::Statement;
+use datafusion_sql::parser::Statement;
 
 use pyo3::prelude::*;
 

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -6,8 +6,8 @@ use crate::sql::types::SqlTypeName;
 
 use async_trait::async_trait;
 
-use datafusion::arrow::datatypes::{DataType, Field, SchemaRef};
-use datafusion::logical_expr::{LogicalPlan, TableSource};
+use arrow::datatypes::{DataType, Field, SchemaRef};
+use datafusion_expr::{LogicalPlan, TableSource};
 
 use pyo3::prelude::*;
 

--- a/dask_planner/src/sql/types.rs
+++ b/dask_planner/src/sql/types.rs
@@ -1,4 +1,4 @@
-use datafusion::arrow::datatypes::{DataType, IntervalUnit, TimeUnit};
+use arrow::datatypes::{DataType, IntervalUnit, TimeUnit};
 
 pub mod rel_data_type;
 pub mod rel_data_type_field;

--- a/dask_planner/src/sql/types/rel_data_type_field.rs
+++ b/dask_planner/src/sql/types/rel_data_type_field.rs
@@ -1,8 +1,7 @@
 use crate::sql::types::DaskTypeMap;
 use crate::sql::types::SqlTypeName;
 
-use datafusion::error::Result;
-use datafusion::logical_plan::{DFField, DFSchema};
+use datafusion_common::{DFField, DFSchema, Result};
 
 use std::fmt;
 


### PR DESCRIPTION
Rather than importing the entire datafusion project (including its own execution engine) we can just use the crates we need. This will help reduce compile time and ensure we don't accidentally start depending on DataFusion physical plans.