### PR TITLE
[DF] Remove python constraint from nightly recipe

### DIFF
--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - setuptools-rust >=1.4.1
   host:
     - pip
-    - python >=3.8
+    - python
     - setuptools-rust >=1.4.1
   run:
     - python


### PR DESCRIPTION
Looks like the nightly packages are all pinned to python 3.10; think this might be because of the `python>=3.8` constraint left behind.