### PR TITLE
Support all boolean operations

### DIFF
--- a/dask_planner/Cargo.toml
+++ b/dask_planner/Cargo.toml
@@ -13,10 +13,10 @@ tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"
 rand = "0.7"
 pyo3 = { version = "0.16.5", features = ["extension-module", "abi3", "abi3-py38"] }
 arrow = { version = "20.0.0", features = ["prettyprint"] }
-datafusion-sql = { git="https://github.com/apache/arrow-datafusion/", rev = "e1d4069de9d2aaf85655edd72744f176431c03d3" }
-datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "e1d4069de9d2aaf85655edd72744f176431c03d3" }
-datafusion-common = { git="https://github.com/apache/arrow-datafusion/", rev = "e1d4069de9d2aaf85655edd72744f176431c03d3" }
-datafusion-optimizer = { git="https://github.com/apache/arrow-datafusion/", rev = "e1d4069de9d2aaf85655edd72744f176431c03d3" }
+datafusion-sql = { git="https://github.com/apache/arrow-datafusion/", rev = "51498ca5ed2bafb39abf208c5b74f40ec17c57aa" }
+datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "51498ca5ed2bafb39abf208c5b74f40ec17c57aa" }
+datafusion-common = { git="https://github.com/apache/arrow-datafusion/", rev = "51498ca5ed2bafb39abf208c5b74f40ec17c57aa" }
+datafusion-optimizer = { git="https://github.com/apache/arrow-datafusion/", rev = "51498ca5ed2bafb39abf208c5b74f40ec17c57aa" }
 uuid = { version = "0.8", features = ["v4"] }
 mimalloc = { version = "*", default-features = false }
 parking_lot = "0.12"

--- a/dask_planner/Cargo.toml
+++ b/dask_planner/Cargo.toml
@@ -13,10 +13,10 @@ tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"
 rand = "0.7"
 pyo3 = { version = "0.16.5", features = ["extension-module", "abi3", "abi3-py38"] }
 arrow = { version = "20.0.0", features = ["prettyprint"] }
-datafusion-sql = { git="https://github.com/apache/arrow-datafusion/", rev = "51498ca5ed2bafb39abf208c5b74f40ec17c57aa" }
-datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "51498ca5ed2bafb39abf208c5b74f40ec17c57aa" }
-datafusion-common = { git="https://github.com/apache/arrow-datafusion/", rev = "51498ca5ed2bafb39abf208c5b74f40ec17c57aa" }
-datafusion-optimizer = { git="https://github.com/apache/arrow-datafusion/", rev = "51498ca5ed2bafb39abf208c5b74f40ec17c57aa" }
+datafusion-sql = { git="https://github.com/apache/arrow-datafusion/", rev = "6c32098a7cb8685b9a9c644dfdaeb5f102076b42" }
+datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "6c32098a7cb8685b9a9c644dfdaeb5f102076b42" }
+datafusion-common = { git="https://github.com/apache/arrow-datafusion/", rev = "6c32098a7cb8685b9a9c644dfdaeb5f102076b42" }
+datafusion-optimizer = { git="https://github.com/apache/arrow-datafusion/", rev = "6c32098a7cb8685b9a9c644dfdaeb5f102076b42" }
 uuid = { version = "0.8", features = ["v4"] }
 mimalloc = { version = "*", default-features = false }
 parking_lot = "0.12"

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -625,7 +625,7 @@ impl PyExpr {
     pub fn bool_value(&mut self) -> PyResult<bool> {
         match &self.expr {
             Expr::Literal(scalar_value) => match scalar_value {
-                ScalarValue::Boolean(iv) => Ok(iv.unwrap()),
+                ScalarValue::Boolean(Some(iv)) => Ok(*iv),
                 _ => Err(py_type_err("getValue<T>() - Unexpected value")),
             },
             _ => Err(py_type_err("getValue<T>() - Non literal value encountered")),

--- a/dask_sql/physical/rex/core/literal.py
+++ b/dask_sql/physical/rex/core/literal.py
@@ -101,8 +101,12 @@ class RexLiteralPlugin(BaseRexPlugin):
         # Call the Rust function to get the actual value and convert the Rust
         # type name back to a SQL type
         if literal_type == "Boolean":
-            literal_type = SqlTypeName.BOOLEAN
-            literal_value = rex.getBoolValue()
+            try:
+                literal_type = SqlTypeName.BOOLEAN
+                literal_value = rex.getBoolValue()
+            except TypeError:
+                literal_type = SqlTypeName.NULL
+                literal_value = None
         elif literal_type == "Float32":
             literal_type = SqlTypeName.FLOAT
             literal_value = rex.getFloat32Value()

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -322,9 +322,6 @@ def test_null(c):
     assert_eq(df, expected_df)
 
 
-@pytest.mark.skip(
-    reason="isTrue/False not supported by datafusion, isUnknown not supported by sqlparser"
-)
 def test_boolean_operations(c):
     df = dd.from_pandas(pd.DataFrame({"b": [1, 0, -1]}), npartitions=1)
     df["b"] = df["b"].apply(
@@ -337,8 +334,8 @@ def test_boolean_operations(c):
         SELECT
             b IS TRUE AS t,
             b IS FALSE AS f,
-            b IS NOT TRUE AS nt,
-            b IS NOT FALSE AS nf,
+            -- b IS NOT TRUE AS nt,
+            -- b IS NOT FALSE AS nf,
             b IS UNKNOWN AS u,
             b IS NOT UNKNOWN AS nu
         FROM df"""
@@ -348,15 +345,15 @@ def test_boolean_operations(c):
         {
             "t": [True, False, False],
             "f": [False, True, False],
-            "nt": [False, True, True],
-            "nf": [True, False, True],
+            # "nt": [False, True, True],
+            # "nf": [True, False, True],
             "u": [False, False, True],
             "nu": [True, True, False],
         },
         dtype="bool",
     )
-    expected_df["nt"] = expected_df["nt"].astype("boolean")
-    expected_df["nf"] = expected_df["nf"].astype("boolean")
+    # expected_df["nt"] = expected_df["nt"].astype("boolean")
+    # expected_df["nf"] = expected_df["nf"].astype("boolean")
     expected_df["nu"] = expected_df["nu"].astype("boolean")
     assert_eq(df, expected_df)
 

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -334,8 +334,8 @@ def test_boolean_operations(c):
         SELECT
             b IS TRUE AS t,
             b IS FALSE AS f,
-            -- b IS NOT TRUE AS nt,
-            -- b IS NOT FALSE AS nf,
+            b IS NOT TRUE AS nt,
+            b IS NOT FALSE AS nf,
             b IS UNKNOWN AS u,
             b IS NOT UNKNOWN AS nu
         FROM df"""
@@ -345,15 +345,15 @@ def test_boolean_operations(c):
         {
             "t": [True, False, False],
             "f": [False, True, False],
-            # "nt": [False, True, True],
-            # "nf": [True, False, True],
+            "nt": [False, True, True],
+            "nf": [True, False, True],
             "u": [False, False, True],
             "nu": [True, True, False],
         },
         dtype="bool",
     )
-    # expected_df["nt"] = expected_df["nt"].astype("boolean")
-    # expected_df["nf"] = expected_df["nf"].astype("boolean")
+    expected_df["nt"] = expected_df["nt"].astype("boolean")
+    expected_df["nf"] = expected_df["nf"].astype("boolean")
     expected_df["nu"] = expected_df["nu"].astype("boolean")
     assert_eq(df, expected_df)
 


### PR DESCRIPTION
With the recent updates to DataFusion and minor Dask SQL changes, "IS TRUE/FALSE" and "IS [NOT] UNKNOWN" are functional.

"IS NOT TRUE" and "IS NOT FALSE" should be functional once https://github.com/apache/arrow-datafusion/pull/3252 is merged.

UPDATE: As long as all checks pass, this should be ready to merge.