### PR TITLE
Fix new clippy warnings

### DIFF
--- a/dask_planner/src/sql/logical/analyze_table.rs
+++ b/dask_planner/src/sql/logical/analyze_table.rs
@@ -85,7 +85,7 @@ impl PyAnalyzeTable {
             .schema_name
             .as_ref()
             .cloned()
-            .unwrap_or_else(|| "".to_string()))
+            .unwrap_or_default())
     }
 
     #[pyo3(name = "getColumns")]

--- a/dask_planner/src/sql/logical/show_columns.rs
+++ b/dask_planner/src/sql/logical/show_columns.rs
@@ -79,7 +79,7 @@ impl PyShowColumns {
             .schema_name
             .as_ref()
             .cloned()
-            .unwrap_or_else(|| "".to_string()))
+            .unwrap_or_default())
     }
 }
 

--- a/dask_planner/src/sql/logical/show_schema.rs
+++ b/dask_planner/src/sql/logical/show_schema.rs
@@ -67,12 +67,7 @@ pub struct PyShowSchema {
 impl PyShowSchema {
     #[pyo3(name = "getLike")]
     fn get_like(&self) -> PyResult<String> {
-        Ok(self
-            .show_schema
-            .like
-            .as_ref()
-            .cloned()
-            .unwrap_or_else(|| "".to_string()))
+        Ok(self.show_schema.like.as_ref().cloned().unwrap_or_default())
     }
 }
 

--- a/dask_planner/src/sql/logical/show_tables.rs
+++ b/dask_planner/src/sql/logical/show_tables.rs
@@ -72,7 +72,7 @@ impl PyShowTables {
             .schema_name
             .as_ref()
             .cloned()
-            .unwrap_or_else(|| "".to_string()))
+            .unwrap_or_default())
     }
 }
 


### PR DESCRIPTION
After running `rustup update` to pick up Rust 1.64, there are new clippy warnings.