### PR TITLE
Add dependabot config to update Rust deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/dask_planner"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
We want to make sure we stay up to date with dependencies, especially when there are vulnerabilities that have been patched.