### PR TITLE
Consolidate limit/offset logic in partition func

### DIFF
--- a/dask_sql/physical/rel/logical/limit.py
+++ b/dask_sql/physical/rel/logical/limit.py
@@ -30,28 +30,33 @@ class DaskLimitPlugin(BaseRelPlugin):
         limit = RexConverter.convert(rel, rel.limit().getFetch(), df, context=context)
         offset = RexConverter.convert(rel, rel.limit().getSkip(), df, context=context)
 
-        # Apply Offset to DataFrame
-        df = self._apply_offset(df, offset) if offset else df
+        # apply offset to limit if specified
+        if limit and offset:
+            limit += offset
 
-        # Limit DataFrame
-        df = df.head(limit, npartitions=-1, compute=False) if limit else df
-
+        # apply limit and/or offset to DataFrame
+        df = self._apply_limit(df, limit, offset)
         cc = self.fix_column_to_row_type(cc, rel.getRowType())
+
         # No column type has changed, so no need to cast again
         return DataContainer(df, cc)
 
-    def _apply_offset(self, df: dd.DataFrame, offset: int) -> dd.DataFrame:
+    def _apply_limit(self, df: dd.DataFrame, limit: int, offset: int) -> dd.DataFrame:
         """
-        Limit the dataframe to the window [offset, end].
+        Limit the dataframe to the window [offset, limit].
 
         Unfortunately, Dask does not currently support row selection through `iloc`, so this must be done using a custom partition function.
         However, it is sometimes possible to compute this window using `head` when an `offset` is not specified.
         """
+        # if no offset is specified we can use `head` to compute the window
+        if not offset:
+            return df.head(limit, npartitions=-1, compute=False)
+
         # compute the size of each partition
         # TODO: compute `cumsum` here when dask#9067 is resolved
         partition_borders = df.map_partitions(lambda x: len(x))
 
-        def offset_partition_func(df, partition_borders, partition_info=None):
+        def limit_partition_func(df, partition_borders, partition_info=None):
             """Limit the partition to values contained within the specified window, returning an empty dataframe if there are none"""
 
             # TODO: remove the `cumsum` call here when dask#9067 is resolved
@@ -65,14 +70,19 @@ class DaskLimitPlugin(BaseRelPlugin):
             )
             partition_border_right = partition_borders[partition_index]
 
-            if offset >= partition_border_right:
+            if (limit and limit < partition_border_left) or (
+                offset >= partition_border_right
+            ):
                 return df.iloc[0:0]
 
             from_index = max(offset - partition_border_left, 0)
+            to_index = (
+                min(limit, partition_border_right) if limit else partition_border_right
+            ) - partition_border_left
 
-            return df.iloc[from_index:]
+            return df.iloc[from_index:to_index]
 
         return df.map_partitions(
-            offset_partition_func,
+            limit_partition_func,
             partition_borders=partition_borders,
         )


### PR DESCRIPTION
This restores the original consolidated computation of limit/offsets in `limit_partition_func`, while also opting to keep the simplified computation of limits when an offset is not specified, which is what we opted for in #529.

Closes #597