### PR TITLE
[DF] Fix `PyExpr.index` bug where it returns `Ok(0)` instead of an `Err` if no match is found

### DIFF
--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -148,7 +148,7 @@ impl PyExpr {
                     .and_then(|fq_name| {
                         schema.index_of_column(&Column::from_qualified_name(&fq_name))
                     })
-                    .map_err(|e| py_runtime_err(e))
+                    .map_err(py_runtime_err)
             }
             _ => Err(py_runtime_err(
                 "We need a valid LogicalPlan instance to get the Expr's index in the schema",

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -139,7 +139,7 @@ impl PyExpr {
     pub fn index(&self) -> PyResult<usize> {
         let input: &Option<Vec<Arc<LogicalPlan>>> = &self.input_plan;
         match input {
-            Some(input_plans) if input_plans.len() > 0 => {
+            Some(input_plans) if !input_plans.is_empty() => {
                 let mut schema: DFSchema = (**input_plans[0].schema()).clone();
                 for plan in input_plans.iter().skip(1) {
                     schema.merge(plan.schema().as_ref());

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -1,4 +1,4 @@
-use crate::sql::exceptions::{py_field_not_found, py_runtime_err, py_type_err};
+use crate::sql::exceptions::{py_runtime_err, py_type_err};
 use crate::sql::logical;
 use crate::sql::types::RexType;
 use arrow::datatypes::DataType;

--- a/dask_planner/src/sql/exceptions.rs
+++ b/dask_planner/src/sql/exceptions.rs
@@ -1,4 +1,3 @@
-use datafusion_common::{DFSchema, SchemaError};
 use pyo3::{create_exception, PyErr};
 use std::fmt::Debug;
 

--- a/dask_planner/src/sql/exceptions.rs
+++ b/dask_planner/src/sql/exceptions.rs
@@ -1,3 +1,4 @@
+use datafusion_common::{DFSchema, SchemaError};
 use pyo3::{create_exception, PyErr};
 use std::fmt::Debug;
 
@@ -21,4 +22,13 @@ pub fn py_parsing_exp(e: impl Debug) -> PyErr {
 
 pub fn py_optimization_exp(e: impl Debug) -> PyErr {
     PyErr::new::<OptimizationException, _>(format!("{:?}", e))
+}
+
+pub fn py_field_not_found(qualifier: Option<&str>, name: &str, schema: &DFSchema) -> PyErr {
+    let schema_error = SchemaError::FieldNotFound {
+        qualifier: qualifier.map(|s| s.to_string()),
+        name: name.to_string(),
+        valid_fields: Some(schema.field_names()),
+    };
+    py_runtime_err(format!("{}", schema_error))
 }

--- a/dask_planner/src/sql/exceptions.rs
+++ b/dask_planner/src/sql/exceptions.rs
@@ -23,12 +23,3 @@ pub fn py_parsing_exp(e: impl Debug) -> PyErr {
 pub fn py_optimization_exp(e: impl Debug) -> PyErr {
     PyErr::new::<OptimizationException, _>(format!("{:?}", e))
 }
-
-pub fn py_field_not_found(qualifier: Option<&str>, name: &str, schema: &DFSchema) -> PyErr {
-    let schema_error = SchemaError::FieldNotFound {
-        qualifier: qualifier.map(|s| s.to_string()),
-        name: name.to_string(),
-        valid_fields: Some(schema.field_names()),
-    };
-    py_runtime_err(format!("{}", schema_error))
-}


### PR DESCRIPTION
`PyExpr.index` has a serious bug where it just returns index 0 if it fails to find a match.

This PR aims to fix that.