### PR TITLE
Bump gpuCI test environment to use python 3.9

### DIFF
--- a/continuous_integration/gpuci/environment.yaml
+++ b/continuous_integration/gpuci/environment.yaml
@@ -1,47 +1,47 @@
 name: dask-sql
 channels:
-  - rapidsai
-  - rapidsai-nightly
-  - nvidia
-  - conda-forge
-  - nodefaults
+- rapidsai
+- rapidsai-nightly
+- nvidia
+- conda-forge
+- nodefaults
 dependencies:
-  - dask-ml=2022.1.22
-  - dask=2022.3.0
-  - fastapi=0.69.0
-  - fugue=0.7.0
-  - intake=0.6.0
-  - jpype1=1.0.2
-  - jsonschema
-  - lightgbm
-  - maven
-  - mlflow
-  - mock
-  - nest-asyncio
-  - openjdk=11
-  - pandas=1.1.2
-  - pre-commit
-  - prompt_toolkit
-  - psycopg2
-  - pyarrow=6.0.1
-  - pygments
-  - pyhive
-  - pytest-cov
-  - pytest-xdist
-  - pytest
-  - python=3.8
-  - scikit-learn=1.0.0
-  - sphinx
-  - tpot
-  - tzlocal=2.1
-  - uvicorn=0.11.3
-  # GPU-specific requirements
-  - cudatoolkit=11.5
-  - cudf=22.10
-  - cuml=22.10
-  - dask-cudf=22.10
-  - dask-cuda=22.10
-  - numpy>=1.20.1
-  - ucx-proc=*=gpu
-  - ucx-py=0.28
-  - xgboost=*=cuda_*
+- dask-ml>=2022.1.22
+- dask>=2022.3.0
+- fastapi>=0.69.0
+- fugue>=0.7.0
+- intake>=0.6.0
+- jpype1>=1.0.2
+- jsonschema
+- lightgbm
+- maven
+- mlflow
+- mock
+- nest-asyncio
+- openjdk=11
+- pandas>=1.1.2
+- pre-commit
+- prompt_toolkit
+- psycopg2
+- pyarrow>=6.0.1
+- pygments
+- pyhive
+- pytest-cov
+- pytest-xdist
+- pytest
+- python=3.9
+- scikit-learn>=1.0.0
+- sphinx
+- tpot
+- tzlocal>=2.1
+- uvicorn>=0.11.3
+# GPU-specific requirements
+- cudatoolkit=11.5
+- cudf=22.10
+- cuml=22.10
+- dask-cudf=22.10
+- dask-cuda=22.10
+- numpy>=1.20.1
+- ucx-proc=*=gpu
+- ucx-py=0.28
+- xgboost=*=cuda_*


### PR DESCRIPTION
Somehow missed in #731 that we are using python 3.9 for gpuCI - this PR amends this error.