### PR TITLE
Don't move jar to local mvn repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def install_java_libraries(dir):
         raise OSError(
             "Can not find the mvn (maven) binary. Make sure to install maven before building the jar."
         )
-    command = [maven_command, "clean", "install", "-f", "pom.xml"]
+    command = [maven_command, "clean", "package", "-f", "pom.xml"]
     subprocess.check_call(command, cwd=os.path.join(dir, "planner"))
 
     # copy generated jar to python package


### PR DESCRIPTION
Since dask-sql does not rely on the mvn repository during runtime but instead adds the jar to the project installation dir and modifies the classpath by reading from pkg_resources it shouldn't be necessary to run `mvn install` here. `mvn package` should suffice.