### PR TITLE
Update CodeCov upload step in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,10 +126,7 @@ jobs:
           path: junit/test-results.xml
       - name: Upload coverage to Codecov
         if: github.repository == 'dask-contrib/dask-sql'
-        uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+        uses: codecov/codecov-action@v3
 
   cluster:
     name: "Test in a dask cluster"


### PR DESCRIPTION
A couple changes to our CodeCov upload step in CI:

- Bumps the action to the latest stable version
- Removes the `token` param, which shouldn't be necessary for public repos (and doesn't save us from unexpected 404 errors)
- Removes the non-default setting for `fail_ci_if_error` so that if are unable to upload the report for some reason it won't register tests as failing