### PR TITLE
Fix `if` condition for gpuCI updating workflow

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -75,6 +75,7 @@ jobs:
         # make sure ucx-py nightlies are available and that cuDF/cuML nightly versions match up
         if: |
           env.UCX_PY_VER != env.NEW_UCX_PY_VER &&
+          env.RAPIDS_VER != env.NEW_CUDF_VER &&
           env.NEW_CUDF_VER == env.NEW_CUML_VER
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates the conditional for opening a gpuCI-updating PR to handle the edge case where new UCX-Py nightlies are available before RAPIDS nightlies.