### PR TITLE
Fix the results from a subquery alias operation with optimizations enabled

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -114,6 +114,7 @@ class Context:
         RelConverter.add_plugin_class(logical.DaskWindowPlugin, replace=False)
         RelConverter.add_plugin_class(logical.SamplePlugin, replace=False)
         RelConverter.add_plugin_class(logical.ExplainPlugin, replace=False)
+        RelConverter.add_plugin_class(logical.SubqueryAlias, replace=False)
         RelConverter.add_plugin_class(custom.AnalyzeTablePlugin, replace=False)
         RelConverter.add_plugin_class(custom.CreateExperimentPlugin, replace=False)
         RelConverter.add_plugin_class(custom.CreateModelPlugin, replace=False)

--- a/dask_sql/physical/rel/convert.py
+++ b/dask_sql/physical/rel/convert.py
@@ -13,11 +13,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# Certain Relational Operators do not need specially mapped Dask operations.
-# Those operators are skipped when generating the Dask task graph
-_SKIPPABLE_RELATIONAL_OPERATORS = ["SubqueryAlias"]
-
-
 class RelConverter(Pluggable):
     """
     Helper to convert from rel to a python expression
@@ -56,20 +51,13 @@ class RelConverter(Pluggable):
 
         try:
             plugin_instance = cls.get_plugin(node_type)
-            logger.debug(
-                f"Processing REL {rel} using {plugin_instance.__class__.__name__}..."
-            )
-            df = plugin_instance.convert(rel, context=context)
-            logger.debug(f"Processed REL {rel} into {LoggableDataFrame(df)}")
-            return df
         except KeyError:  # pragma: no cover
-            if node_type in _SKIPPABLE_RELATIONAL_OPERATORS:
-                logger.debug(
-                    f"'{node_type}' is a relational algebra operation which doesn't require a direct Dask task. \
-                    Omitting it from the resulting Dask task graph."
-                )
-                return BaseRelPlugin.assert_inputs(rel, 1, context)[0]
-            else:
-                raise NotImplementedError(
-                    f"No relational conversion for node type {node_type} available (yet)."
-                )
+            raise NotImplementedError(
+                f"No relational conversion for node type {node_type} available (yet)."
+            )
+        logger.debug(
+            f"Processing REL {rel} using {plugin_instance.__class__.__name__}..."
+        )
+        df = plugin_instance.convert(rel, context=context)
+        logger.debug(f"Processed REL {rel} into {LoggableDataFrame(df)}")
+        return df

--- a/dask_sql/physical/rel/convert.py
+++ b/dask_sql/physical/rel/convert.py
@@ -68,9 +68,7 @@ class RelConverter(Pluggable):
                     f"'{node_type}' is a relational algebra operation which doesn't require a direct Dask task. \
                     Omitting it from the resulting Dask task graph."
                 )
-                return context.schema[rel.getCurrentNodeSchemaName()].tables[
-                    rel.getCurrentNodeTableName()
-                ]
+                return BaseRelPlugin.assert_inputs(rel, 1, context)[0]
             else:
                 raise NotImplementedError(
                     f"No relational conversion for node type {node_type} available (yet)."

--- a/dask_sql/physical/rel/logical/__init__.py
+++ b/dask_sql/physical/rel/logical/__init__.py
@@ -7,6 +7,7 @@ from .limit import DaskLimitPlugin
 from .project import DaskProjectPlugin
 from .sample import SamplePlugin
 from .sort import DaskSortPlugin
+from .subquery_alias import SubqueryAlias
 from .table_scan import DaskTableScanPlugin
 from .union import DaskUnionPlugin
 from .values import DaskValuesPlugin
@@ -26,4 +27,5 @@ __all__ = [
     DaskWindowPlugin,
     SamplePlugin,
     ExplainPlugin,
+    SubqueryAlias,
 ]

--- a/dask_sql/physical/rel/logical/subquery_alias.py
+++ b/dask_sql/physical/rel/logical/subquery_alias.py
@@ -1,0 +1,19 @@
+from typing import TYPE_CHECKING
+
+from dask_sql.physical.rel.base import BaseRelPlugin
+
+if TYPE_CHECKING:
+    import dask_sql
+    from dask_planner.rust import LogicalPlan
+
+
+class SubqueryAlias(BaseRelPlugin):
+    """
+    SubqueryAlias is used to assign an alias to a table and/or subquery
+    """
+
+    class_name = "SubqueryAlias"
+
+    def convert(self, rel: "LogicalPlan", context: "dask_sql.Context"):
+        (dc,) = self.assert_inputs(rel, 1, context)
+        return dc

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -126,7 +126,12 @@ class ReduceOperation(Operation):
 
     def reduce(self, *operands, **kwargs):
         if len(operands) > 1:
-            if any(map(pd.api.types.is_datetime64_dtype, operands)):
+            if any(
+                map(
+                    lambda op: is_frame(op) & pd.api.types.is_datetime64_dtype(op),
+                    operands,
+                )
+            ):
                 operands = tuple(map(as_timelike, operands))
             return reduce(partial(self.operation, **kwargs), operands)
         else:

--- a/tests/integration/test_join.py
+++ b/tests/integration/test_join.py
@@ -374,3 +374,12 @@ def test_intersect_multi_col(c):
         }
     )
     assert_eq(return_df, expected_df, check_index=False)
+
+
+def test_join_alias_w_projection(c, parquet_ddf):
+    result_df = c.sql(
+        "SELECT t2.c as c_y from parquet_ddf t1, parquet_ddf t2 WHERE t1.a=t2.a and t1.c='A'"
+    )
+    expected_df = parquet_ddf.merge(parquet_ddf, on=["a"], how="inner")
+    expected_df = expected_df[expected_df["c_x"] == "A"][["c_y"]]
+    assert_eq(result_df, expected_df, check_index=False)


### PR DESCRIPTION
Subquery alias operation was directly returning a table without the column/null projection filters being applied to them resulting in wrong results downstream.