### PR TITLE
Fix upstream failures in `test_groupby_split_out`

### DIFF
--- a/tests/integration/test_groupby.py
+++ b/tests/integration/test_groupby.py
@@ -376,7 +376,7 @@ def test_groupby_split_out(c, input_table, split_out, request):
         FROM {input_table}
         GROUP BY user_id
         """,
-        config_options={"sql.groupby.split_out": split_out},
+        config_options={"sql.groupby.split_out": split_out} if split_out else {},
     )
     expected_df = (
         user_table.groupby(by="user_id")


### PR DESCRIPTION
Looks like with https://github.com/dask/dask/pull/9453 Dask's `aggregate` codepath has changed such that passing through a null `split_out` will error where it once didn't; not sure if this was something that was once supported, but looking at the codepath before this commit it seems like it would've errored in some other cases too.

Closes #761