### PR TITLE
Don't check order for filtered groupby test

### DIFF
--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -109,7 +109,7 @@ def test_group_by_filtered(c):
         },
     )
 
-    assert_eq(return_df, expected_df)
+    assert_eq(return_df, expected_df, check_index=False)
 
     return_df = c.sql(
         """


### PR DESCRIPTION
Looks like changes in Dask have made the ordering of one of the results in `test_group_by_filtered` different, causing failures - this PR adds `check_index=False` to the relevant assertion, since maintaining a sorted ordering for groupbys wasn't a guarantee to begin with.

Perhaps it would be worth thinking about if we want to make this a default kwarg for our `assert_eq` shim, considering we aren't concerned with ordering unless something like an `ORDER BY` statement is being tested (cc @ayushdg).

Closes #701