### PR TITLE
[DF] Update DataFusion to pick up SQL support for LIKE, ILIKE, SIMILAR TO with escape char

### DIFF
--- a/dask_planner/Cargo.lock
+++ b/dask_planner/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion/?rev=7c04964fee0210411f02bf3938aefe7773710e42#7c04964fee0210411f02bf3938aefe7773710e42"
+source = "git+https://github.com/apache/arrow-datafusion/?rev=8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae#8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae"
 dependencies = [
  "arrow",
  "ordered-float",
@@ -302,7 +302,7 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion/?rev=7c04964fee0210411f02bf3938aefe7773710e42#7c04964fee0210411f02bf3938aefe7773710e42"
+source = "git+https://github.com/apache/arrow-datafusion/?rev=8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae#8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -313,7 +313,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion/?rev=7c04964fee0210411f02bf3938aefe7773710e42#7c04964fee0210411f02bf3938aefe7773710e42"
+source = "git+https://github.com/apache/arrow-datafusion/?rev=8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae#8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae"
 dependencies = [
  "arrow",
  "async-trait",
@@ -328,7 +328,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion/?rev=7c04964fee0210411f02bf3938aefe7773710e42#7c04964fee0210411f02bf3938aefe7773710e42"
+source = "git+https://github.com/apache/arrow-datafusion/?rev=8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae#8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -352,7 +352,7 @@ dependencies = [
 [[package]]
 name = "datafusion-row"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion/?rev=7c04964fee0210411f02bf3938aefe7773710e42#7c04964fee0210411f02bf3938aefe7773710e42"
+source = "git+https://github.com/apache/arrow-datafusion/?rev=8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae#8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -363,7 +363,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "11.0.0"
-source = "git+https://github.com/apache/arrow-datafusion/?rev=7c04964fee0210411f02bf3938aefe7773710e42#7c04964fee0210411f02bf3938aefe7773710e42"
+source = "git+https://github.com/apache/arrow-datafusion/?rev=8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae#8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae"
 dependencies = [
  "ahash 0.8.0",
  "arrow",
@@ -1055,9 +1055,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "sqlparser"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6483de5881514f11fe570f53fcee3cd9194e91eb43659cb356df69f99ef0f83e"
+checksum = "0beb13adabbdda01b63d595f38c8bfd19a361e697fd94ce0098a634077bc5b25"
 dependencies = [
  "log",
 ]

--- a/dask_planner/Cargo.toml
+++ b/dask_planner/Cargo.toml
@@ -13,10 +13,10 @@ tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"
 rand = "0.7"
 pyo3 = { version = "0.16.5", features = ["extension-module", "abi3", "abi3-py38"] }
 arrow = { version = "22.0.0", features = ["prettyprint"] }
-datafusion-sql = { git="https://github.com/apache/arrow-datafusion/", rev = "7c04964fee0210411f02bf3938aefe7773710e42" }
-datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "7c04964fee0210411f02bf3938aefe7773710e42" }
-datafusion-common = { git="https://github.com/apache/arrow-datafusion/", rev = "7c04964fee0210411f02bf3938aefe7773710e42" }
-datafusion-optimizer = { git="https://github.com/apache/arrow-datafusion/", rev = "7c04964fee0210411f02bf3938aefe7773710e42" }
+datafusion-sql = { git="https://github.com/apache/arrow-datafusion/", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
+datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
+datafusion-common = { git="https://github.com/apache/arrow-datafusion/", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
+datafusion-optimizer = { git="https://github.com/apache/arrow-datafusion/", rev = "8b59b207aaadd6f2c19c28d1f1431a0cb8d110ae" }
 uuid = { version = "0.8", features = ["v4"] }
 mimalloc = { version = "*", default-features = false }
 parking_lot = "0.12"

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -367,9 +367,27 @@ impl PyExpr {
             Expr::InList { .. } => "in list".to_string(),
             Expr::Negative(..) => "negative".to_string(),
             Expr::Not(..) => "not".to_string(),
-            Expr::Like { .. } => "like".to_string(),
-            Expr::ILike { .. } => "ilike".to_string(),
-            Expr::SimilarTo { .. } => "similar to".to_string(),
+            Expr::Like { negated, .. } => {
+                if *negated {
+                    "not like".to_string()
+                } else {
+                    "like".to_string()
+                }
+            }
+            Expr::ILike { negated, .. } => {
+                if *negated {
+                    "not ilike".to_string()
+                } else {
+                    "ilike".to_string()
+                }
+            }
+            Expr::SimilarTo { negated, .. } => {
+                if *negated {
+                    "not similar to".to_string()
+                } else {
+                    "similar to".to_string()
+                }
+            }
             _ => {
                 return Err(py_type_err(format!(
                     "Catch all triggered in get_operator_name: {:?}",
@@ -691,6 +709,20 @@ impl PyExpr {
             Expr::Sort { nulls_first, .. } => Ok(*nulls_first),
             _ => Err(py_type_err(format!(
                 "Provided Expr {:?} is not a sort type",
+                &self.expr
+            ))),
+        }
+    }
+
+    /// Returns the escape char for like/ilike/similar to expr variants
+    #[pyo3(name = "getEscapeChar")]
+    pub fn get_escape_char(&self) -> PyResult<Option<char>> {
+        match &self.expr {
+            Expr::Like { escape_char, .. }
+            | Expr::ILike { escape_char, .. }
+            | Expr::SimilarTo { escape_char, .. } => Ok(*escape_char),
+            _ => Err(py_type_err(format!(
+                "Provided Expr {:?} not one of Like/ILike/SimilarTo",
                 &self.expr
             ))),
         }

--- a/dask_planner/src/expression.rs
+++ b/dask_planner/src/expression.rs
@@ -367,6 +367,9 @@ impl PyExpr {
             Expr::InList { .. } => "in list".to_string(),
             Expr::Negative(..) => "negative".to_string(),
             Expr::Not(..) => "not".to_string(),
+            Expr::Like { .. } => "like".to_string(),
+            Expr::ILike { .. } => "ilike".to_string(),
+            Expr::SimilarTo { .. } => "similar to".to_string(),
             _ => {
                 return Err(py_type_err(format!(
                     "Catch all triggered in get_operator_name: {:?}",

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -75,7 +75,7 @@ class Operation:
 
     def of(self, op: "Operation") -> "Operation":
         """Functional composition"""
-        new_op = Operation(lambda *x: self(op(*x)))
+        new_op = Operation(lambda *x, **kwargs: self(op(*x, **kwargs)))
         new_op.needs_dc = Operation.op_needs_dc(op)
         new_op.needs_rex = Operation.op_needs_rex(op)
 
@@ -368,20 +368,17 @@ class IsNotDistinctOperation(Operation):
 class RegexOperation(Operation):
     """An abstract regex operation, which transforms the SQL regex into something python can understand"""
 
+    needs_rex = True
+
     def __init__(self):
         super().__init__(self.regex)
 
-    def regex(
-        self,
-        test: SeriesOrScalar,
-        regex: str,
-        escape: str = None,
-    ) -> SeriesOrScalar:
+    def regex(self, test: SeriesOrScalar, regex: str, rex=None) -> SeriesOrScalar:
         """
         Returns true, if the string test matches the given regex
         (maybe escaped by escape)
         """
-
+        escape = rex.getEscapeChar() if rex else None
         if not escape:
             escape = "\\"
 

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -239,6 +239,8 @@ def test_like(c, input_table, gpu, request):
 
     assert len(df) == 0
 
+    # TODO: uncomment when sqlparser adds parsing support for non-standard escape characters
+    # https://github.com/dask-contrib/dask-sql/issues/754
     # df = c.sql(
     #     f"""
     #     SELECT * FROM {input_table}

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -202,9 +202,6 @@ def test_operators(c, df):
     assert_eq(result_df, expected_df)
 
 
-@pytest.mark.skip(
-    reason="Depends on https://github.com/apache/arrow-datafusion/issues/3016"
-)
 @pytest.mark.parametrize(
     "input_table,gpu",
     [
@@ -242,14 +239,14 @@ def test_like(c, input_table, gpu, request):
 
     assert len(df) == 0
 
-    df = c.sql(
-        f"""
-        SELECT * FROM {input_table}
-        WHERE a LIKE 'Ä%Ä_Ä%' ESCAPE 'Ä'
-    """
-    )
+    # df = c.sql(
+    #     f"""
+    #     SELECT * FROM {input_table}
+    #     WHERE a LIKE 'Ä%Ä_Ä%' ESCAPE 'Ä'
+    # """
+    # )
 
-    assert_eq(df, string_table.iloc[[1]])
+    # assert_eq(df, string_table.iloc[[1]])
 
     df = c.sql(
         f"""


### PR DESCRIPTION
There is one test failure after this update:

```
FAILED tests/integration/test_sqlite.py::test_filter - AssertionError: DataFrame are different
```

The reason for this is that the representation of `Like` and `NotLike` has changed in the logical plan and the corresponding Python code now needs updating.

Previously these were modeled as `Expr::Binary` with `Operator::Like/NotLike` but now they are represented as a new top-level `Expr::Like` expression instead.