### PR TITLE
Handle nullable types and empty partitions before Dask-ML predict

### DIFF
--- a/dask_sql/physical/rel/custom/create_model.py
+++ b/dask_sql/physical/rel/custom/create_model.py
@@ -1,4 +1,5 @@
 import logging
+import numpy as np
 from typing import TYPE_CHECKING
 
 from dask import delayed
@@ -183,7 +184,13 @@ class CreateModelPlugin(BaseRelPlugin):
 
             delayed_model = [delayed(model.fit)(x_p, y_p) for x_p, y_p in zip(X_d, y_d)]
             model = delayed_model[0].compute()
-            model = ParallelPostFit(estimator=model)
+            output_meta = np.array([])
+            model = ParallelPostFit(
+                estimator=model,
+                predict_meta=output_meta,
+                predict_proba_meta=output_meta,
+                transform_meta=output_meta,
+            )
 
         else:
             model.fit(X, y, **fit_kwargs)

--- a/dask_sql/physical/rel/custom/create_model.py
+++ b/dask_sql/physical/rel/custom/create_model.py
@@ -1,7 +1,7 @@
 import logging
-import numpy as np
 from typing import TYPE_CHECKING
 
+import numpy as np
 from dask import delayed
 
 from dask_sql.datacontainer import DataContainer

--- a/dask_sql/physical/rel/custom/predict.py
+++ b/dask_sql/physical/rel/custom/predict.py
@@ -1,7 +1,8 @@
 import logging
-import numpy as np
 import uuid
 from typing import TYPE_CHECKING
+
+import numpy as np
 
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.physical.rel.base import BaseRelPlugin
@@ -61,7 +62,10 @@ class PredictModelPlugin(BaseRelPlugin):
         model, training_columns = context.schema[schema_name].models[model_name]
         df = context.sql(sql_select)
         part = df[training_columns]
-        output_meta = model.predict_meta
+        try:
+            output_meta = model.predict_meta
+        except AttributeError:
+            output_meta = None
         if part.shape[0].compute() == 0 and output_meta is not None:
             empty_output = self.handle_empty_partitions(output_meta)
             if empty_output is not None:
@@ -87,7 +91,7 @@ class PredictModelPlugin(BaseRelPlugin):
 
         return dc
 
-    def handle_empty_partitions(self, output_meta):            
+    def handle_empty_partitions(self, output_meta):
         if hasattr(output_meta, "__array_function__"):
             if len(output_meta.shape) == 1:
                 shape = 0


### PR DESCRIPTION
Tagging @randerzander and @VibhuJawa 

Changes in `create_model.py` handle nullable types, such as for this example:

```
df = pd.DataFrame({
    "rough_day_of_year": pd.Series([0, 1, 2, 3], dtype='Int32'),
    "prev_day_inches_rained": pd.Series([0, 1, 2, 3], dtype='float32'),
    "rained": pd.Series([False, False, False, True])
})
c.create_table("train_set", df)

model_class = ".linear_model.LogisticRegression'"
if GPU:
    model_class = "'cuml" + model_class
else:
    model_class = "'sklearn" + model_class

c.sql(f"""
CREATE OR REPLACE MODEL model WITH (
    model_class = {model_class},
     wrap_predict = True,
     wrap_fit = False,
    target_column = 'rained'
) AS (
    SELECT *
    FROM train_set
)
""")

c.sql("""
SELECT * FROM PREDICT(
  MODEL model,
  SELECT * FROM train_set
)
""").compute()
```

Changes in `predict.py` handle empty partitions, modeled based on this Dask-ML PR: https://github.com/dask/dask-ml/pull/912
