### PR TITLE
Refactor LIMIT computation to always use `head` when possible

### DIFF
--- a/dask_sql/physical/rel/logical/limit.py
+++ b/dask_sql/physical/rel/logical/limit.py
@@ -60,10 +60,11 @@ class DaskLimitPlugin(BaseRelPlugin):
             if dask_config.get("sql.limit.check-partitions"):
                 partition_borders = partition_borders.compute()
                 nrows = 0
-                for i, n in enumerate(partition_borders):
+                npartitions = 0
+                for n in partition_borders:
                     nrows += n
+                    npartitions += 1
                     if end <= nrows:
-                        npartitions = i + 1
                         break
             else:
                 npartitions = -1

--- a/dask_sql/sql-schema.yaml
+++ b/dask_sql/sql-schema.yaml
@@ -27,6 +27,18 @@ properties:
             description: |
               Whether sql identifiers are considered case sensitive while parsing.
 
+      limit:
+        type: object
+        properties:
+
+          check-partitions:
+            type: boolean
+            description: |
+              Whether or not to check partition length when computing a LIMIT without an OFFSET;
+              checking partition length triggers a Dask graph computation which can be slow for
+              complex queries, but can signicantly reduce memory usage when querying a small subset
+              of a large table. Default is ``true``.
+
       predicate_pushdown:
         type: boolean
         description: |

--- a/dask_sql/sql-schema.yaml
+++ b/dask_sql/sql-schema.yaml
@@ -31,13 +31,14 @@ properties:
         type: object
         properties:
 
-          check-partitions:
+          check-first-partition:
             type: boolean
             description: |
-              Whether or not to check partition length when computing a LIMIT without an OFFSET;
-              checking partition length triggers a Dask graph computation which can be slow for
-              complex queries, but can signicantly reduce memory usage when querying a small subset
-              of a large table. Default is ``true``.
+              Whether or not to check the first partition length when computing a LIMIT without an OFFSET
+              on a table with a relatively simple Dask graph (i.e. only IO and/or partition-wise layers);
+              checking partition length triggers a Dask graph computation which can be slow for complex
+              queries, but can signicantly reduce memory usage when querying a small subset of a large
+              table. Default is ``true``.
 
       predicate_pushdown:
         type: boolean

--- a/dask_sql/sql.yaml
+++ b/dask_sql/sql.yaml
@@ -7,6 +7,6 @@ sql:
     case_sensitive: True
 
   limit:
-    check-partitions: True
+    check-first-partition: True
 
   predicate_pushdown: True

--- a/dask_sql/sql.yaml
+++ b/dask_sql/sql.yaml
@@ -6,4 +6,7 @@ sql:
   identifier:
     case_sensitive: True
 
+  limit:
+    check-partitions: True
+
   predicate_pushdown: True


### PR DESCRIPTION
Takes @sarahyurick's suggestion to use `map_partitions` to compute partition lengths in our LIMIT check, which should allow us to always use `head` to compute a LIMIT when no OFFSET is specified.

Also added in a configuration variable to control whether or not we actually compute this `map_partitions` call, which we may or may not want depending on query complexity and table size.

Closes #686 