### PR TITLE
Use `compiler` function in nightly recipe, pin to Rust 1.62.1

### DIFF
--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -25,7 +25,7 @@ dependencies:
 - pytest-xdist
 - pytest
 - python=3.10
-- rust>=1.62.1
+- rust=1.62.1
 - scikit-learn>=1.0.0
 - setuptools-rust>=1.4.1
 - sphinx

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -25,7 +25,7 @@ dependencies:
 - pytest-xdist
 - pytest
 - python=3.9
-- rust>=1.62.1
+- rust=1.62.1
 - scikit-learn>=1.0.0
 - setuptools-rust>=1.4.1
 - sphinx

--- a/continuous_integration/recipe/conda_build_config.yaml
+++ b/continuous_integration/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+rust_version:
+    - 1.62.1

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -22,7 +22,7 @@ build:
 
 requirements:
   build:
-    - rust>=1.62.1
+    - {{ compiler('rust') }}
     - setuptools-rust>=1.4.1
   host:
     - pip


### PR DESCRIPTION
- switches back to using the `compiler` function to set our Rust build requirement, which should be unblocked with https://github.com/conda-forge/rust-activation-feedstock/pull/22 in
- specifies the Rust build requirement with a conda build config file, as suggested by @jakirkham 
- pins our CI to this Rust version (1.62.1) to match with the nightly builds