### PR TITLE
Bump setuptools-rust from 1.1.1 -> 1.4.1

### DIFF
--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -26,7 +26,7 @@ dependencies:
 - python=3.10
 - rust>=1.60.0
 - scikit-learn>=1.0.0
-- setuptools-rust>=1.1.2
+- setuptools-rust>=1.4.1
 - sphinx
 - tpot
 - tzlocal>=2.1

--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -13,7 +13,7 @@ dependencies:
 - mlflow
 - mock
 - nest-asyncio
-- pandas>=1.1.2
+- pandas>=1.4.0
 - pre-commit
 - prompt_toolkit
 - psycopg2

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -13,7 +13,7 @@ dependencies:
 - mlflow
 - mock
 - nest-asyncio
-- pandas=1.1.2
+- pandas=1.4.0
 - pre-commit
 - prompt_toolkit
 - psycopg2

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -26,7 +26,7 @@ dependencies:
 - python=3.8
 - rust=1.60.0
 - scikit-learn=1.0.0
-- setuptools-rust=1.1.2
+- setuptools-rust=1.4.1
 - sphinx
 - tpot
 - tzlocal=2.1

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -26,7 +26,7 @@ dependencies:
 - python=3.9
 - rust>=1.60.0
 - scikit-learn>=1.0.0
-- setuptools-rust>=1.1.2
+- setuptools-rust>=1.4.1
 - sphinx
 - tpot
 - tzlocal>=2.1

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -13,7 +13,7 @@ dependencies:
 - mlflow
 - mock
 - nest-asyncio
-- pandas>=1.1.2
+- pandas>=1.4.0
 - pre-commit
 - prompt_toolkit
 - psycopg2

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -23,11 +23,11 @@ build:
 requirements:
   build:
     - {{ compiler('rust') }}
-    - setuptools-rust>=1.1.2
+    - setuptools-rust>=1.4.1
   host:
     - pip
     - python >=3.8
-    - setuptools-rust>=1.1.2
+    - setuptools-rust>=1.4.1
   run:
     - python
     - dask >=2022.3.0

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   run:
     - python
     - dask >=2022.3.0
-    - pandas >=1.1.2
+    - pandas >=1.4.0
     - fastapi >=0.69.0
     - uvicorn >=0.11.3
     - tzlocal >=2.1

--- a/docker/conda.txt
+++ b/docker/conda.txt
@@ -1,6 +1,6 @@
 python>=3.8
 dask>=2022.3.0
-pandas>=1.1.2
+pandas>=1.4.0
 jpype1>=1.0.2
 openjdk>=8
 maven>=3.6.0

--- a/docker/conda.txt
+++ b/docker/conda.txt
@@ -22,4 +22,4 @@ intake>=0.6.0
 pre-commit>=2.11.1
 black=22.3.0
 isort=5.7.0
-setuptools-rust>=1.1.2
+setuptools-rust>=1.4.1

--- a/docker/main.dockerfile
+++ b/docker/main.dockerfile
@@ -14,7 +14,7 @@ RUN conda config --add channels conda-forge \
     "prompt_toolkit>=3.0.8" \
     "pygments>=2.7.1" \
     "dask-ml>=2022.1.22" \
-    "setuptools-rust>=1.1.2" \
+    "setuptools-rust>=1.4.1" \
     "scikit-learn>=1.0.0" \
     "intake>=0.6.0" \
     && conda clean -ay

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - sphinx-tabs
   - dask-sphinx-theme>=2.0.3
   - dask>=2022.3.0
-  - pandas>=1.1.2
+  - pandas>=1.4.0
   - fugue>=0.5.3
   - jpype1>=1.0.2
   - fastapi>=0.69.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,5 +18,5 @@ dependencies:
   - pygments
   - tabulate
   - nest-asyncio
-  - setuptools-rust>=1.2.0
+  - setuptools-rust>=1.4.1
   - rust>=1.60.0

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -2,7 +2,7 @@ sphinx>=4.0.0
 sphinx-tabs
 dask-sphinx-theme>=3.0.0
 dask>=2022.3.0
-pandas>=1.1.2
+pandas>=1.4.0
 fugue>=0.5.3
 fastapi>=0.69.0
 uvicorn>=0.11.3

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -11,4 +11,4 @@ prompt_toolkit
 pygments
 tabulate
 nest-asyncio
-setuptools-rust>=1.2.0
+setuptools-rust>=1.4.1

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     setup_requires=sphinx_requirements,
     install_requires=[
         "dask[dataframe,distributed]>=2022.3.0",
-        "pandas>=1.1.2",
+        "pandas>=1.4.0",
         "fastapi>=0.69.0",
         "uvicorn>=0.11.3",
         "tzlocal>=2.1",


### PR DESCRIPTION
Bumping setuptools-rust version to take advantage of some new Rust PyO3 enhancements we can use during our Rust work