### PR TITLE
Push down null filters into TableScan

### DIFF
--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -73,7 +73,7 @@ impl ContextProvider for DaskSQLContext {
                         let mut fields: Vec<Field> = Vec::new();
                         // Iterate through the DaskTable instance and create a Schema instance
                         for (column_name, column_type) in &table.columns {
-                            fields.push(Field::new(column_name, column_type.data_type(), false));
+                            fields.push(Field::new(column_name, column_type.data_type(), true));
                         }
 
                         resp = Some(Schema::new(fields));

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -38,6 +38,8 @@ impl TableSource for DaskTableSource {
         self.schema.clone()
     }
 
+    // temporarily disable clippy until TODO comment below is addressed
+    #[allow(clippy::if_same_then_else)]
     fn supports_filter_pushdown(
         &self,
         filter: &Expr,
@@ -62,10 +64,7 @@ impl TableSource for DaskTableSource {
 fn is_supported_push_down_expr(expr: &Expr) -> bool {
     match expr {
         // for now, we just attempt to push down simple IS NOT NULL filters on columns
-        Expr::IsNotNull(ref a) => match a.as_ref() {
-            Expr::Column(_) => true,
-            _ => false,
-        },
+        Expr::IsNotNull(ref a) => matches!(a.as_ref(), Expr::Column(_)),
         _ => false,
     }
 }

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -7,10 +7,11 @@ use crate::sql::types::SqlTypeName;
 use async_trait::async_trait;
 
 use arrow::datatypes::{DataType, Field, SchemaRef};
-use datafusion_expr::{LogicalPlan, TableSource};
+use datafusion_expr::{Expr, LogicalPlan, TableProviderFilterPushDown, TableSource};
 
 use pyo3::prelude::*;
 
+use datafusion_optimizer::utils::split_conjunction;
 use std::any::Any;
 use std::sync::Arc;
 
@@ -35,6 +36,37 @@ impl TableSource for DaskTableSource {
 
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
+    }
+
+    fn supports_filter_pushdown(
+        &self,
+        filter: &Expr,
+    ) -> datafusion_common::Result<TableProviderFilterPushDown> {
+        let mut filters = vec![];
+        split_conjunction(filter, &mut filters);
+        if filters.iter().all(|f| is_supported_push_down_expr(*f)) {
+            // TODO this should return Exact but we cannot make that change until we
+            // are actually pushing the TableScan filters down to the reader because
+            // returning Exact here would remove the Filter from the plan
+            Ok(TableProviderFilterPushDown::Inexact)
+        } else if filters.iter().any(|f| is_supported_push_down_expr(*f)) {
+            // we can partially apply the filter in the TableScan but we need
+            // to retain the Filter operator in the plan as well
+            Ok(TableProviderFilterPushDown::Inexact)
+        } else {
+            Ok(TableProviderFilterPushDown::Unsupported)
+        }
+    }
+}
+
+fn is_supported_push_down_expr(expr: &Expr) -> bool {
+    match expr {
+        // for now, we just attempt to push down simple IS NOT NULL filters on columns
+        Expr::IsNotNull(ref a) => match a.as_ref() {
+            Expr::Column(_) => true,
+            _ => false,
+        },
+        _ => false,
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/dask-contrib/dask-sql/issues/594

Changes in this PR:

- Implement `DaskTableSource::supports_filter_pushdown` so that it accepts simple `IS NOT NULL` filters
- Change default `nullable` to true

