### PR TITLE
[DF] Use correct schema in TableProvider

### DIFF
--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -86,7 +86,10 @@ impl ContextProvider for DaskSQLContext {
             name.resolve(&self.default_catalog_name, &self.default_schema_name);
         if reference.catalog != self.default_catalog_name {
             // there is a single catalog in Dask SQL
-            return Err(DataFusionError::Plan(format!("Cannot resolve catalog '{}'", reference.catalog)));
+            return Err(DataFusionError::Plan(format!(
+                "Cannot resolve catalog '{}'",
+                reference.catalog
+            )));
         }
         match self.schemas.get(reference.schema) {
             Some(schema) => {

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -84,7 +84,7 @@ impl ContextProvider for DaskSQLContext {
     ) -> Result<Arc<dyn TableSource>, DataFusionError> {
         let reference: ResolvedTableReference =
             name.resolve(&self.default_catalog_name, &self.default_schema_name);
-        match self.schemas.get(&self.default_schema_name) {
+        match self.schemas.get(reference.schema) {
             Some(schema) => {
                 let mut resp = None;
                 for table in schema.tables.values() {

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -84,6 +84,10 @@ impl ContextProvider for DaskSQLContext {
     ) -> Result<Arc<dyn TableSource>, DataFusionError> {
         let reference: ResolvedTableReference =
             name.resolve(&self.default_catalog_name, &self.default_schema_name);
+        if reference.catalog != self.default_catalog_name {
+            // there is a single catalog in Dask SQL
+            return Err(DataFusionError::Plan(format!("Cannot resolve catalog '{}'", reference.catalog)));
+        }
         match self.schemas.get(reference.schema) {
             Some(schema) => {
                 let mut resp = None;


### PR DESCRIPTION
When the SQL parser is trying to resolve a table, we were ignoring the schema in qualified names and using the default schema instead.