### PR TITLE
Update docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -27,9 +27,9 @@ GPU support
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 - GPU support is currently tied to the `RAPIDS <https://rapids.ai/>`_  libraries.
-- It generally requires the latest `cuDF/Dask-cuDF <https://docs.rapids.ai/api/cudf/legacy/10min.html>`_ nightlies.
+- It generally requires the latest `cuDF/Dask-cuDF <https://docs.rapids.ai/api/cudf/nightly/user_guide/10min.html>`_ nightlies.
 
-Create a new conda environment or use an existing one to install RAPIDS with the chosen methods and packages. 
+Create a new conda environment or use an existing one to install RAPIDS with the chosen methods and packages.
 More details can be found on the `RAPIDS Getting Started <https://rapids.ai/start.html>`_ page, but as an example:
 
 .. code-block:: bash
@@ -37,6 +37,9 @@ More details can be found on the `RAPIDS Getting Started <https://rapids.ai/star
     conda create --name rapids-env -c rapidsai-nightly -c nvidia -c conda-forge \
         cudf=22.10 dask-cudf=22.10 ucx-py ucx-proc=*=gpu python=3.9 cudatoolkit=11.5
     conda activate rapids-env
+
+Note that using UCX is mainly necessary if you have an Infiniband or NVLink enabled system.
+Refer to the `UCX-Py docs <https://ucx-py.readthedocs.io/en/latest/>`_ for more information.
 
 Install the stable package from the ``conda-forge`` channel:
 
@@ -81,11 +84,11 @@ After that, you can install the package in development mode
 
     pip install -e ".[dev]"
 
-To compile the Rust code (at the beginning or after changes), run
+To compile the Rust code (after changes), run
 
 .. code-block:: bash
 
-    python setup.py install
+    python setup.py build_ext
 
 You can run the tests (after installation) with
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -24,7 +24,7 @@ Install the package from the ``conda-forge`` channel:
     conda install dask-sql -c conda-forge
 
 GPU support
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^
 
 - GPU support is currently tied to the `RAPIDS <https://rapids.ai/>`_  libraries.
 - It generally requires the latest `cuDF/Dask-cuDF <https://docs.rapids.ai/api/cudf/nightly/user_guide/10min.html>`_ nightlies.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -23,19 +23,19 @@ Install the package from the ``conda-forge`` channel:
 
     conda install dask-sql -c conda-forge
 
-Experimental GPU support
+GPU support
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 - GPU support is currently tied to the `RAPIDS <https://rapids.ai/>`_  libraries.
-- It is in development and generally requires the latest `cuDF/Dask-cuDF <https://docs.rapids.ai/api/cudf/legacy/10min.html>`_ nightlies.
-- It is experimental, so users should expect some bugs or undefined behavior.
+- It generally requires the latest `cuDF/Dask-cuDF <https://docs.rapids.ai/api/cudf/legacy/10min.html>`_ nightlies.
 
-Create a new conda environment or use an existing one to install RAPIDS with the chosen methods and packages:
+Create a new conda environment or use an existing one to install RAPIDS with the chosen methods and packages. 
+More details can be found on the `RAPIDS Getting Started <https://rapids.ai/start.html>`_ page, but as an example:
 
 .. code-block:: bash
 
     conda create --name rapids-env -c rapidsai-nightly -c nvidia -c conda-forge \
-        cudf=22.02 dask-cudf=22.02 ucx-py ucx-proc=*=gpu python=3.8 cudatoolkit=11.2
+        cudf=22.10 dask-cudf=22.10 ucx-py ucx-proc=*=gpu python=3.9 cudatoolkit=11.5
     conda activate rapids-env
 
 Install the stable package from the ``conda-forge`` channel:
@@ -81,11 +81,11 @@ After that, you can install the package in development mode
 
     pip install -e ".[dev]"
 
-To compile the Java classes (at the beginning or after changes), run
+To compile the Rust code (at the beginning or after changes), run
 
 .. code-block:: bash
 
-    python setup.py build_ext
+    python setup.py install
 
 You can run the tests (after installation) with
 


### PR DESCRIPTION
A couple of updates for the [Installation](https://github.com/dask-contrib/dask-sql/blob/datafusion-sql-planner/docs/source/installation.rst) docs, including:

- Remove "experimental" terminology from GPU section
- Update RAPIDS versions and point to https://rapids.ai/start.html
- Change Java reference to Rust