### PR TITLE
[DF] Switch back to architectured builds

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -58,4 +58,4 @@ jobs:
           # install anaconda for upload
           mamba install anaconda-client
 
-          anaconda upload --label $LABEL noarch/*.tar.bz2
+          anaconda upload --label $LABEL linux-64/*.tar.bz2

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -5,6 +5,12 @@ on:
       - main
       - datafusion-sql-planner
   pull_request:
+    paths:
+      - setup.py
+      - continuous_integration/recipe/**
+      - .github/workflows/conda.yml
+  schedule:
+    - cron: '0 0 * * 0'
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     paths:
       - setup.py
+      - dask_planner/Cargo.toml
+      - dask_planner/Cargo.lock
+      - dask_planner/pyproject.toml
+      - dask_planner/rust-toolchain.toml
       - continuous_integration/recipe/**
       - .github/workflows/conda.yml
   schedule:

--- a/continuous_integration/recipe/conda_build_config.yaml
+++ b/continuous_integration/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
 rust_compiler_version:
     - 1.62.1
 python:
-    - 3.7
     - 3.8
     - 3.9
+    - 3.10

--- a/continuous_integration/recipe/conda_build_config.yaml
+++ b/continuous_integration/recipe/conda_build_config.yaml
@@ -1,2 +1,6 @@
 rust_compiler_version:
     - 1.62.1
+python:
+    - 3.7
+    - 3.8
+    - 3.9

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -13,11 +13,11 @@ source:
 
 build:
   number: {{ GIT_DESCRIBE_NUMBER }}
-  noarch: python
+  skip: true   # [py2k]
   entry_points:
     - dask-sql-server = dask_sql.server.app:main
     - dask-sql = dask_sql.cmd:main
-  string: py_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
+  string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:


### PR DESCRIPTION
Turns out that our Rust binary is compiled for the Python version & platform of the build platform - there is probably a way to get cross-compiled packages so this isn't an issue, but a short-term unblocker is just to build & publish packages for all our supported Python versions.