### PR TITLE
Add environment file & documentation for GPU tests 

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ You can run the tests (after installation) with
 
     pytest tests
 
+GPU-specific tests require additional dependencies specified in `continuous_integration/gpuci/environment.yaml`.
+These can be added to the development environment by running
+
+```
+conda env update -n dask-sql -f continuous_integration/gpuci/environment.yaml
+```
+
+And GPU-specific tests can be run with
+
+```
+pytest tests -m gpu --rungpu
+```
+
 ## SQL Server
 
 `dask-sql` comes with a small test implementation for a SQL server.

--- a/continuous_integration/gpuci/environment.yaml
+++ b/continuous_integration/gpuci/environment.yaml
@@ -1,0 +1,17 @@
+name: gpuci
+channels:
+  - rapidsai
+  - rapidsai-nightly
+  - nvidia
+dependencies:
+  - rust>=1.60.0
+  - setuptools-rust>=1.2.0
+  - cudatoolkit=11.5
+  - cudf=22.08
+  - cuml=22.08
+  - dask-cudf=22.08
+  - dask-cuda=22.08
+  - numpy>=1.20.0
+  - ucx-proc=*=gpu
+  - ucx-py=0.27
+  - xgboost=*=cuda_*

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -109,6 +109,19 @@ You can run the tests (after installation) with
 
     pytest tests
 
+GPU-specific tests require additional dependencies specified in `continuous_integration/gpuci/environment.yaml`.
+These can be added to the development environment by running
+
+.. code-block:: bash
+
+    conda env update -n dask-sql -f continuous_integration/gpuci/environment.yaml
+
+And GPU-specific tests can be run with
+
+.. code-block:: bash
+
+    pytest tests -m gpu --rungpu
+
 This repository uses pre-commit hooks. To install them, call
 
 .. code-block:: bash


### PR DESCRIPTION
A different approach to #630; adds a new environment file to `continuous_integration/gpuci/` specifying the additional packages that get installed on top of the CI environment for gpuCI, along with some documentation on how to use this file to run GPU tests.

Planning to follow up on this with https://github.com/rapidsai/dask-build-environment/pull/39, which would use this file to install requirements into the gpuCI images, which should improve transparency on how the GPU tests work.