### PR TITLE
Expose groupby agg configs to drop_duplicates (distinct) egg

### DIFF
--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -228,12 +228,17 @@ class DaskAggregatePlugin(BaseRelPlugin):
             rel, df, cc, context, additional_column_name, output_column_order
         )
 
+        groupby_agg_options = dask_config.get("sql.groupby")
+
         if not collected_aggregations:
             backend_names = [
                 cc.get_backend_by_frontend_name(group_name)
                 for group_name in group_columns
             ]
-            return df[backend_names].drop_duplicates(), output_column_order
+            return (
+                df[backend_names].drop_duplicates(**groupby_agg_options),
+                output_column_order,
+            )
 
         # SQL needs to have a column with the grouped values as the first
         # output column.
@@ -241,8 +246,6 @@ class DaskAggregatePlugin(BaseRelPlugin):
         # are the same for a single group anyways, we just use the first row
         for col in group_columns:
             collected_aggregations[None].append((col, col, "first"))
-
-        groupby_agg_options = dask_config.get("sql.groupby")
 
         # Now we can go ahead and use these grouped aggregations
         # to perform the actual aggregation

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -228,7 +228,7 @@ class DaskAggregatePlugin(BaseRelPlugin):
             rel, df, cc, context, additional_column_name, output_column_order
         )
 
-        groupby_agg_options = dask_config.get("sql.groupby")
+        groupby_agg_options = dask_config.get("sql.aggregate")
 
         if not collected_aggregations:
             backend_names = [

--- a/dask_sql/sql-schema.yaml
+++ b/dask_sql/sql-schema.yaml
@@ -4,7 +4,7 @@ properties:
     type: object
     properties:
 
-      groupby:
+      aggregate:
         type: object
         properties:
 

--- a/dask_sql/sql-schema.yaml
+++ b/dask_sql/sql-schema.yaml
@@ -11,12 +11,12 @@ properties:
           split_out:
             type: integer
             description: |
-              Number of output partitions for a groupby operation
+              Number of output partitions from an aggregation operation
 
           split_every:
             type: [integer, "null"]
             description: |
-              Number of branches per reduction step for a groupby operation.
+              Number of branches per reduction step from an aggregation operation.
 
       identifier:
         type: object

--- a/dask_sql/sql.yaml
+++ b/dask_sql/sql.yaml
@@ -1,5 +1,5 @@
 sql:
-  groupby:
+  aggregate:
     split_out: 1
     split_every: null
 

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -405,17 +405,26 @@ def test_groupby_split_out(c, input_table, split_out, request):
     assert return_df.npartitions == split_out if split_out else 1
     assert_eq(return_df.sort_values("user_id"), expected_df, check_index=False)
 
+    return_df = c.sql(
+        f"""
+        SELECT DISTINCT(user_id) FROM {input_table}
+        """,
+        config_options={"sql.groupby.split_out": split_out},
+    )
+    expected_df = user_table[["user_id"]].drop_duplicates()
+    assert return_df.npartitions == split_out if split_out else 1
+    assert_eq(return_df.sort_values("user_id"), expected_df, check_index=False)
 
-@pytest.mark.skip(reason="WIP DataFusion")
+
 @pytest.mark.parametrize(
     "gpu,split_every,expected_keys",
     [
-        (False, 2, 74),
-        (False, 3, 68),
-        (False, 4, 64),
-        pytest.param(True, 2, 107, marks=pytest.mark.gpu),
-        pytest.param(True, 3, 101, marks=pytest.mark.gpu),
-        pytest.param(True, 4, 97, marks=pytest.mark.gpu),
+        (False, 2, 72),
+        (False, 3, 66),
+        (False, 4, 62),
+        pytest.param(True, 2, 105, marks=pytest.mark.gpu),
+        pytest.param(True, 3, 99, marks=pytest.mark.gpu),
+        pytest.param(True, 4, 95, marks=pytest.mark.gpu),
     ],
 )
 def test_groupby_split_every(c, gpu, split_every, expected_keys):

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -1,5 +1,3 @@
-import math
-
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
@@ -418,9 +416,8 @@ def test_groupby_split_out(c, input_table, split_out, request):
     assert_eq(return_df.sort_values("user_id"), expected_df, check_index=False)
 
 
-@pytest.mark.parametrize("split_every", [2, 3, 4])
 @pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
-def test_groupby_split_every(c, gpu, split_every):
+def test_groupby_split_every(c, gpu):
     input_ddf = dd.from_pandas(
         pd.DataFrame({"user_id": [1, 2, 3, 4] * 16, "b": [5, 6, 7, 8] * 16}),
         npartitions=16,
@@ -428,66 +425,67 @@ def test_groupby_split_every(c, gpu, split_every):
 
     c.create_table("split_every_input", input_ddf, gpu=gpu)
 
-    return_df = c.sql(
-        """
-        SELECT
+    query_string = """
+    SELECT
         user_id, SUM(b) AS "S"
-        FROM split_every_input
-        GROUP BY user_id
-        """,
-        config_options={"sql.aggregate.split_every": split_every},
+    FROM split_every_input
+    GROUP BY user_id
+    """
+    split_every_2_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 2},
     )
+    split_every_3_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 3},
+    )
+    split_every_4_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 4},
+    )
+
     expected_df = (
         input_ddf.groupby(by="user_id")
-        .agg({"b": "sum"}, split_every=split_every)
+        .agg({"b": "sum"})
         .reset_index(drop=False)
         .rename(columns={"b": "S"})
         .sort_values("user_id")
     )
-    got_agg_keys = [
-        key
-        for key in return_df.dask.keys()
-        if (key[0].startswith("aggregate-combine") and key[-1] > 0)
-        or (key[0].startswith("aggregate-agg"))
-        # For dask-cudf groupby operations
-        or (key[0].startswith("groupby_tree_reduce") and key[-1] > 0)
-    ]
-    assert len(got_agg_keys) == num_expected_agg_keys(
-        input_ddf.npartitions, split_every
+    assert (
+        len(split_every_2_df.dask.keys())
+        >= len(split_every_3_df.dask.keys())
+        >= len(split_every_4_df.dask.keys())
     )
-    assert_eq(return_df, expected_df, check_index=False)
 
-    return_df = c.sql(
-        """
-        SELECT DISTINCT(user_id) FROM split_every_input
-        """,
-        config_options={"sql.aggregate.split_every": split_every},
+    assert_eq(split_every_2_df, expected_df, check_index=False)
+    assert_eq(split_every_3_df, expected_df, check_index=False)
+    assert_eq(split_every_4_df, expected_df, check_index=False)
+
+    query_string = """
+    SELECT DISTINCT(user_id) FROM split_every_input
+    """
+    split_every_2_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 2},
     )
+    split_every_3_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 3},
+    )
+    split_every_4_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 4},
+    )
+
     expected_df = input_ddf[["user_id"]].drop_duplicates()
-    got_agg_keys = [
-        key
-        for key in return_df.dask.keys()
-        if (key[0].startswith("drop-duplicates-combine") and key[-1] > 0)
-        or (key[0].startswith("drop-duplicates-agg"))
-    ]
-    assert len(got_agg_keys) == num_expected_agg_keys(
-        input_ddf.npartitions, split_every
+
+    assert (
+        len(split_every_2_df.dask.keys())
+        >= len(split_every_3_df.dask.keys())
+        >= len(split_every_4_df.dask.keys())
     )
-    assert_eq(return_df, expected_df, check_index=False)
+    assert_eq(split_every_2_df, expected_df, check_index=False)
+    assert_eq(split_every_3_df, expected_df, check_index=False)
+    assert_eq(split_every_4_df, expected_df, check_index=False)
 
     c.drop_table("split_every_input")
-
-
-def num_expected_agg_keys(npartitions, split_every):
-    """
-    Returns expected number of tree reduction operations in a aggregate reduction
-    """
-    if split_every >= npartitions:
-        return 1
-    num_keys = 0
-    # Number of levels in the tree reduction
-    upper_bound = math.ceil(math.log(npartitions, split_every))
-    # Accumulating the number of operations at each level
-    for i in range(1, upper_bound + 1):
-        num_keys += math.ceil(npartitions / split_every**i)
-    return num_keys

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -392,7 +392,7 @@ def test_groupby_split_out(c, input_table, split_out, request):
         FROM {input_table}
         GROUP BY user_id
         """,
-        config_options={"sql.groupby.split_out": split_out},
+        config_options={"sql.aggregate.split_out": split_out},
     )
     expected_df = (
         user_table.groupby(by="user_id")
@@ -409,7 +409,7 @@ def test_groupby_split_out(c, input_table, split_out, request):
         f"""
         SELECT DISTINCT(user_id) FROM {input_table}
         """,
-        config_options={"sql.groupby.split_out": split_out},
+        config_options={"sql.aggregate.split_out": split_out},
     )
     expected_df = user_table[["user_id"]].drop_duplicates()
     assert return_df.npartitions == split_out if split_out else 1
@@ -442,7 +442,7 @@ def test_groupby_split_every(c, gpu, split_every, expected_keys):
         FROM split_every_input
         GROUP BY user_id
         """,
-        config_options={"sql.groupby.split_every": split_every},
+        config_options={"sql.aggregate.split_every": split_every},
     )
     expected_df = (
         input_ddf.groupby(by="user_id")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,7 +12,7 @@ import dask_sql  # noqa: F401
 def test_custom_yaml(tmpdir):
     custom_config = {}
     custom_config["sql"] = dask_config.get("sql")
-    custom_config["sql"]["groupby"]["split_out"] = 16
+    custom_config["sql"]["aggregate"]["split_out"] = 16
     custom_config["sql"]["foo"] = {"bar": [1, 2, 3], "baz": None}
 
     with open(os.path.join(tmpdir, "custom-sql.yaml"), mode="w") as f:
@@ -26,9 +26,9 @@ def test_custom_yaml(tmpdir):
 
 
 def test_env_variable():
-    with mock.patch.dict("os.environ", {"DASK_SQL__GROUPBY__SPLIT_OUT": "200"}):
+    with mock.patch.dict("os.environ", {"DASK_SQL__AGGREGATE__SPLIT_OUT": "200"}):
         dask_config.refresh()
-        assert dask_config.get("sql.groupby.split-out") == 200
+        assert dask_config.get("sql.aggregate.split-out") == 200
     dask_config.refresh()
 
 


### PR DESCRIPTION
- Extends the use groupby config params of `split_out` and `split_every` to the `drop_duplicates` operation.
- Renames the `sql.groupby` config option to `sql.aggregate`.
- Updates `split_every` test