### PR TITLE
Use `PyErrs` for all Python-facing methods in `dask_planner`

### DIFF
--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -114,7 +114,7 @@ impl PyExpr {
     pub fn subquery_plan(&self) -> PyResult<logical::PyLogicalPlan> {
         match &self.expr {
             Expr::ScalarSubquery(subquery) => Ok((&*subquery.subquery).clone().into()),
-            _ => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+            _ => Err(py_type_err(format!(
                 "Attempted to extract a LogicalPlan instance from invalid Expr {:?}.
                 Only Subquery and related variants are supported for this operation.",
                 &self.expr
@@ -369,7 +369,7 @@ impl PyExpr {
             Expr::ScalarUDF { fun, .. } => Ok(fun.name.clone()),
             Expr::InList { .. } => Ok("in list".to_string()),
             Expr::Negative(..) => Ok("negative".to_string()),
-            _ => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+            _ => Err(py_type_err(format!(
                 "Catch all triggered for get_operator_name: {:?}",
                 &self.expr
             ))),
@@ -647,7 +647,7 @@ impl PyExpr {
             | Expr::Exists { negated, .. }
             | Expr::InList { negated, .. }
             | Expr::InSubquery { negated, .. } => Ok(negated.clone()),
-            _ => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!(
+            _ => Err(py_type_err(format!(
                 "unknown Expr type {:?} encountered",
                 &self.expr
             ))),

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -216,35 +216,40 @@ impl PyExpr {
     /// the Rex conversion
     #[pyo3(name = "getExprType")]
     pub fn get_expr_type(&self) -> PyResult<String> {
-        match &self.expr {
-            Expr::Alias(..) => Ok("Alias".to_string()),
-            Expr::Column(..) => Ok("Column".to_string()),
-            Expr::ScalarVariable(..) => Err(py_type_err("ScalarVariable!!!")),
-            Expr::Literal(..) => Ok("Literal".to_string()),
-            Expr::BinaryExpr { .. } => Ok("BinaryExpr".to_string()),
-            Expr::Not(..) => Err(py_type_err("Not!!!")),
-            Expr::IsNotNull(..) => Err(py_type_err("IsNotNull!!!")),
-            Expr::Negative(..) => Err(py_type_err("Negative!!!")),
-            Expr::GetIndexedField { .. } => Err(py_type_err("GetIndexedField!!!")),
-            Expr::IsNull(..) => Err(py_type_err("IsNull!!!")),
-            Expr::Between { .. } => Ok("Between".to_string()),
-            Expr::Case { .. } => Err(py_type_err("Case!!!")),
-            Expr::Cast { .. } => Ok("Cast".to_string()),
-            Expr::TryCast { .. } => Err(py_type_err("TryCast!!!")),
-            Expr::Sort { .. } => Ok("Sort".to_string()),
-            Expr::ScalarFunction { .. } => Ok("ScalarFunction".to_string()),
-            Expr::AggregateFunction { .. } => Ok("AggregateFunction".to_string()),
-            Expr::WindowFunction { .. } => Err(py_type_err("WindowFunction!!!")),
-            Expr::AggregateUDF { .. } => Err(py_type_err("AggregateUDF!!!")),
-            Expr::InList { .. } => Ok("InList".to_string()),
-            Expr::Wildcard => Err(py_type_err("Wildcard!!!")),
-            Expr::InSubquery { .. } => Ok("Subquery".to_string()),
-            Expr::ScalarUDF { .. } => Ok("ScalarUDF".to_string()),
-            Expr::Exists { .. } => Ok("Exists".to_string()),
-            Expr::ScalarSubquery(..) => Ok("ScalarSubquery".to_string()),
-            Expr::QualifiedWildcard { .. } => Ok("Wildcard".to_string()),
-            Expr::GroupingSet(..) => Ok("GroupingSet".to_string()),
-        }
+        Ok(String::from(match &self.expr {
+            Expr::Alias(..)
+            | Expr::Column(..)
+            | Expr::Literal(..)
+            | Expr::BinaryExpr { .. }
+            | Expr::Between { .. }
+            | Expr::Cast { .. }
+            | Expr::Sort { .. }
+            | Expr::ScalarFunction { .. }
+            | Expr::AggregateFunction { .. }
+            | Expr::InList { .. }
+            | Expr::InSubquery { .. }
+            | Expr::ScalarUDF { .. }
+            | Expr::Exists { .. }
+            | Expr::ScalarSubquery(..)
+            | Expr::QualifiedWildcard { .. }
+            | Expr::GroupingSet(..) => self.expr.variant_name(),
+            Expr::ScalarVariable(..)
+            | Expr::Not(..)
+            | Expr::IsNotNull(..)
+            | Expr::Negative(..)
+            | Expr::GetIndexedField { .. }
+            | Expr::IsNull(..)
+            | Expr::Case { .. }
+            | Expr::TryCast { .. }
+            | Expr::WindowFunction { .. }
+            | Expr::AggregateUDF { .. }
+            | Expr::Wildcard => {
+                return Err(py_type_err(format!(
+                    "Encountered unsupported expression type: {}",
+                    &self.expr.variant_name()
+                )))
+            }
+        }))
     }
 
     /// Determines the type of this Expr based on its variant

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -10,7 +10,7 @@ pub mod types;
 
 use crate::{
     dialect::DaskSqlDialect,
-    sql::exceptions::{OptimizationException, ParsingException},
+    sql::exceptions::{py_optimization_exp, py_parsing_exp, py_runtime_err},
 };
 
 use arrow::datatypes::{DataType, Field, Schema};
@@ -171,7 +171,7 @@ impl DaskSQLContext {
                 schema.add_function(function);
                 Ok(true)
             }
-            None => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+            None => Err(py_runtime_err(format!(
                 "Schema: {} not found in DaskSQLContext",
                 schema_name
             ))),
@@ -189,7 +189,7 @@ impl DaskSQLContext {
                 schema.add_table(table);
                 Ok(true)
             }
-            None => Err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!(
+            None => Err(py_runtime_err(format!(
                 "Schema: {} not found in DaskSQLContext",
                 schema_name
             ))),
@@ -211,7 +211,7 @@ impl DaskSQLContext {
                 );
                 Ok(statements)
             }
-            Err(e) => Err(PyErr::new::<ParsingException, _>(format!("{}", e))),
+            Err(e) => Err(py_parsing_exp(e)),
         }
     }
 
@@ -227,7 +227,7 @@ impl DaskSQLContext {
                 original_plan: k,
                 current_node: None,
             })
-            .map_err(|e| PyErr::new::<ParsingException, _>(format!("{}", e)))
+            .map_err(|e| py_parsing_exp(e))
     }
 
     /// Accepts an existing relational plan, `LogicalPlan`, and optimizes it
@@ -249,13 +249,13 @@ impl DaskSQLContext {
                             original_plan: k,
                             current_node: None,
                         })
-                        .map_err(|e| PyErr::new::<OptimizationException, _>(format!("{}", e)))
+                        .map_err(|e| py_optimization_exp(e))
                 } else {
                     // This LogicalPlan does not support Optimization. Return original
                     Ok(existing_plan)
                 }
             }
-            Err(e) => Err(PyErr::new::<OptimizationException, _>(format!("{}", e))),
+            Err(e) => Err(py_optimization_exp(e)),
         }
     }
 }

--- a/dask_planner/src/sql/exceptions.rs
+++ b/dask_planner/src/sql/exceptions.rs
@@ -1,4 +1,3 @@
-use datafusion_common::DataFusionError;
 use pyo3::{create_exception, PyErr};
 use std::fmt::Debug;
 

--- a/dask_planner/src/sql/exceptions.rs
+++ b/dask_planner/src/sql/exceptions.rs
@@ -12,6 +12,14 @@ pub fn py_type_err(e: impl Debug) -> PyErr {
     PyErr::new::<pyo3::exceptions::PyTypeError, _>(format!("{:?}", e))
 }
 
-pub fn py_runtime_err(e: DataFusionError) -> PyErr {
+pub fn py_runtime_err(e: impl Debug) -> PyErr {
     PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(format!("{:?}", e))
+}
+
+pub fn py_parsing_exp(e: impl Debug) -> PyErr {
+    PyErr::new::<ParsingException, _>(format!("{:?}", e))
+}
+
+pub fn py_optimization_exp(e: impl Debug) -> PyErr {
+    PyErr::new::<OptimizationException, _>(format!("{:?}", e))
 }

--- a/dask_planner/src/sql/logical.rs
+++ b/dask_planner/src/sql/logical.rs
@@ -138,7 +138,7 @@ impl PyLogicalPlan {
     pub fn table(&mut self) -> PyResult<table::DaskTable> {
         match table::table_from_logical_plan(&self.current_node()) {
             Some(table) => Ok(table),
-            None => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            None => Err(py_type_err(
                 "Unable to compute DaskTable from DataFusion LogicalPlan",
             )),
         }
@@ -163,9 +163,7 @@ impl PyLogicalPlan {
     pub fn get_current_node_table_name(&mut self) -> PyResult<String> {
         match self.table() {
             Ok(dask_table) => Ok(dask_table.name),
-            Err(_e) => Err(PyErr::new::<pyo3::exceptions::PyTypeError, _>(
-                "Unable to determine current node table name",
-            )),
+            Err(_e) => Err(py_type_err("Unable to determine current node table name")),
         }
     }
 

--- a/dask_planner/src/sql/logical/aggregate.rs
+++ b/dask_planner/src/sql/logical/aggregate.rs
@@ -19,7 +19,9 @@ impl PyAggregate {
     pub fn distinct_columns(&self) -> PyResult<Vec<String>> {
         match &self.distinct {
             Some(e) => Ok(e.input.schema().field_names()),
-            None => panic!("distinct_columns invoked for non distinct instance"),
+            None => Err(py_type_err(
+                "distinct_columns invoked for non distinct instance",
+            )),
         }
     }
 
@@ -42,10 +44,12 @@ impl PyAggregate {
 
     #[pyo3(name = "getAggregationFuncName")]
     pub fn agg_func_name(&self, expr: PyExpr) -> PyResult<String> {
-        Ok(match expr.expr {
-            Expr::AggregateFunction { fun, .. } => fun.to_string(),
-            _ => panic!("Encountered a non Aggregate type in agg_func_name"),
-        })
+        match expr.expr {
+            Expr::AggregateFunction { fun, .. } => Ok(fun.to_string()),
+            _ => Err(py_type_err(
+                "Encountered a non Aggregate type in agg_func_name",
+            )),
+        }
     }
 
     #[pyo3(name = "getArgs")]
@@ -55,7 +59,9 @@ impl PyAggregate {
                 Some(e) => py_expr_list(&e.input, &args),
                 None => Ok(vec![]),
             },
-            _ => panic!("Encountered a non Aggregate type in agg_func_name"),
+            _ => Err(py_type_err(
+                "Encountered a non Aggregate type in agg_func_name",
+            )),
         }
     }
 

--- a/dask_planner/src/sql/logical/join.rs
+++ b/dask_planner/src/sql/logical/join.rs
@@ -49,12 +49,20 @@ impl PyJoin {
     pub fn join_conditions(&mut self) -> PyResult<Vec<(column::PyColumn, column::PyColumn)>> {
         let lhs_table_name: String = match &*self.join.left {
             LogicalPlan::TableScan(scan) => scan.table_name.clone(),
-            _ => panic!("lhs Expected TableScan but something else was received!"),
+            _ => {
+                return Err(py_type_err(
+                    "lhs Expected TableScan but something else was received!",
+                ))
+            }
         };
 
         let rhs_table_name: String = match &*self.join.right {
             LogicalPlan::TableScan(scan) => scan.table_name.clone(),
-            _ => panic!("rhs Expected TableScan but something else was received!"),
+            _ => {
+                return Err(py_type_err(
+                    "rhs Expected TableScan but something else was received!",
+                ))
+            }
         };
 
         let mut join_conditions: Vec<(column::PyColumn, column::PyColumn)> = Vec::new();

--- a/dask_planner/src/sql/types.rs
+++ b/dask_planner/src/sql/types.rs
@@ -109,10 +109,7 @@ impl DaskTypeMap {
                 };
                 DataType::Timestamp(unit, tz)
             }
-            _ => {
-                // panic!("stop here");
-                sql_type.to_arrow()
-            }
+            _ => sql_type.to_arrow(),
         };
 
         DaskTypeMap {


### PR DESCRIPTION
As a follow up on reviews I received in #656, this PR replaces the `panic` calls within Python-facing methods in `dask_planner` and replaces them with `Err(PyErr))`, making modifications to signatures and logic where necessary to get this working.

This PR also adds/modifies the custom exceptions so that they can be used throughout the codebase instead of `PyErr::new`.