### PR TITLE
Add step argument to get_window_bounds for pandas>=1.5

### DIFF
--- a/.github/cluster-upstream.yml
+++ b/.github/cluster-upstream.yml
@@ -7,7 +7,8 @@ services:
         command: dask-scheduler
         environment:
             USE_MAMBA: "true"
-            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pandas>=1.5.0"
+            # TODO: remove pandas constraint once Dask images are updated
+            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pandas>=1.1.2"
         ports:
             - "8786:8786"
     dask-worker:
@@ -16,6 +17,7 @@ services:
         command: dask-worker dask-scheduler:8786
         environment:
             USE_MAMBA: "true"
-            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0 pandas>=1.5.0"
+            # TODO: remove pandas constraint once Dask images are updated
+            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0 pandas>=1.1.2"
         volumes:
             - /tmp:/tmp

--- a/.github/cluster-upstream.yml
+++ b/.github/cluster-upstream.yml
@@ -8,7 +8,7 @@ services:
         environment:
             USE_MAMBA: "true"
             # TODO: remove pandas constraint once Dask images are updated
-            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pandas>=1.1.2"
+            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pandas>=1.5.0"
         ports:
             - "8786:8786"
     dask-worker:
@@ -18,6 +18,6 @@ services:
         environment:
             USE_MAMBA: "true"
             # TODO: remove pandas constraint once Dask images are updated
-            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0 pandas>=1.1.2"
+            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0 pandas>=1.5.0"
         volumes:
             - /tmp:/tmp

--- a/.github/cluster-upstream.yml
+++ b/.github/cluster-upstream.yml
@@ -7,7 +7,7 @@ services:
         command: dask-scheduler
         environment:
             USE_MAMBA: "true"
-            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0"
+            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pandas>=1.5.0"
         ports:
             - "8786:8786"
     dask-worker:
@@ -16,6 +16,6 @@ services:
         command: dask-worker dask-scheduler:8786
         environment:
             USE_MAMBA: "true"
-            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0"
+            EXTRA_CONDA_PACKAGES: "dask/label/dev::dask cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0 pandas>=1.5.0"
         volumes:
             - /tmp:/tmp

--- a/.github/cluster.yml
+++ b/.github/cluster.yml
@@ -13,6 +13,6 @@ services:
         command: dask-worker dask-scheduler:8786
         environment:
             USE_MAMBA: "true"
-            EXTRA_CONDA_PACKAGES: "cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0"
+            EXTRA_CONDA_PACKAGES: "cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0 pandas>=1.5.0"
         volumes:
             - /tmp:/tmp

--- a/.github/cluster.yml
+++ b/.github/cluster.yml
@@ -14,6 +14,6 @@ services:
         environment:
             USE_MAMBA: "true"
             # TODO: remove pandas constraint once Dask images are updated
-            EXTRA_CONDA_PACKAGES: "cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0 pandas>=1.1.2"
+            EXTRA_CONDA_PACKAGES: "cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0 pandas>=1.5.0"
         volumes:
             - /tmp:/tmp

--- a/.github/cluster.yml
+++ b/.github/cluster.yml
@@ -13,6 +13,7 @@ services:
         command: dask-worker dask-scheduler:8786
         environment:
             USE_MAMBA: "true"
-            EXTRA_CONDA_PACKAGES: "cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0 pandas>=1.5.0"
+            # TODO: remove pandas constraint once Dask images are updated
+            EXTRA_CONDA_PACKAGES: "cloudpickle>=2.1.0 pyarrow>=6.0.1 libstdcxx-ng>=12.1.0 pandas>=1.1.2"
         volumes:
             - /tmp:/tmp

--- a/dask_sql/_compat.py
+++ b/dask_sql/_compat.py
@@ -7,6 +7,7 @@ _prompt_toolkit_version = parseVersion(prompt_toolkit.__version__)
 
 FLOAT_NAN_IMPLEMENTED = _pandas_version >= parseVersion("1.2.0")
 INT_NAN_IMPLEMENTED = _pandas_version >= parseVersion("1.0.0")
+INDEXER_WINDOW_STEP_IMPLEMENTED = _pandas_version >= parseVersion("1.5.0")
 
 # TODO: remove if prompt-toolkit min version gets bumped
 PIPE_INPUT_CONTEXT_MANAGER = _prompt_toolkit_version >= parseVersion("3.0.29")

--- a/dask_sql/physical/rel/logical/window.py
+++ b/dask_sql/physical/rel/logical/window.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.indexers import BaseIndexer
 
+from dask_sql._compat import INDEXER_WINDOW_STEP_IMPLEMENTED
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.java import org
 from dask_sql.physical.rel.base import BaseRelPlugin
@@ -121,7 +122,7 @@ class Indexer(BaseIndexer):
     def __init__(self, start: int, end: int):
         super().__init__(self, start=start, end=end)
 
-    def get_window_bounds(
+    def _get_window_bounds(
         self,
         num_values: int = 0,
         min_periods: Optional[int] = None,
@@ -149,6 +150,29 @@ class Indexer(BaseIndexer):
                     "This case should have been handled before! Please report this bug"
                 )
         return start, end
+
+    if INDEXER_WINDOW_STEP_IMPLEMENTED:
+
+        def get_window_bounds(
+            self,
+            num_values: int = 0,
+            min_periods: Optional[int] = None,
+            center: Optional[bool] = None,
+            closed: Optional[str] = None,
+            step: Optional[int] = None,
+        ) -> Tuple[np.ndarray, np.ndarray]:
+            return self._get_window_bounds(num_values, min_periods, center, closed)
+
+    else:
+
+        def get_window_bounds(
+            self,
+            num_values: int = 0,
+            min_periods: Optional[int] = None,
+            center: Optional[bool] = None,
+            closed: Optional[str] = None,
+        ) -> Tuple[np.ndarray, np.ndarray]:
+            return self._get_window_bounds(num_values, min_periods, center, closed)
 
 
 def map_on_each_group(


### PR DESCRIPTION
With pandas 1.5 the `get_window_bounds` method of `baseIndexer` added a `step` argument which was causing failing tests during the pandas signature inspection.  This pr fixes that by added the arg for pandas>=1.5