### PR TITLE
`COT` function

### DIFF
--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -108,6 +108,11 @@ impl ContextProvider for DaskSQLContext {
             let rtf: ReturnTypeFunction = Arc::new(|_| Ok(Arc::new(DataType::Int64)));
             return Some(Arc::new(ScalarUDF::new("year", &sig, &rtf, &fun)));
         }
+        if "cot".eq(name) {
+            let sig = Signature::variadic(vec![DataType::Float64], Volatility::Immutable);
+            let rtf: ReturnTypeFunction = Arc::new(|_| Ok(Arc::new(DataType::Float64)));
+            return Some(Arc::new(ScalarUDF::new("cot", &sig, &rtf, &fun)));
+        }
 
         // Loop through all of the user defined functions
         for (_schema_name, schema) in &self.schemas {

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -603,14 +603,6 @@ class YearOperation(Operation):
         df = convert_to_datetime(df)
         return df.year
 
-class CotOperation(Operation):
-    def __init__(self):
-        super().__init__(self.do_cot)
-
-    def do_cot(self, df: SeriesOrScalar):
-        df = 1 / np.tan(df)
-        return df
-
 
 class CeilFloorOperation(PredicateBasedOperation):
     """
@@ -951,7 +943,6 @@ class RexCallPlugin(BaseRexPlugin):
         # Temporary UDF functions that need to be moved after this POC
         "datepart": DatePartOperation(),
         "year": YearOperation(),
-        "cot": CotOperation(),
     }
 
     def convert(

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -603,6 +603,14 @@ class YearOperation(Operation):
         df = convert_to_datetime(df)
         return df.year
 
+class CotOperation(Operation):
+    def __init__(self):
+        super().__init__(self.do_cot)
+
+    def do_cot(self, df: SeriesOrScalar):
+        df = 1 / np.tan(df)
+        return df
+
 
 class CeilFloorOperation(PredicateBasedOperation):
     """
@@ -943,6 +951,7 @@ class RexCallPlugin(BaseRexPlugin):
         # Temporary UDF functions that need to be moved after this POC
         "datepart": DatePartOperation(),
         "year": YearOperation(),
+        "cot": CotOperation(),
     }
 
     def convert(

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -333,30 +333,29 @@ def test_math_operations(c, df):
             , ACOS(b) AS "acos"
             , ASIN(b) AS "asin"
             , ATAN(b) AS "atan"
+            -- , ATAN2(a, b) AS "atan2"
+            -- , CBRT(b) AS "cbrt"
             , CEIL(b) AS "ceil"
             , COS(b) AS "cos"
             , COT(b) AS "cot"
+            -- , DEGREES(b) AS "degrees"
             , EXP(b) AS "exp"
             , FLOOR(b) AS "floor"
             , LOG10(b) AS "log10"
             , LN(b) AS "ln"
+            -- , MOD(b, 4) AS "mod"
             , POWER(b, 2) AS "power"
             , POWER(b, a) AS "power2"
+            -- , RADIANS(b) AS "radians"
             , ROUND(b) AS "round"
             , ROUND(b, 3) AS "round2"
+            -- , SIGN(b) AS "sign"
             , SIN(b) AS "sin"
             , TAN(b) AS "tan"
+            -- , TRUNCATE(b) AS "truncate"
         FROM df
     """
     )
-    # TODO: The following functions need to be implemented and tested:
-    # , ATAN2(a, b) AS "atan2"
-    # , CBRT(b) AS "cbrt"
-    # , DEGREES(b) AS "degrees"
-    # , MOD(b, 4) AS "mod"
-    # , RADIANS(b) AS "radians"
-    # , SIGN(b) AS "sign"
-    # , TRUNCATE(b) AS "truncate"
 
     expected_df = pd.DataFrame(index=df.index)
     expected_df["abs"] = df.b.abs()

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -325,7 +325,6 @@ def test_boolean_operations(c):
     assert_eq(df, expected_df)
 
 
-@pytest.mark.skip(reason="WIP DataFusion")
 def test_math_operations(c, df):
     result_df = c.sql(
         """
@@ -334,55 +333,56 @@ def test_math_operations(c, df):
             , ACOS(b) AS "acos"
             , ASIN(b) AS "asin"
             , ATAN(b) AS "atan"
-            , ATAN2(a, b) AS "atan2"
-            , CBRT(b) AS "cbrt"
             , CEIL(b) AS "ceil"
             , COS(b) AS "cos"
             , COT(b) AS "cot"
-            , DEGREES(b) AS "degrees"
             , EXP(b) AS "exp"
             , FLOOR(b) AS "floor"
             , LOG10(b) AS "log10"
             , LN(b) AS "ln"
-            , MOD(b, 4) AS "mod"
             , POWER(b, 2) AS "power"
             , POWER(b, a) AS "power2"
-            , RADIANS(b) AS "radians"
             , ROUND(b) AS "round"
             , ROUND(b, 3) AS "round2"
-            , SIGN(b) AS "sign"
             , SIN(b) AS "sin"
             , TAN(b) AS "tan"
-            , TRUNCATE(b) AS "truncate"
         FROM df
     """
     )
+    # TODO: The following functions need to be implemented and tested:
+    # , ATAN2(a, b) AS "atan2"
+    # , CBRT(b) AS "cbrt"
+    # , DEGREES(b) AS "degrees"
+    # , MOD(b, 4) AS "mod"
+    # , RADIANS(b) AS "radians"
+    # , SIGN(b) AS "sign"
+    # , TRUNCATE(b) AS "truncate"
 
     expected_df = pd.DataFrame(index=df.index)
     expected_df["abs"] = df.b.abs()
     expected_df["acos"] = np.arccos(df.b)
     expected_df["asin"] = np.arcsin(df.b)
     expected_df["atan"] = np.arctan(df.b)
-    expected_df["atan2"] = np.arctan2(df.a, df.b)
-    expected_df["cbrt"] = np.cbrt(df.b)
+    # expected_df["atan2"] = np.arctan2(df.a, df.b)
+    # expected_df["cbrt"] = np.cbrt(df.b)
     expected_df["ceil"] = np.ceil(df.b)
     expected_df["cos"] = np.cos(df.b)
     expected_df["cot"] = 1 / np.tan(df.b)
-    expected_df["degrees"] = df.b / np.pi * 180
+    # expected_df["degrees"] = df.b / np.pi * 180
     expected_df["exp"] = np.exp(df.b)
     expected_df["floor"] = np.floor(df.b)
     expected_df["log10"] = np.log10(df.b)
     expected_df["ln"] = np.log(df.b)
-    expected_df["mod"] = np.mod(df.b, 4)
+    # expected_df["mod"] = np.mod(df.b, 4)
     expected_df["power"] = np.power(df.b, 2)
     expected_df["power2"] = np.power(df.b, df.a)
-    expected_df["radians"] = df.b / 180 * np.pi
+    # expected_df["radians"] = df.b / 180 * np.pi
     expected_df["round"] = np.round(df.b)
     expected_df["round2"] = np.round(df.b, 3)
-    expected_df["sign"] = np.sign(df.b)
+    # expected_df["sign"] = np.sign(df.b)
     expected_df["sin"] = np.sin(df.b)
     expected_df["tan"] = np.tan(df.b)
-    expected_df["truncate"] = np.trunc(df.b)
+    # expected_df["truncate"] = np.trunc(df.b)
     assert_eq(result_df, expected_df)
 
 


### PR DESCRIPTION
Looking at Issue #621 ... the changes so far allow for basic COT functionality with code like:

```
from dask_sql import Context
from dask.distributed import Client

client = Client()
c = Context()

c.sql("""
    SELECT COT(42) AS "the answer"
""", return_futures=False)
```

Mostly just wanting to check that there aren't any obvious issues with how I'm implementing this? Maybe want `da.tan()` instead of numpy?