### PR TITLE
Fix bug when filtering on specific scalars.

### DIFF
--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -126,7 +126,12 @@ class ReduceOperation(Operation):
 
     def reduce(self, *operands, **kwargs):
         if len(operands) > 1:
-            if any(map(pd.api.types.is_datetime64_dtype, operands)):
+            if any(
+                map(
+                    lambda op: is_frame(op) & pd.api.types.is_datetime64_dtype(op),
+                    operands,
+                )
+            ):
                 operands = tuple(map(as_timelike, operands))
             return reduce(partial(self.operation, **kwargs), operands)
         else:

--- a/tests/integration/test_filter.py
+++ b/tests/integration/test_filter.py
@@ -66,6 +66,11 @@ def test_string_filter(c, string_table):
         return_df,
         string_table.head(1),
     )
+    # Condition needs to specifically check on `M` since this the literal `M`
+    # was getting parsed as a datetime dtype
+    return_df = c.sql("SELECT * from string_table WHERE a = 'M'")
+    expected_df = string_table[string_table["a"] == "M"]
+    assert_eq(return_df, expected_df)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When filtering on certain scalars like `M` or `m` we run into a specific bug where the `pd.api.types.is_datetime64_type` check returns `True` because these string correspond to date time like dtypes when pandas tries to convert this to a Dtype based on the Array-protocol section [here](https://numpy.org/doc/stable/reference/arrays.dtypes.html#specifying-and-constructing-data-types)