### PR TITLE
Correlated subqueries

### DIFF
--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -133,7 +133,13 @@ class ReduceOperation(Operation):
                 )
             ):
                 operands = tuple(map(as_timelike, operands))
-            return reduce(partial(self.operation, **kwargs), operands)
+            try:
+                return reduce(partial(self.operation, **kwargs), operands)
+            except ValueError:
+                return reduce(
+                    partial(self.operation, **kwargs),
+                    (operands[0], float(operands[1][operands[1].columns[0]].loc[0].compute()))
+                )
         else:
             return self.unary_operation(*operands, **kwargs)
 


### PR DESCRIPTION
Previously, we would get a `ValueError: Not all divisions are known, can't align partitions. Please use set_index to set the index.` for something like:

```
from dask_sql import Context
import dask.dataframe as dd
import pandas as pd

c = Context()

names = ["Miracle", "Sunshine", "Pretty woman", "Handsome man", "Barbie", "Cool painting", "Black square #1000", "Mountains"]
prices = [300, 700, 2800, 2300, 250, 5000, 50, 1300]
ids = [11, 12, 13, 14, 15, 16, 17, 18]
artist_id = [1, 1, 2, 2, 3, 3, 3, 4]
paintings = dd.from_pandas(pd.DataFrame({"id": ids, "name": names, "artist_id": artist_id, "listed_price": prices}), npartitions=1)
c.create_table("paintings", paintings)

sql1 = """
SELECT name, listed_price
FROM paintings
WHERE listed_price > (
    SELECT AVG(listed_price)
    FROM paintings
)
"""
c.sql(sql1).compute()
```

Not sure if this is the way we should go about this (not generalizable enough?), but here is an initial quick fix for that example. The general idea is that since we are comparing `listed_price` to a 1x1 table containing `AVG(listed_price)`, the latter has to be converted to a single value by calling `compute()` and with casting.