### PR TITLE
[DF] Fix regressions in `EliminateAggDistinct`, run `cargo test` in CI

### DIFF
--- a/.github/actions/setup-builder/action.yaml
+++ b/.github/actions/setup-builder/action.yaml
@@ -1,0 +1,17 @@
+name: Prepare Rust Builder
+description: 'Prepare Rust Build Environment'
+inputs:
+  rust-version:
+    description: 'version of rust to install (e.g. stable)'
+    required: true
+    default: 'stable'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Rust toolchain
+      shell: bash
+      run: |
+        echo "Installing ${{ inputs.rust-version }}"
+        rustup toolchain install ${{ inputs.rust-version }}
+        rustup default ${{ inputs.rust-version }}
+        rustup component add rustfmt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,75 @@
+name: Rust
+
+on:
+  # always trigger on PR
+  push:
+  pull_request:
+  # manual trigger
+  # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
+
+jobs:
+  # Check crate compiles
+  linux-build-lib:
+    name: cargo check
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache Cargo
+        uses: actions/cache@v3
+        with:
+          # these represent dependencies downloaded by cargo
+          # and thus do not depend on the OS, arch nor rust version.
+          path: /github/home/.cargo
+          key: cargo-cache-
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Check workspace in debug mode
+        run: |
+          cargo check
+      - name: Check workspace in release mode
+        run: |
+          cargo check --release
+      - name: Check workspace without default features
+        run: |
+          cargo check --no-default-features -p datafusion
+      - name: Check workspace with all features
+        run: |
+          cargo check
+
+  # test the crate
+  linux-test:
+    name: cargo test (amd64)
+    needs: [linux-build-lib]
+    runs-on: ubuntu-latest
+    container:
+      image: amd64/rust
+      env:
+        # Disable full debug symbol generation to speed up CI build and keep memory down
+        # "1" means line tables only, which is useful for panic tracebacks.
+        RUSTFLAGS: "-C debuginfo=1"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Cache Cargo
+        uses: actions/cache@v3
+        with:
+          path: /github/home/.cargo
+          # this key equals the ones on `linux-build-lib` for re-use
+          key: cargo-cache-
+      - name: Setup Rust toolchain
+        uses: ./.github/actions/setup-builder
+        with:
+          rust-version: stable
+      - name: Run tests
+        run: |
+          cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,16 +34,12 @@ jobs:
           rust-version: stable
       - name: Check workspace in debug mode
         run: |
+          cd dask_planner
           cargo check
       - name: Check workspace in release mode
         run: |
+          cd dask_planner
           cargo check --release
-      - name: Check workspace without default features
-        run: |
-          cargo check --no-default-features -p datafusion
-      - name: Check workspace with all features
-        run: |
-          cargo check
 
   # test the crate
   linux-test:
@@ -72,4 +68,5 @@ jobs:
           rust-version: stable
       - name: Run tests
         run: |
+          cd dask_planner
           cargo test


### PR DESCRIPTION
We haven't been running `cargo test` in CI and some regressions crept in.

The goal of this PR is just to get us back to a stable point and enable Rust tests in CI.

Changes in this PR:

- Run `cargo test` in CI
- Revert to an earlier version of the EliminateAggDistinct rule and ignore 2 failing tests

Proof that this works (from the logs):

```
running 9 tests
test sql::optimizer::eliminate_agg_distinct::tests::test_count_and_distinct_no_group_by ... ok
test sql::optimizer::eliminate_agg_distinct::tests::test_count_and_distinct_no_group_by_with_alias ... ok
test sql::optimizer::eliminate_agg_distinct::tests::test_multiple_distinct ... ok
test sql::optimizer::eliminate_agg_distinct::tests::test_count_and_distinct_group_by ... ok
test sql::optimizer::eliminate_agg_distinct::tests::test_multiple_distinct_with_aliases ... ok
test sql::optimizer::eliminate_agg_distinct::tests::test_single_distinct_group_by ... ignored
test sql::optimizer::eliminate_agg_distinct::tests::test_single_distinct_group_by_with_alias ... ignored
test sql::optimizer::eliminate_agg_distinct::tests::test_single_distinct_no_group_by ... ok
test sql::optimizer::eliminate_agg_distinct::tests::test_single_distinct_no_group_by_with_alias ... ok

test result: ok. 7 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.01s
```