### PR TITLE
Update gpuCI environment file, updating workflow

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -57,10 +57,18 @@ jobs:
       - name: Update RAPIDS version
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          include: 'continuous_integration\/gpuci\/axis\.yaml'
+          include: 'continuous_integration/gpuci/**'
           find: "${{ env.RAPIDS_VER }}"
           replace: "${{ env.NEW_CUDF_VER }}"
-          regex: false
+          regex: true
+
+      - name: Update UCX-Py version
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          include: 'continuous_integration/gpuci/**'
+          find: "${{ env.UCX_PY_VER }}"
+          replace: "${{ env.NEW_UCX_PY_VER }}"
+          regex: true
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -79,4 +87,4 @@ jobs:
           body: |
             New cuDF and ucx-py nightly versions have been detected.
 
-            Updated `axis.yaml` to use `${{ env.NEW_CUDF_VER }}`.
+            Updated gpuCI to use RAPIDS ${{ env.NEW_CUDF_VER }} and UCX-Py ${{ env.NEW_UCX_PY_VER }}.

--- a/continuous_integration/gpuci/environment.yaml
+++ b/continuous_integration/gpuci/environment.yaml
@@ -1,17 +1,47 @@
-name: gpuci
+name: dask-sql
 channels:
   - rapidsai
   - rapidsai-nightly
   - nvidia
+  - conda-forge
+  - nodefaults
 dependencies:
-  - rust>=1.60.0
-  - setuptools-rust>=1.2.0
+  - dask-ml=2022.1.22
+  - dask=2022.3.0
+  - fastapi=0.69.0
+  - fugue=0.7.0
+  - intake=0.6.0
+  - jpype1=1.0.2
+  - jsonschema
+  - lightgbm
+  - maven
+  - mlflow
+  - mock
+  - nest-asyncio
+  - openjdk=11
+  - pandas=1.1.2
+  - pre-commit
+  - prompt_toolkit
+  - psycopg2
+  - pyarrow=6.0.1
+  - pygments
+  - pyhive
+  - pytest-cov
+  - pytest-xdist
+  - pytest
+  - python=3.8
+  - scikit-learn=1.0.0
+  - sphinx
+  - tpot
+  - tzlocal=2.1
+  - uvicorn=0.11.3
+  # GPU-specific requirements
   - cudatoolkit=11.5
-  - cudf=22.08
-  - cuml=22.08
-  - dask-cudf=22.08
-  - dask-cuda=22.08
-  - numpy>=1.20.0
+  - cudf=22.10
+  - cuml=22.10
+  - dask-cudf=22.10
+  - dask-cuda=22.10
+  - numpy>=1.20.1
   - ucx-proc=*=gpu
-  - ucx-py=0.27
+  - ucx-py=0.28
   - xgboost=*=cuda_*

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -109,14 +109,13 @@ You can run the tests (after installation) with
 
     pytest tests
 
-GPU-specific tests require additional dependencies specified in `continuous_integration/gpuci/environment.yaml`.
-These can be added to the development environment by running
+GPU-specific tests require additional dependencies specified in `continuous_integration/gpuci/environment.yaml`:
 
 .. code-block:: bash
 
-    conda env update -n dask-sql -f continuous_integration/gpuci/environment.yaml
+    conda env create -n dask-sql-gpuci -f continuous_integration/gpuci/environment.yaml
 
-And GPU-specific tests can be run with
+GPU-specific tests can be run with
 
 .. code-block:: bash
 


### PR DESCRIPTION
This PR adds the additional dependencies of our 3.9 CI to the gpuCI environment file, so that it can be used to create the gpuCI conda environment in a single `conda env create` command, and updates the GHA workflow that updates gpuCI's nightly versions so that is also targeting this file.