### PR TITLE
Make sure scheduler has Dask nightlies in upstream cluster testing

### DIFF
--- a/.github/cluster-upstream.yml
+++ b/.github/cluster-upstream.yml
@@ -5,6 +5,9 @@ services:
         container_name: dask-scheduler
         image: daskdev/dask:dev
         command: dask-scheduler
+        environment:
+            USE_MAMBA: "true"
+            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0"
         ports:
             - "8786:8786"
     dask-worker:


### PR DESCRIPTION
I neglected to install Dask nightlies on the scheduler for upstream  cluster testing, which is resulting in failures in our daily testing; this PR should resolve these.

Closes #570