### PR TITLE
Always raise error for duplicate UDF names if `replace=False`

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -909,19 +909,17 @@ class Context:
             f = UDF(f, row_udf, parameters, return_type)
         lower_name = name.lower()
         if lower_name in schema.functions:
-            if replace:
-                schema.function_lists = list(
-                    filter(
-                        lambda f: f.name.lower() != lower_name,
-                        schema.function_lists,
-                    )
-                )
-                del schema.functions[lower_name]
-
-            elif schema.functions[lower_name] != f:
+            if not replace:
                 raise ValueError(
                     "Registering multiple functions with the same name is only permitted if replace=True"
                 )
+            schema.function_lists = list(
+                filter(
+                    lambda f: f.name.lower() != lower_name,
+                    schema.function_lists,
+                )
+            )
+            del schema.functions[lower_name]
 
         schema.function_lists.append(
             FunctionDescription(
@@ -930,7 +928,7 @@ class Context:
         )
         schema.function_lists.append(
             FunctionDescription(
-                name.lower(), sql_parameters, sql_return_type, aggregation
+                lower_name, sql_parameters, sql_return_type, aggregation
             )
         )
         schema.functions[lower_name] = f

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -220,11 +220,6 @@ class UDF:
             result = self.func(*args, **kwargs)
         return result
 
-    def __eq__(self, other):
-        if isinstance(other, UDF):
-            return self.func == other.func and self.row_udf == other.row_udf
-        return NotImplemented
-
     def __hash__(self):
         return (self.func, self.row_udf).__hash__()
 


### PR DESCRIPTION
Currently, `register_function` has unexpected behavior when attempting to register a `UDF` with an identical name, `func`, and `row_udf` but different input/output types with `replace=False`, with the schema's list of `FunctionDescriptions` getting updated with `FunctionDescriptions` of the new function but keeping those of the old one. This doesn't have an impact on main, but breaks things in the datafusion branch where additional function registration has to happen on the Rust end.

This PR makes it so we immediately raise an error if we see that the user is attempting to register a function that already exists with `replace=False`, rather than doing an equality check on the function, which IMO can cause issues if we add more attributes to the `UDF` object that need to be inspected; this should also open up a path in the datafusion branch to update the UDF replace logic to handle function registration in Rust.