### PR TITLE
Fix docker build errors

### DIFF
--- a/docker/main.dockerfile
+++ b/docker/main.dockerfile
@@ -25,7 +25,9 @@ RUN conda config --add channels conda-forge \
     "dask-ml>=2022.1.22" \
     "scikit-learn>=1.0.0" \
     "intake>=0.6.0" \
-    && conda clean -ay
+    && conda clean -ay \
+    && apt-get update \
+    && apt-get install build-essential -y
 
 # install dask-sql
 COPY setup.py /opt/dask_sql/


### PR DESCRIPTION
Fixes some of the docker build errors seen in https://github.com/dask-contrib/dask-sql/actions/runs/3114356609/jobs/5050098670 by installing build-essentials that includes the cc compiler needed for some rust build steps. 