### PR TITLE
`pip` install `awscli` in cloud images

### DIFF
--- a/docker/cloud.dockerfile
+++ b/docker/cloud.dockerfile
@@ -5,7 +5,7 @@ RUN conda config --add channels conda-forge \
     && /opt/conda/bin/mamba install --freeze-installed -y \
     s3fs \
     dask-cloudprovider \
-    awscli \
+    && pip install awscli \
     && conda clean -ay
 
 ENTRYPOINT ["tini", "-g", "--", "/usr/bin/prepare.sh"]


### PR DESCRIPTION
This should unblock Docker build / uploads for now; @ayushdg pointed out that another solution would be to create the initial conda environment without `--freeze-installed`, which might be worthwhile to explore once we have Docker checks running in CI.