### PR TITLE
Test function `test_aggregate_function`

### DIFF
--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -175,6 +175,7 @@ impl PyExpr {
             | Expr::InList { .. }
             | Expr::InSubquery { .. }
             | Expr::ScalarUDF { .. }
+            | Expr::AggregateUDF { .. }
             | Expr::Exists { .. }
             | Expr::ScalarSubquery(..)
             | Expr::QualifiedWildcard { .. }
@@ -188,7 +189,6 @@ impl PyExpr {
             | Expr::Case { .. }
             | Expr::TryCast { .. }
             | Expr::WindowFunction { .. }
-            | Expr::AggregateUDF { .. }
             | Expr::Wildcard => {
                 return Err(py_type_err(format!(
                     "Encountered unsupported expression type: {}",

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -165,6 +165,7 @@ impl ContextProvider for DaskSQLContext {
                     if function.aggregation.eq(&true) {
                         return None;
                     }
+                    let sig = {
                         Signature::one_of(
                             function
                                 .return_types

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -250,7 +250,7 @@ impl ContextProvider for DaskSQLContext {
                         match function.return_types.get(&input_types.to_vec()) {
                             Some(return_type) => Ok(Arc::new(return_type.clone())),
                             None => Err(DataFusionError::Plan(format!(
-                                "UDF signature not found for input types {:?}",
+                                "UDAF signature not found for input types {:?}",
                                 input_types
                             ))),
                         }

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -176,7 +176,6 @@ impl ContextProvider for DaskSQLContext {
                     };
                     let function = function.clone();
                     let rtf: ReturnTypeFunction = Arc::new(move |input_types| {
-                        let function = function.lock().unwrap();
                         match function.return_types.get(&input_types.to_vec()) {
                             Some(return_type) => Ok(Arc::new(return_type.clone())),
                             None => Err(DataFusionError::Plan(format!(

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -200,7 +200,7 @@ impl ContextProvider for DaskSQLContext {
 
     fn get_aggregate_meta(&self, name: &str) -> Option<Arc<AggregateUDF>> {
         let acc: AccumulatorFunctionImplementation =
-            Arc::new(|_| Err(DataFusionError::NotImplemented("".to_string())));
+            Arc::new(|| Err(DataFusionError::NotImplemented("".to_string())));
 
         let st: StateTypeFunction =
             Arc::new(|_| Err(DataFusionError::NotImplemented("".to_string())));

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -255,13 +255,7 @@ impl ContextProvider for DaskSQLContext {
                             ))),
                         }
                     });
-                    return Some(Arc::new(AggregateUDF::new(
-                        fun_name,
-                        &sig,
-                        &rtf,
-                        &acc,
-                        &st,
-                    )));
+                    return Some(Arc::new(AggregateUDF::new(fun_name, &sig, &rtf, &acc, &st)));
                 }
             }
         }

--- a/dask_planner/src/sql/function.rs
+++ b/dask_planner/src/sql/function.rs
@@ -10,6 +10,7 @@ pub struct DaskFunction {
     #[pyo3(get, set)]
     pub(crate) name: String,
     pub(crate) return_types: HashMap<Vec<DataType>, DataType>,
+    pub(crate) aggregation: bool,
 }
 
 impl DaskFunction {
@@ -17,10 +18,12 @@ impl DaskFunction {
         function_name: String,
         input_types: Vec<PyDataType>,
         return_type: PyDataType,
+        aggregation: bool,
     ) -> Self {
         let mut func = Self {
             name: function_name,
             return_types: HashMap::new(),
+            aggregation: aggregation,
         };
         func.add_type_mapping(input_types, return_type);
         func

--- a/dask_planner/src/sql/function.rs
+++ b/dask_planner/src/sql/function.rs
@@ -18,12 +18,12 @@ impl DaskFunction {
         function_name: String,
         input_types: Vec<PyDataType>,
         return_type: PyDataType,
-        aggregation: bool,
+        aggregation_bool: bool,
     ) -> Self {
         let mut func = Self {
             name: function_name,
             return_types: HashMap::new(),
-            aggregation: aggregation,
+            aggregation: aggregation_bool,
         };
         func.add_type_mapping(input_types, return_type);
         func

--- a/dask_planner/src/sql/logical/aggregate.rs
+++ b/dask_planner/src/sql/logical/aggregate.rs
@@ -46,6 +46,7 @@ impl PyAggregate {
     pub fn agg_func_name(&self, expr: PyExpr) -> PyResult<String> {
         match expr.expr {
             Expr::AggregateFunction { fun, .. } => Ok(fun.to_string()),
+            Expr::AggregateUDF { fun, .. } => Ok(fun.name.clone()),
             _ => Err(py_type_err(
                 "Encountered a non Aggregate type in agg_func_name",
             )),
@@ -55,7 +56,8 @@ impl PyAggregate {
     #[pyo3(name = "getArgs")]
     pub fn aggregation_arguments(&self, expr: PyExpr) -> PyResult<Vec<PyExpr>> {
         match expr.expr {
-            Expr::AggregateFunction { fun: _, args, .. } => match &self.aggregate {
+            Expr::AggregateFunction { fun: _, args, .. }
+            | Expr::AggregateUDF { fun: _, args, .. } => match &self.aggregate {
                 Some(e) => py_expr_list(&e.input, &args),
                 None => Ok(vec![]),
             },

--- a/dask_planner/src/sql/schema.rs
+++ b/dask_planner/src/sql/schema.rs
@@ -50,6 +50,30 @@ impl DaskSchema {
                     name,
                     input_types,
                     return_type,
+                    false,
+                )))
+            });
+    }
+
+    pub fn add_or_overload_aggregation(
+        &mut self,
+        name: String,
+        input_types: Vec<PyDataType>,
+        return_type: PyDataType,
+    ) {        
+        self.functions
+            .entry(name.clone())
+            .and_modify(|e| {
+                (*e).lock()
+                    .unwrap()
+                    .add_type_mapping(input_types.clone(), return_type.clone());
+            })
+            .or_insert_with(|| {
+                Arc::new(Mutex::new(DaskFunction::new(
+                    name,
+                    input_types,
+                    return_type,
+                    true,
                 )))
             });
     }

--- a/dask_planner/src/sql/schema.rs
+++ b/dask_planner/src/sql/schema.rs
@@ -37,6 +37,7 @@ impl DaskSchema {
         name: String,
         input_types: Vec<PyDataType>,
         return_type: PyDataType,
+        aggregation: bool,
     ) {
         self.functions
             .entry(name.clone())
@@ -50,30 +51,7 @@ impl DaskSchema {
                     name,
                     input_types,
                     return_type,
-                    false,
-                )))
-            });
-    }
-
-    pub fn add_or_overload_aggregation(
-        &mut self,
-        name: String,
-        input_types: Vec<PyDataType>,
-        return_type: PyDataType,
-    ) {        
-        self.functions
-            .entry(name.clone())
-            .and_modify(|e| {
-                (*e).lock()
-                    .unwrap()
-                    .add_type_mapping(input_types.clone(), return_type.clone());
-            })
-            .or_insert_with(|| {
-                Arc::new(Mutex::new(DaskFunction::new(
-                    name,
-                    input_types,
-                    return_type,
-                    true,
+                    aggregation,
                 )))
             });
     }

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -752,12 +752,11 @@ class Context:
                 sql_parameters = function_description.parameters
                 if function_description.aggregation:
                     logger.debug(f"Adding function '{name}' to schema as aggregation.")
-                    # TODO: Not yet implemented
-                    # rust_schema.add_or_overload_aggregation(
-                    #     name,
-                    #     [param[1].getDataType() for param in sql_parameters],
-                    #     sql_return_type.getDataType(),
-                    # )
+                    rust_schema.add_or_overload_aggregation(
+                        name,
+                        [param[1].getDataType() for param in sql_parameters],
+                        sql_return_type.getDataType(),
+                    )
                 else:
                     logger.debug(
                         f"Adding function '{name}' to schema as scalar function."

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -752,10 +752,11 @@ class Context:
                 sql_parameters = function_description.parameters
                 if function_description.aggregation:
                     logger.debug(f"Adding function '{name}' to schema as aggregation.")
-                    rust_schema.add_or_overload_aggregation(
+                    rust_schema.add_or_overload_function(
                         name,
                         [param[1].getDataType() for param in sql_parameters],
                         sql_return_type.getDataType(),
+                        True,
                     )
                 else:
                     logger.debug(
@@ -765,6 +766,7 @@ class Context:
                         name,
                         [param[1].getDataType() for param in sql_parameters],
                         sql_return_type.getDataType(),
+                        False,
                     )
 
             schema_list.append(rust_schema)

--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -332,8 +332,7 @@ class DaskAggregatePlugin(BaseRelPlugin):
                 "AggregateUDF",
             }, "Do not know how to handle this case!"
 
-            # TODO: Generally we need a way to capture the current SQL schema here in case this is a custom aggregation function
-            schema_name = "root"
+            schema_name = context.schema_name
             aggregation_name = rel.aggregate().getAggregationFuncName(expr).lower()
 
             # Gather information about the input column

--- a/tests/integration/test_function.py
+++ b/tests/integration/test_function.py
@@ -163,9 +163,6 @@ def test_multiple_definitions(c, df_simple):
     assert_eq(return_df, expected_df)
 
 
-@pytest.mark.skip(
-    reason="WIP DataFusion - https://github.com/dask-contrib/dask-sql/issues/465"
-)
 def test_aggregate_function(c):
     fagg = dd.Aggregation("f", lambda x: x.sum(), lambda x: x.sum())
     c.register_aggregation(fagg, "fagg", [("x", np.float64)], np.float64)


### PR DESCRIPTION
In `test_function.py`, the only remaining test is `test_aggregate_function()`. This PR allows this test to pass by introducing the `aggregation` bool to the `DaskFunction` struct (following a similar convention to `FunctionDescription`) and implementing the `add_or_overload_aggregation` function.

Builds upon changes from #698