### PR TITLE
[DF] Upgrade pyo and change some signatures to use `&str` instead of `String`

### DIFF
--- a/dask_planner/Cargo.lock
+++ b/dask_planner/Cargo.lock
@@ -631,6 +631,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mimalloc"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,13 +827,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.16.6"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0220c44442c9b239dd4357aa856ac468a4f5e1f0df19ddb89b2522952eb4c6ca"
+checksum = "12f72538a0230791398a0986a6518ebd88abc3fded89007b506ed072acc831e1"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
+ "memoffset",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -834,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.16.6"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c819d397859445928609d0ec5afc2da5204e0d0f73d6bf9e153b04e83c9cdc2"
+checksum = "fc4cf18c20f4f09995f3554e6bcf9b09bd5e4d6b67c562fdfaafa644526ba479"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -844,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.16.6"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca882703ab55f54702d7bfe1189b41b0af10272389f04cae38fe4cd56c65f75f"
+checksum = "a41877f28d8ebd600b6aa21a17b40c3b0fc4dfe73a27b6e81ab3d895e401b0e9"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -854,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.16.6"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568749402955ad7be7bad9a09b8593851cd36e549ac90bfd44079cea500f3f21"
+checksum = "2e81c8d4bcc2f216dc1b665412df35e46d12ee8d3d046b381aad05f1fcf30547"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -866,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.16.6"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611f64e82d98f447787e82b8e7b0ebc681e1eb78fc1252668b2c605ffb4e1eb8"
+checksum = "85752a767ee19399a78272cc2ab625cd7d373b2e112b4b13db28de71fa892784"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/dask_planner/Cargo.toml
+++ b/dask_planner/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.62"
 [dependencies]
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 rand = "0.7"
-pyo3 = { version = "0.16.5", features = ["extension-module", "abi3", "abi3-py38"] }
+pyo3 = { version = "0.17.1", features = ["extension-module", "abi3", "abi3-py38"] }
 arrow = { version = "22.0.0", features = ["prettyprint"] }
 datafusion-sql = { git="https://github.com/apache/arrow-datafusion/", rev = "12.0.0-rc1" }
 datafusion-expr = { git="https://github.com/apache/arrow-datafusion/", rev = "12.0.0-rc1" }

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -271,9 +271,9 @@ impl ContextProvider for DaskSQLContext {
 #[pymethods]
 impl DaskSQLContext {
     #[new]
-    pub fn new(default_catalog_name: String, default_schema_name: String) -> Self {
+    pub fn new(default_catalog_name: &str, default_schema_name: String) -> Self {
         Self {
-            default_catalog_name,
+            default_catalog_name: default_catalog_name.to_owned(),
             default_schema_name,
             schemas: HashMap::new(),
         }
@@ -308,9 +308,9 @@ impl DaskSQLContext {
     }
 
     /// Parses a SQL string into an AST presented as a Vec of Statements
-    pub fn parse_sql(&self, sql: String) -> PyResult<Vec<statement::PyStatement>> {
+    pub fn parse_sql(&self, sql: &str) -> PyResult<Vec<statement::PyStatement>> {
         let dd: DaskDialect = DaskDialect {};
-        match DaskParser::parse_sql_with_dialect(sql.as_str(), &dd) {
+        match DaskParser::parse_sql_with_dialect(sql, &dd) {
             Ok(k) => {
                 let mut statements: Vec<statement::PyStatement> = Vec::new();
                 for statement in k {

--- a/dask_planner/src/sql/schema.rs
+++ b/dask_planner/src/sql/schema.rs
@@ -20,9 +20,9 @@ pub struct DaskSchema {
 #[pymethods]
 impl DaskSchema {
     #[new]
-    pub fn new(schema_name: String) -> Self {
+    pub fn new(schema_name: &str) -> Self {
         Self {
-            name: schema_name,
+            name: schema_name.to_owned(),
             tables: HashMap::new(),
             functions: HashMap::new(),
         }

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -102,10 +102,10 @@ pub struct DaskTable {
 #[pymethods]
 impl DaskTable {
     #[new]
-    pub fn new(schema: String, name: String, row_count: f64) -> Self {
+    pub fn new(schema: &str, name: &str, row_count: f64) -> Self {
         Self {
-            schema,
-            name,
+            schema: schema.to_owned(),
+            name: name.to_owned(),
             statistics: DaskStatistics::new(row_count),
             columns: Vec::new(),
         }
@@ -113,8 +113,8 @@ impl DaskTable {
 
     // TODO: Really wish we could accept a SqlTypeName instance here instead of a String for `column_type` ....
     #[pyo3(name = "add_column")]
-    pub fn add_column(&mut self, column_name: String, type_map: DaskTypeMap) {
-        self.columns.push((column_name, type_map));
+    pub fn add_column(&mut self, column_name: &str, type_map: DaskTypeMap) {
+        self.columns.push((column_name.to_owned(), type_map));
     }
 
     #[pyo3(name = "getSchema")]
@@ -147,7 +147,7 @@ impl DaskTable {
     pub fn row_type(&self) -> RelDataType {
         let mut fields: Vec<RelDataTypeField> = Vec::new();
         for (name, data_type) in &self.columns {
-            fields.push(RelDataTypeField::new(name.clone(), data_type.clone(), 255));
+            fields.push(RelDataTypeField::new(name.as_str(), data_type.clone(), 255));
         }
         RelDataType::new(false, fields)
     }

--- a/dask_planner/src/sql/types.rs
+++ b/dask_planner/src/sql/types.rs
@@ -269,8 +269,8 @@ impl SqlTypeName {
 impl SqlTypeName {
     #[pyo3(name = "fromString")]
     #[staticmethod]
-    pub fn from_string(input_type: String) -> Self {
-        match input_type.as_str() {
+    pub fn from_string(input_type: &str) -> Self {
+        match input_type {
             "ANY" => SqlTypeName::ANY,
             "ARRAY" => SqlTypeName::ARRAY,
             "NULL" => SqlTypeName::NULL,

--- a/dask_planner/src/sql/types/rel_data_type.rs
+++ b/dask_planner/src/sql/types/rel_data_type.rs
@@ -34,14 +34,14 @@ impl RelDataType {
     /// * `field_name` - A String containing the name of the field to find
     /// * `case_sensitive` - True if column name matching should be case sensitive and false otherwise
     #[pyo3(name = "getField")]
-    pub fn field(&self, field_name: String, case_sensitive: bool) -> PyResult<RelDataTypeField> {
+    pub fn field(&self, field_name: &str, case_sensitive: bool) -> PyResult<RelDataTypeField> {
         let field_map: HashMap<String, RelDataTypeField> = self.field_map();
         if case_sensitive && !field_map.is_empty() {
-            Ok(field_map.get(&field_name).unwrap().clone())
+            Ok(field_map.get(field_name).unwrap().clone())
         } else {
             for field in &self.field_list {
-                if (case_sensitive && field.name().eq(&field_name))
-                    || (!case_sensitive && field.name().eq_ignore_ascii_case(&field_name))
+                if (case_sensitive && field.name().eq(field_name))
+                    || (!case_sensitive && field.name().eq_ignore_ascii_case(field_name))
                 {
                     return Ok(field.clone());
                 }

--- a/dask_planner/src/sql/types/rel_data_type_field.rs
+++ b/dask_planner/src/sql/types/rel_data_type_field.rs
@@ -39,10 +39,10 @@ impl RelDataTypeField {
 #[pymethods]
 impl RelDataTypeField {
     #[new]
-    pub fn new(name: String, type_map: DaskTypeMap, index: usize) -> Self {
+    pub fn new(name: &str, type_map: DaskTypeMap, index: usize) -> Self {
         Self {
             qualifier: None,
-            name,
+            name: name.to_owned(),
             data_type: type_map,
             index,
         }


### PR DESCRIPTION
A while ago, there was a new Clippy lint that caused us to change some signatures to use `String` instead of `&str` due to the lint being incompatible with Pyo. Pyo 0.17.1 resolves this so this PR upgrades to that version and changes some signatures from `String` to `&str`.