### PR TITLE
Add STDDEV, STDDEV_SAMP, and STDDEV_POP

### DIFF
--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -131,6 +131,23 @@ class DaskAggregatePlugin(BaseRelPlugin):
             )
         ),
         "avg": AggregationSpecification("mean", AggregationOnPandas("mean")),
+        "stddev": AggregationSpecification("std", AggregationOnPandas("std")),
+        "stddevsamp": AggregationSpecification("std", AggregationOnPandas("std")),
+        "stddevpop": AggregationSpecification(
+            dd.Aggregation(
+                "stddevpop",
+                lambda s: (s.count(), s.sum(), s.agg(lambda x: (x**2).sum())),
+                lambda count, sum, sum_of_squares: (
+                    count.sum(),
+                    sum.sum(),
+                    sum_of_squares.sum(),
+                ),
+                lambda count, sum, sum_of_squares: (
+                    (sum_of_squares / count) - (sum / count) ** 2
+                )
+                ** (1 / 2),
+            )
+        ),
         "bit_and": AggregationSpecification(
             ReduceAggregation("bit_and", operator.and_)
         ),

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -447,13 +447,14 @@ class DaskAggregatePlugin(BaseRelPlugin):
         if additional_column_name is None:
             additional_column_name = new_temporary_column(dc.df)
 
+        group_columns = [
+            dc.column_container.get_backend_by_frontend_name(group_name)
+            for group_name in group_columns
+        ]
+
         # perform groupby operation; if we are using custom aggregations, we must handle
         # null values manually (this is slow)
         if fast_groupby:
-            group_columns = [
-                dc.column_container.get_backend_by_frontend_name(group_name)
-                for group_name in group_columns
-            ]
             grouped_df = tmp_df.groupby(
                 by=(group_columns or [additional_column_name]), dropna=False
             )

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -251,6 +251,58 @@ def test_aggregations(c):
     assert_eq(return_df.reset_index(drop=True), expected_df)
 
 
+def test_stddev(c):
+    df = pd.DataFrame(
+        {
+            "a": [1, 1, 2, 1, 2],
+            "b": [4, 6, 3, 8, 5],
+        }
+    )
+
+    c.create_table("df", df)
+
+    return_df = c.sql(
+        """
+        SELECT
+            STDDEV(b) AS s
+        FROM df
+        GROUP BY df.a
+        """
+    )
+
+    expected_df = pd.DataFrame({"s": df.groupby("a").std()["b"]})
+
+    assert_eq(return_df, expected_df.reset_index(drop=True))
+
+    return_df = c.sql(
+        """
+        SELECT
+            STDDEV_SAMP(b) AS ss
+        FROM df
+        GROUP BY df.a
+        """
+    )
+
+    expected_df = pd.DataFrame({"ss": df.groupby("a").std()["b"]})
+
+    assert_eq(return_df, expected_df.reset_index(drop=True))
+
+    return_df = c.sql(
+        """
+        SELECT
+            STDDEV_POP(b) AS sp
+        FROM df
+        GROUP BY df.a
+        """
+    )
+
+    expected_df = pd.DataFrame({"sp": df.groupby("a").std(ddof=0)["b"]})
+
+    assert_eq(return_df, expected_df.reset_index(drop=True))
+
+    c.drop_table("df")
+
+
 @pytest.mark.skip(
     reason="WIP DataFusion - https://github.com/dask-contrib/dask-sql/issues/463"
 )

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -287,6 +287,7 @@ def test_stddev(c, gpu):
 
     assert_eq(return_df, expected_df.reset_index(drop=True))
 
+    # Can be removed after addressing: https://github.com/dask-contrib/dask-sql/issues/681
     if gpu:
         c.drop_table("df")
         pytest.skip()

--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -287,6 +287,10 @@ def test_stddev(c, gpu):
 
     assert_eq(return_df, expected_df.reset_index(drop=True))
 
+    if gpu:
+        c.drop_table("df")
+        pytest.skip()
+
     return_df = c.sql(
         """
         SELECT


### PR DESCRIPTION
Closes #608

Blocked by: https://github.com/rapidsai/cudf/issues/11515

Note: currently, performing multiple aggregations at once seems to result in incorrect values. Ex: `SELECT STDDEV(a) AS s1, STDDEV_POP(a) AS s2 FROM df` returns the same result for both `s1` and `s2` but running two separate queries (one for each aggregation) returns the correct results (#655)