### PR TITLE
Check default `cargo` being used by GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,6 +164,9 @@ jobs:
           channel-priority: strict
       - name: Install dependencies and nothing else
         run: |
+          which cargo
+          cargo --version
+
           mamba install setuptools-rust
           pip install -e . -vv
 


### PR DESCRIPTION
Looks like our bare requirement CI is passing without setting up a Rust toolchain, which seems to imply one is already present in the GHA runner.