### PR TITLE
Add max version constraint for `fugue`

### DIFF
--- a/continuous_integration/environment-3.10-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk11-dev.yaml
@@ -33,7 +33,7 @@ dependencies:
 - uvicorn>=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
-- antlr4-python3-runtime
+- antlr4-python3-runtime<4.10
 - ciso8601
 - fs
 - pip

--- a/continuous_integration/environment-3.10-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk11-dev.yaml
@@ -33,7 +33,7 @@ dependencies:
 - uvicorn>=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
-- antlr4-python3-runtime<4.10
+- antlr4-python3-runtime
 - ciso8601
 - fs
 - pip

--- a/continuous_integration/environment-3.10-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk11-dev.yaml
@@ -40,4 +40,5 @@ dependencies:
 - qpd
 - triad
 - pip:
-  - fugue[sql]>=0.5.3
+  # TODO: remove max version constraint when fugue adds back python 3.9+ support
+  - fugue[sql]>=0.5.3,<0.7.0

--- a/continuous_integration/environment-3.10-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk11-dev.yaml
@@ -40,5 +40,5 @@ dependencies:
 - qpd
 - triad
 - pip:
-  # TODO: remove max version constraint when fugue adds back python 3.9+ support
+  # FIXME: tests are failing with fugue 0.7.0
   - fugue[sql]>=0.5.3,<0.7.0

--- a/continuous_integration/environment-3.10-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk8-dev.yaml
@@ -33,7 +33,7 @@ dependencies:
 - uvicorn>=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
-- antlr4-python3-runtime
+- antlr4-python3-runtime<4.10
 - ciso8601
 - fs
 - pip

--- a/continuous_integration/environment-3.10-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk8-dev.yaml
@@ -33,7 +33,7 @@ dependencies:
 - uvicorn>=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
-- antlr4-python3-runtime<4.10
+- antlr4-python3-runtime
 - ciso8601
 - fs
 - pip

--- a/continuous_integration/environment-3.10-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk8-dev.yaml
@@ -40,4 +40,5 @@ dependencies:
 - qpd
 - triad
 - pip:
-  - fugue[sql]>=0.5.3
+  # TODO: remove max version constraint when fugue adds back python 3.9+ support
+  - fugue[sql]>=0.5.3,<0.7.0

--- a/continuous_integration/environment-3.10-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.10-jdk8-dev.yaml
@@ -40,5 +40,5 @@ dependencies:
 - qpd
 - triad
 - pip:
-  # TODO: remove max version constraint when fugue adds back python 3.9+ support
+  # FIXME: tests are failing with fugue 0.7.0
   - fugue[sql]>=0.5.3,<0.7.0

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -3,34 +3,34 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
-- dask-ml>=2022.1.22
-- dask>=2022.3.0
-- fastapi>=0.69.0
-- intake>=0.6.0
-- jpype1>=1.0.2
+- dask-ml=2022.1.22
+- dask=2022.3.0
+- fastapi=0.69.0
+- intake=0.6.0
+- jpype1=1.0.2
 - jsonschema
 - lightgbm
 - maven
 - mlflow
 - mock
 - nest-asyncio
-- openjdk>=11
-- pandas>=1.1.2
+- openjdk=11
+- pandas=1.1.2
 - pre-commit
 - prompt_toolkit
 - psycopg2
-- pyarrow>=3.0.0
+- pyarrow=3.0.0
 - pygments
 - pyhive
 - pytest-cov
 - pytest-xdist
 - pytest
-- python>=3.8
-- scikit-learn>=1.0.0
+- python=3.8
+- scikit-learn=1.0.0
 - sphinx
 - tpot
-- tzlocal>=2.1
-- uvicorn>=0.11.3
+- tzlocal=2.1
+- uvicorn=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
 - antlr4-python3-runtime
@@ -41,4 +41,4 @@ dependencies:
 - qpd>0.2.7
 - triad
 - pip:
-  - fugue[sql]>=0.5.3
+  - fugue[sql]==0.5.3

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -33,12 +33,11 @@ dependencies:
 - uvicorn=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
-- antlr4-python3-runtime
+- antlr4-python3-runtime<4.10
 - ciso8601
 - fs
-- fugue-sql-antlr
 - pip
-- qpd>0.2.7
+- qpd
 - triad
 - pip:
   - fugue[sql]==0.5.3

--- a/continuous_integration/environment-3.8-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.8-jdk11-dev.yaml
@@ -3,41 +3,42 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
-- dask-ml=2022.1.22
-- dask=2022.3.0
-- fastapi=0.69.0
-- intake=0.6.0
-- jpype1=1.0.2
+- dask-ml>=2022.1.22
+- dask>=2022.3.0
+- fastapi>=0.69.0
+- intake>=0.6.0
+- jpype1>=1.0.2
 - jsonschema
 - lightgbm
 - maven
 - mlflow
 - mock
 - nest-asyncio
-- openjdk=11
-- pandas=1.1.2
+- openjdk>=11
+- pandas>=1.1.2
 - pre-commit
 - prompt_toolkit
 - psycopg2
-- pyarrow=3.0.0
+- pyarrow>=3.0.0
 - pygments
 - pyhive
 - pytest-cov
 - pytest-xdist
 - pytest
-- python=3.8
-- scikit-learn=1.0.0
+- python>=3.8
+- scikit-learn>=1.0.0
 - sphinx
 - tpot
-- tzlocal=2.1
-- uvicorn=0.11.3
+- tzlocal>=2.1
+- uvicorn>=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
-- antlr4-python3-runtime<4.10
+- antlr4-python3-runtime
 - ciso8601
 - fs
+- fugue-sql-antlr
 - pip
-- qpd
+- qpd>0.2.7
 - triad
 - pip:
-  - fugue[sql]==0.5.3
+  - fugue[sql]>=0.5.3

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -33,7 +33,7 @@ dependencies:
 - uvicorn>=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
-- antlr4-python3-runtime
+- antlr4-python3-runtime<4.10
 - ciso8601
 - fs
 - pip

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -33,7 +33,7 @@ dependencies:
 - uvicorn>=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
-- antlr4-python3-runtime<4.10
+- antlr4-python3-runtime
 - ciso8601
 - fs
 - pip

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -40,4 +40,5 @@ dependencies:
 - qpd
 - triad
 - pip:
-  - fugue[sql]>=0.5.3
+  # TODO: remove max version constraint when fugue adds back python 3.9+ support
+  - fugue[sql]>=0.5.3,<0.7.0

--- a/continuous_integration/environment-3.9-jdk11-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk11-dev.yaml
@@ -40,5 +40,5 @@ dependencies:
 - qpd
 - triad
 - pip:
-  # TODO: remove max version constraint when fugue adds back python 3.9+ support
+  # FIXME: tests are failing with fugue 0.7.0
   - fugue[sql]>=0.5.3,<0.7.0

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -33,7 +33,7 @@ dependencies:
 - uvicorn>=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
-- antlr4-python3-runtime
+- antlr4-python3-runtime<4.10
 - ciso8601
 - fs
 - pip

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -33,7 +33,7 @@ dependencies:
 - uvicorn>=0.11.3
 # fugue dependencies; remove when we conda install fugue
 - adagio
-- antlr4-python3-runtime<4.10
+- antlr4-python3-runtime
 - ciso8601
 - fs
 - pip

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -40,4 +40,5 @@ dependencies:
 - qpd
 - triad
 - pip:
-  - fugue[sql]>=0.5.3
+  # TODO: remove max version constraint when fugue adds back python 3.9+ support
+  - fugue[sql]>=0.5.3,<0.7.0

--- a/continuous_integration/environment-3.9-jdk8-dev.yaml
+++ b/continuous_integration/environment-3.9-jdk8-dev.yaml
@@ -40,5 +40,5 @@ dependencies:
 - qpd
 - triad
 - pip:
-  # TODO: remove max version constraint when fugue adds back python 3.9+ support
+  # FIXME: tests are failing with fugue 0.7.0
   - fugue[sql]>=0.5.3,<0.7.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - maven>=3.6.0
   - dask>=2022.3.0
   - pandas>=1.1.2
-  # TODO: remove max version constraint when fugue adds back python 3.9+ support
+  # FIXME: tests are failing with fugue 0.7.0
   - fugue>=0.5.3,<0.7.0
   - jpype1>=1.0.2
   - fastapi>=0.69.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,8 @@ dependencies:
   - maven>=3.6.0
   - dask>=2022.3.0
   - pandas>=1.1.2
-  - fugue>=0.5.3
+  # TODO: remove max version constraint when fugue adds back python 3.9+ support
+  - fugue>=0.5.3,<0.7.0
   - jpype1>=1.0.2
   - fastapi>=0.69.0
   - uvicorn>=0.11.3

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -3,7 +3,7 @@ sphinx-tabs
 dask-sphinx-theme>=3.0.0
 dask>=2022.3.0
 pandas>=1.1.2
-# TODO: remove max version constraint when fugue adds back python 3.9+ support
+# FIXME: tests are failing with fugue 0.7.0
 fugue>=0.5.3,<0.7.0
 jpype1>=1.0.2
 fastapi>=0.69.0

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -3,7 +3,8 @@ sphinx-tabs
 dask-sphinx-theme>=3.0.0
 dask>=2022.3.0
 pandas>=1.1.2
-fugue>=0.5.3
+# TODO: remove max version constraint when fugue adds back python 3.9+ support
+fugue>=0.5.3,<0.7.0
 jpype1>=1.0.2
 fastapi>=0.69.0
 uvicorn>=0.11.3

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
             "black==22.3.0",
             "isort==5.7.0",
         ],
-        # TODO: remove max version constraint when fugue adds back python 3.9+ support
+        # FIXME: tests are failing with fugue 0.7.0
         "fugue": ["fugue[sql]>=0.5.3,<0.7.0"],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,8 @@ setup(
             "black==22.3.0",
             "isort==5.7.0",
         ],
-        "fugue": ["fugue[sql]>=0.5.3"],
+        # TODO: remove max version constraint when fugue adds back python 3.9+ support
+        "fugue": ["fugue[sql]>=0.5.3,<0.7.0"],
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
It looks like the recent release of Fugue 0.7.0 has bumped its `qpd` dependency to a version that only has python support up to 3.8. I'm not sure if this is the cause for the recent Fugue-related failures, but it does mean that at least for now, we should constrain to `fugue<0.7.0`, where 3.9+ support is guaranteed.

In the long run, we should probably see what the blockers are to allowing 3.9+ support on `qpd` again, cc @goodwanghan in case you have any additional context to provide here.