### PR TITLE
[DF] Add support for `CREATE [OR REPLACE] TABLE [IF NOT EXISTS] WITH`

### DIFF
--- a/dask_planner/src/parser.rs
+++ b/dask_planner/src/parser.rs
@@ -358,7 +358,7 @@ impl<'a> DaskParser<'a> {
         Ok(DaskStatement::CreateModel(Box::new(create)))
     }
 
-    /// Parse Dask-SQL CREATE TABLE ... WITH statement
+    /// Parse Dask-SQL CREATE [OR REPLACE] TABLE ... statement
     fn parse_create_table(&mut self, or_replace: bool) -> Result<DaskStatement, ParserError> {
         // parse [IF NOT EXISTS] `table_name` AS|WITH
         let if_not_exists =

--- a/dask_planner/src/parser.rs
+++ b/dask_planner/src/parser.rs
@@ -382,7 +382,7 @@ impl<'a> DaskParser<'a> {
                             self.parser.parse_create_table(or_replace, false, None)?,
                         )))
                     }
-                    _ => {
+                    "with" => {
                         // `table_name` has been parsed at this point but is needed in `parse_table_factor`, reset consumption
                         self.parser.prev_token();
 
@@ -400,10 +400,17 @@ impl<'a> DaskParser<'a> {
                         };
                         Ok(DaskStatement::CreateTable(Box::new(create)))
                     }
+                    _ => self.expected("'as' or 'with'", self.parser.peek_token()),
                 }
             }
             _ => {
                 self.parser.prev_token();
+                if if_not_exists {
+                    // Go back three tokens if IF NOT EXISTS was consumed
+                    self.parser.prev_token();
+                    self.parser.prev_token();
+                    self.parser.prev_token();
+                }
                 // use the native parser
                 Ok(DaskStatement::Statement(Box::from(
                     self.parser.parse_create_table(or_replace, false, None)?,

--- a/dask_planner/src/parser.rs
+++ b/dask_planner/src/parser.rs
@@ -36,6 +36,10 @@ pub struct CreateTable {
     pub table_schema: String,
     /// table name
     pub name: String,
+    /// if not exists
+    pub if_not_exists: bool,
+    /// or replace
+    pub or_replace: bool,
     /// with options
     pub with_options: Vec<Expr>,
 }
@@ -356,15 +360,24 @@ impl<'a> DaskParser<'a> {
 
     /// Parse Dask-SQL CREATE TABLE ... WITH statement
     fn parse_create_table(&mut self, or_replace: bool) -> Result<DaskStatement, ParserError> {
-        // Parser's current position is at `table_name`, peek if rest of statement contains an `AS`
-        let _table_name = self.parser.parse_identifier(); // `table_name`
-        let after_name_token = self.parser.peek_token(); // Token following `table_name`
+        // parse [IF NOT EXISTS] `table_name` AS|WITH
+        let if_not_exists =
+            self.parser
+                .parse_keywords(&[Keyword::IF, Keyword::NOT, Keyword::EXISTS]);
+        let _table_name = self.parser.parse_identifier();
+        let after_name_token = self.parser.peek_token();
 
         match after_name_token {
             Token::Word(w) => {
                 match w.value.to_lowercase().as_str() {
                     "as" => {
                         self.parser.prev_token();
+                        if if_not_exists {
+                            // Go back three tokens if IF NOT EXISTS was consumed
+                            self.parser.prev_token();
+                            self.parser.prev_token();
+                            self.parser.prev_token();
+                        }
                         Ok(DaskStatement::Statement(Box::from(
                             self.parser.parse_create_table(or_replace, false, None)?,
                         )))
@@ -381,6 +394,8 @@ impl<'a> DaskParser<'a> {
                         let create = CreateTable {
                             table_schema: tbl_schema,
                             name: tbl_name,
+                            if_not_exists,
+                            or_replace,
                             with_options,
                         };
                         Ok(DaskStatement::CreateTable(Box::new(create)))

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -318,6 +318,8 @@ impl DaskSQLContext {
                     schema: Arc::new(DFSchema::empty()),
                     table_schema: create_table.table_schema,
                     table_name: create_table.name,
+                    if_not_exists: create_table.if_not_exists,
+                    or_replace: create_table.or_replace,
                     with_options: create_table.with_options,
                 }),
             })),

--- a/dask_planner/src/sql/logical/create_table.rs
+++ b/dask_planner/src/sql/logical/create_table.rs
@@ -17,6 +17,8 @@ pub struct CreateTablePlanNode {
     pub schema: DFSchemaRef,
     pub table_schema: String, // "something" in `something.table_name`
     pub table_name: String,
+    pub if_not_exists: bool,
+    pub or_replace: bool,
     pub with_options: Vec<SqlParserExpr>,
 }
 
@@ -59,6 +61,8 @@ impl UserDefinedLogicalNode for CreateTablePlanNode {
             schema: Arc::new(DFSchema::empty()),
             table_schema: self.table_schema.clone(),
             table_name: self.table_name.clone(),
+            if_not_exists: self.if_not_exists,
+            or_replace: self.or_replace,
             with_options: self.with_options.clone(),
         })
     }
@@ -74,6 +78,16 @@ impl PyCreateTable {
     #[pyo3(name = "getTableName")]
     fn get_table_name(&self) -> PyResult<String> {
         Ok(self.create_table.table_name.clone())
+    }
+
+    #[pyo3(name = "getIfNotExists")]
+    fn get_if_not_exists(&self) -> PyResult<bool> {
+        Ok(self.create_table.if_not_exists)
+    }
+
+    #[pyo3(name = "getOrReplace")]
+    fn get_or_replace(&self) -> PyResult<bool> {
+        Ok(self.create_table.or_replace)
     }
 
     #[pyo3(name = "getSQLWithOptions")]

--- a/dask_sql/physical/rel/custom/create_table.py
+++ b/dask_sql/physical/rel/custom/create_table.py
@@ -47,7 +47,7 @@ class CreateTablePlugin(BaseRelPlugin):
         if table_name in context.schema[schema_name].tables:
             if create_table.getIfNotExists():
                 return
-            elif not create_table.getReplace():
+            elif not create_table.getOrReplace():
                 raise RuntimeError(
                     f"A table with the name {table_name} is already present."
                 )

--- a/tests/integration/test_create.py
+++ b/tests/integration/test_create.py
@@ -153,7 +153,6 @@ def test_create_from_query(c, df):
     assert_eq(df, return_df)
 
 
-@pytest.mark.skip(reason="WIP DataFusion")
 @pytest.mark.parametrize(
     "gpu",
     [
@@ -217,7 +216,6 @@ def test_view_table_persist(c, temporary_data_file, df, gpu):
     assert_eq(from_table, pd.DataFrame({"c": [700]}))
 
 
-@pytest.mark.skip(reason="WIP DataFusion")
 def test_replace_and_error(c, temporary_data_file, df):
     c.sql(
         """


### PR DESCRIPTION
Updates the custom parsing logic for `CREATE TABLE WITH` statements to support `IF NOT EXISTS` and `OR REPLACE`; we could probably do the same for `CREATE MODEL`, not sure if we want to do this now or wait until we start rewriting the Python plugin.