### PR TITLE
Relax `test_groupby_split_every` key check

### DIFF
--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -390,18 +390,8 @@ def test_groupby_split_out(c, input_table, split_out, request):
     assert_eq(return_df.sort_values("user_id"), expected_df, check_index=False)
 
 
-@pytest.mark.parametrize(
-    "gpu,split_every,expected_keys",
-    [
-        (False, 2, 74),
-        (False, 3, 68),
-        (False, 4, 64),
-        pytest.param(True, 2, 107, marks=pytest.mark.gpu),
-        pytest.param(True, 3, 101, marks=pytest.mark.gpu),
-        pytest.param(True, 4, 97, marks=pytest.mark.gpu),
-    ],
-)
-def test_groupby_split_every(c, gpu, split_every, expected_keys):
+@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
+def test_groupby_split_every(c, gpu):
     input_ddf = dd.from_pandas(
         pd.DataFrame({"user_id": [1, 2, 3, 4] * 16, "b": [5, 6, 7, 8] * 16}),
         npartitions=16,
@@ -409,24 +399,67 @@ def test_groupby_split_every(c, gpu, split_every, expected_keys):
 
     c.create_table("split_every_input", input_ddf, gpu=gpu)
 
-    return_df = c.sql(
-        """
-        SELECT
+    query_string = """
+    SELECT
         user_id, SUM(b) AS "S"
-        FROM split_every_input
-        GROUP BY user_id
-        """,
-        config_options={"sql.groupby.split_every": split_every},
+    FROM split_every_input
+    GROUP BY user_id
+    """
+    split_every_2_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 2},
     )
+    split_every_3_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 3},
+    )
+    split_every_4_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 4},
+    )
+
     expected_df = (
         input_ddf.groupby(by="user_id")
-        .agg({"b": "sum"}, split_every=split_every)
+        .agg({"b": "sum"})
         .reset_index(drop=False)
         .rename(columns={"b": "S"})
         .sort_values("user_id")
     )
+    assert (
+        len(split_every_2_df.dask.keys())
+        >= len(split_every_3_df.dask.keys())
+        >= len(split_every_4_df.dask.keys())
+    )
 
-    assert len(return_df.dask.keys()) == expected_keys
-    assert_eq(return_df, expected_df, check_index=False)
+    assert_eq(split_every_2_df, expected_df, check_index=False)
+    assert_eq(split_every_3_df, expected_df, check_index=False)
+    assert_eq(split_every_4_df, expected_df, check_index=False)
+
+    query_string = """
+    SELECT DISTINCT(user_id) FROM split_every_input
+    """
+    split_every_2_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 2},
+    )
+    split_every_3_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 3},
+    )
+    split_every_4_df = c.sql(
+        query_string,
+        config_options={"sql.aggregate.split_every": 4},
+    )
+
+    expected_df = input_ddf[["user_id"]].drop_duplicates()
+
+    assert (
+        len(split_every_2_df.dask.keys())
+        >= len(split_every_3_df.dask.keys())
+        >= len(split_every_4_df.dask.keys())
+    )
+    assert_eq(split_every_2_df, expected_df, check_index=False)
+    assert_eq(split_every_3_df, expected_df, check_index=False)
+    assert_eq(split_every_4_df, expected_df, check_index=False)
 
     c.drop_table("split_every_input")


### PR DESCRIPTION
This PR just applies @ayushdg's changes to `test_groupby_split_every` in the datafusion branch to `main`, which should circumvent any upstream breakage that would have occurred as a result of https://github.com/rapidsai/cudf/pull/11571.

cc @rjzamora 