### PR TITLE
Improve `SqlTypeName` to support more types and also improve error handling

### DIFF
--- a/dask_planner/Cargo.lock
+++ b/dask_planner/Cargo.lock
@@ -28,18 +28,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121d8a5b0346092c18a4b2fd6f620d7a06f0eb7ac0a45860939a0884bc579c56"
+checksum = "85914173c2f558d61613bfbbf1911f14e630895087a7ed2fafc0f5319e1536e7"
 dependencies = [
  "strum",
  "strum_macros",
@@ -247,9 +247,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -506,9 +506,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.46"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -547,9 +547,9 @@ checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -626,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "libm"
@@ -647,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658646b21e0b72f7866c7038ab086d3d5e1cd6271f060fd37defb241949d0582"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
  "digest",
 ]
@@ -806,15 +806,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "ordered-float"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bcbab4bfea7a59c2c0fe47211a1ac4e3e96bea6eb446d704f310bc5c732ae2"
+checksum = "98ffdb14730ed2ef599c65810c15b000896e21e8776b512de0db0c3d7335cc2a"
 dependencies = [
  "num-traits",
 ]
@@ -844,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9423e2b32f7a043629287a536f21951e8c6a82482d0acb1eeebfc90bc2225b22"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "pin-project-lite"
@@ -868,9 +868,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -965,7 +965,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -985,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.7",
 ]
@@ -1067,18 +1067,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1098,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1155,9 +1155,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1181,18 +1181,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1210,13 +1210,12 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "tokio-macros",
@@ -1241,21 +1240,21 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unindent"
@@ -1292,9 +1291,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1302,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -1317,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1327,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1340,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "winapi"

--- a/dask_planner/rust-toolchain.toml
+++ b/dask_planner/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/dask_planner/rust-toolchain.toml
+++ b/dask_planner/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/dask_planner/src/error.rs
+++ b/dask_planner/src/error.rs
@@ -2,6 +2,7 @@ use datafusion_common::DataFusionError;
 use datafusion_sql::sqlparser::parser::ParserError;
 use datafusion_sql::sqlparser::tokenizer::TokenizerError;
 use pyo3::PyErr;
+use std::fmt::{Display, Formatter};
 
 pub type Result<T> = std::result::Result<T, DaskPlannerError>;
 
@@ -11,6 +12,17 @@ pub enum DaskPlannerError {
     ParserError(ParserError),
     TokenizerError(TokenizerError),
     Internal(String),
+}
+
+impl Display for DaskPlannerError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DataFusionError(e) => write!(f, "DataFusion Error: {}", e),
+            Self::ParserError(e) => write!(f, "SQL Parser Error: {}", e),
+            Self::TokenizerError(e) => write!(f, "SQL Tokenizer Error: {}", e),
+            Self::Internal(e) => write!(f, "Internal Error: {}", e),
+        }
+    }
 }
 
 impl From<TokenizerError> for DaskPlannerError {

--- a/dask_planner/src/error.rs
+++ b/dask_planner/src/error.rs
@@ -1,4 +1,6 @@
 use datafusion_common::DataFusionError;
+use datafusion_sql::sqlparser::parser::ParserError;
+use datafusion_sql::sqlparser::tokenizer::TokenizerError;
 use pyo3::PyErr;
 
 pub type Result<T> = std::result::Result<T, DaskPlannerError>;
@@ -6,7 +8,21 @@ pub type Result<T> = std::result::Result<T, DaskPlannerError>;
 #[derive(Debug)]
 pub enum DaskPlannerError {
     DataFusionError(DataFusionError),
+    ParserError(ParserError),
+    TokenizerError(TokenizerError),
     Internal(String),
+}
+
+impl From<TokenizerError> for DaskPlannerError {
+    fn from(err: TokenizerError) -> Self {
+        Self::TokenizerError(err)
+    }
+}
+
+impl From<ParserError> for DaskPlannerError {
+    fn from(err: ParserError) -> Self {
+        Self::ParserError(err)
+    }
 }
 
 impl From<DataFusionError> for DaskPlannerError {

--- a/dask_planner/src/sql/logical.rs
+++ b/dask_planner/src/sql/logical.rs
@@ -31,9 +31,10 @@ pub mod table_scan;
 pub mod use_schema;
 pub mod window;
 
-use datafusion_common::{DFSchemaRef, DataFusionError, Result};
+use datafusion_common::{DFSchemaRef, DataFusionError};
 use datafusion_expr::LogicalPlan;
 
+use crate::error::Result;
 use crate::sql::exceptions::py_type_err;
 use pyo3::prelude::*;
 
@@ -231,7 +232,7 @@ impl PyLogicalPlan {
     /// otherwise None is returned
     #[pyo3(name = "getTable")]
     pub fn table(&mut self) -> PyResult<table::DaskTable> {
-        match table::table_from_logical_plan(&self.current_node()) {
+        match table::table_from_logical_plan(&self.current_node())? {
             Some(table) => Ok(table),
             None => Err(py_type_err(
                 "Unable to compute DaskTable from DataFusion LogicalPlan",

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -13,6 +13,7 @@ use datafusion_expr::{Expr, LogicalPlan, TableProviderFilterPushDown, TableSourc
 use datafusion_sql::TableReference;
 use pyo3::prelude::*;
 
+use crate::error::DaskPlannerError;
 use datafusion_optimizer::utils::split_conjunction;
 use std::any::Any;
 use std::sync::Arc;
@@ -154,7 +155,9 @@ impl DaskTable {
 }
 
 /// Traverses the logical plan to locate the Table associated with the query
-pub(crate) fn table_from_logical_plan(plan: &LogicalPlan) -> Option<DaskTable> {
+pub(crate) fn table_from_logical_plan(
+    plan: &LogicalPlan,
+) -> Result<Option<DaskTable>, DaskPlannerError> {
     match plan {
         LogicalPlan::Projection(projection) => table_from_logical_plan(&projection.input),
         LogicalPlan::Filter(filter) => table_from_logical_plan(&filter.input),
@@ -169,7 +172,10 @@ pub(crate) fn table_from_logical_plan(plan: &LogicalPlan) -> Option<DaskTable> {
                 let data_type: &DataType = field.data_type();
                 cols.push((
                     String::from(field.name()),
-                    DaskTypeMap::from(SqlTypeName::from_arrow(data_type), data_type.clone().into()),
+                    DaskTypeMap::from(
+                        SqlTypeName::from_arrow(data_type)?,
+                        data_type.clone().into(),
+                    ),
                 ));
             }
 
@@ -184,12 +190,12 @@ pub(crate) fn table_from_logical_plan(plan: &LogicalPlan) -> Option<DaskTable> {
                 } => (schema, table),
             };
 
-            Some(DaskTable {
+            Ok(Some(DaskTable {
                 schema: String::from(schema),
                 name: String::from(tbl),
                 statistics: DaskStatistics { row_count: 0.0 },
                 columns: cols,
-            })
+            }))
         }
         LogicalPlan::Join(join) => {
             //TODO: Don't always hardcode the left
@@ -205,43 +211,46 @@ pub(crate) fn table_from_logical_plan(plan: &LogicalPlan) -> Option<DaskTable> {
                 let data_type: &DataType = field.data_type();
                 cols.push((
                     String::from(field.name()),
-                    DaskTypeMap::from(SqlTypeName::from_arrow(data_type), data_type.clone().into()),
+                    DaskTypeMap::from(
+                        SqlTypeName::from_arrow(data_type)?,
+                        data_type.clone().into(),
+                    ),
                 ));
             }
 
-            Some(DaskTable {
+            Ok(Some(DaskTable {
                 schema: String::from("EmptySchema"),
                 name: String::from("EmptyRelation"),
                 statistics: DaskStatistics { row_count: 0.0 },
                 columns: cols,
-            })
+            }))
         }
         LogicalPlan::Extension(ex) => {
             let node = ex.node.as_any();
             if let Some(e) = node.downcast_ref::<CreateTablePlanNode>() {
-                Some(DaskTable {
+                Ok(Some(DaskTable {
                     schema: e.table_schema.clone(),
                     name: e.table_name.clone(),
                     statistics: DaskStatistics { row_count: 0.0 },
                     columns: vec![],
-                })
+                }))
             } else if let Some(e) = node.downcast_ref::<PredictModelPlanNode>() {
-                Some(DaskTable {
+                Ok(Some(DaskTable {
                     schema: e.model_schema.clone(),
                     name: e.model_name.clone(),
                     statistics: DaskStatistics { row_count: 0.0 },
                     columns: vec![],
-                })
+                }))
             } else {
-                todo!(
+                Err(DaskPlannerError::Internal(format!(
                     "table_from_logical_plan: unimplemented LogicalPlan type {:?} encountered",
                     plan
-                )
+                )))
             }
         }
-        _ => todo!(
+        _ => Err(DaskPlannerError::Internal(format!(
             "table_from_logical_plan: unimplemented LogicalPlan type {:?} encountered",
             plan
-        ),
+        ))),
     }
 }

--- a/dask_planner/src/sql/types.rs
+++ b/dask_planner/src/sql/types.rs
@@ -3,9 +3,9 @@ use arrow::datatypes::{DataType, IntervalUnit, TimeUnit};
 pub mod rel_data_type;
 pub mod rel_data_type_field;
 
+use crate::error::DaskPlannerError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
-use crate::error::DaskPlannerError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[pyclass(name = "RexType", module = "datafusion")]
@@ -321,11 +321,14 @@ impl SqlTypeName {
             "DECIMAL" => Ok(SqlTypeName::DECIMAL),
             "DYNAMIC_STAT" => Ok(SqlTypeName::DYNAMIC_STAR),
             "UNKNOWN" => Ok(SqlTypeName::UNKNOWN),
-            _ => Err(DaskPlannerError::Internal(format!("Cannot determine SQL type name for '{}'", input_type)).into()),
+            _ => Err(DaskPlannerError::Internal(format!(
+                "Cannot determine SQL type name for '{}'",
+                input_type
+            ))
+            .into()),
         }
     }
 }
-
 
 #[cfg(test)]
 mod test {
@@ -333,12 +336,19 @@ mod test {
 
     #[test]
     fn valid_type_name() {
-        assert_eq!("", &format!("{:?}", SqlTypeName::from_string("string").unwrap()));
+        assert_eq!(
+            "VARCHAR",
+            &format!("{:?}", SqlTypeName::from_string("string").unwrap())
+        );
     }
 
     #[test]
     fn invalid_type_name() {
-        assert_eq!("", SqlTypeName::from_string("42").expect_err("invalid type name").to_string());
+        assert_eq!(
+            "Cannot determine SQL type name for '42'",
+            SqlTypeName::from_string("42")
+                .expect_err("invalid type name")
+                .to_string()
+        );
     }
-
 }

--- a/dask_planner/src/sql/types.rs
+++ b/dask_planner/src/sql/types.rs
@@ -5,6 +5,7 @@ pub mod rel_data_type_field;
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+use crate::error::DaskPlannerError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[pyclass(name = "RexType", module = "datafusion")]
@@ -269,58 +270,75 @@ impl SqlTypeName {
 impl SqlTypeName {
     #[pyo3(name = "fromString")]
     #[staticmethod]
-    pub fn from_string(input_type: &str) -> Self {
-        match input_type {
-            "ANY" => SqlTypeName::ANY,
-            "ARRAY" => SqlTypeName::ARRAY,
-            "NULL" => SqlTypeName::NULL,
-            "BOOLEAN" => SqlTypeName::BOOLEAN,
-            "COLUMN_LIST" => SqlTypeName::COLUMN_LIST,
-            "DISTINCT" => SqlTypeName::DISTINCT,
-            "CURSOR" => SqlTypeName::CURSOR,
-            "TINYINT" => SqlTypeName::TINYINT,
-            "SMALLINT" => SqlTypeName::SMALLINT,
-            "INT" => SqlTypeName::INTEGER,
-            "INTEGER" => SqlTypeName::INTEGER,
-            "BIGINT" => SqlTypeName::BIGINT,
-            "REAL" => SqlTypeName::REAL,
-            "FLOAT" => SqlTypeName::FLOAT,
-            "GEOMETRY" => SqlTypeName::GEOMETRY,
-            "DOUBLE" => SqlTypeName::DOUBLE,
-            "TIME" => SqlTypeName::TIME,
-            "TIME_WITH_LOCAL_TIME_ZONE" => SqlTypeName::TIME_WITH_LOCAL_TIME_ZONE,
-            "TIMESTAMP" => SqlTypeName::TIMESTAMP,
-            "TIMESTAMP_WITH_LOCAL_TIME_ZONE" => SqlTypeName::TIMESTAMP_WITH_LOCAL_TIME_ZONE,
-            "DATE" => SqlTypeName::DATE,
-            "INTERVAL" => SqlTypeName::INTERVAL,
-            "INTERVAL_DAY" => SqlTypeName::INTERVAL_DAY,
-            "INTERVAL_DAY_HOUR" => SqlTypeName::INTERVAL_DAY_HOUR,
-            "INTERVAL_DAY_MINUTE" => SqlTypeName::INTERVAL_DAY_MINUTE,
-            "INTERVAL_DAY_SECOND" => SqlTypeName::INTERVAL_DAY_SECOND,
-            "INTERVAL_HOUR" => SqlTypeName::INTERVAL_HOUR,
-            "INTERVAL_HOUR_MINUTE" => SqlTypeName::INTERVAL_HOUR_MINUTE,
-            "INTERVAL_HOUR_SECOND" => SqlTypeName::INTERVAL_HOUR_SECOND,
-            "INTERVAL_MINUTE" => SqlTypeName::INTERVAL_MINUTE,
-            "INTERVAL_MINUTE_SECOND" => SqlTypeName::INTERVAL_MINUTE_SECOND,
-            "INTERVAL_MONTH" => SqlTypeName::INTERVAL_MONTH,
-            "INTERVAL_SECOND" => SqlTypeName::INTERVAL_SECOND,
-            "INTERVAL_YEAR" => SqlTypeName::INTERVAL_YEAR,
-            "INTERVAL_YEAR_MONTH" => SqlTypeName::INTERVAL_YEAR_MONTH,
-            "MAP" => SqlTypeName::MAP,
-            "MULTISET" => SqlTypeName::MULTISET,
-            "OTHER" => SqlTypeName::OTHER,
-            "ROW" => SqlTypeName::ROW,
-            "SARG" => SqlTypeName::SARG,
-            "BINARY" => SqlTypeName::BINARY,
-            "VARBINARY" => SqlTypeName::VARBINARY,
-            "CHAR" => SqlTypeName::CHAR,
-            "VARCHAR" => SqlTypeName::VARCHAR,
-            "STRUCTURED" => SqlTypeName::STRUCTURED,
-            "SYMBOL" => SqlTypeName::SYMBOL,
-            "DECIMAL" => SqlTypeName::DECIMAL,
-            "DYNAMIC_STAT" => SqlTypeName::DYNAMIC_STAR,
-            "UNKNOWN" => SqlTypeName::UNKNOWN,
-            _ => unimplemented!("SqlTypeName::from_string() for str type: {}", input_type),
+    pub fn from_string(input_type: &str) -> PyResult<Self> {
+        match input_type.to_uppercase().as_ref() {
+            "ANY" => Ok(SqlTypeName::ANY),
+            "ARRAY" => Ok(SqlTypeName::ARRAY),
+            "NULL" => Ok(SqlTypeName::NULL),
+            "BOOLEAN" => Ok(SqlTypeName::BOOLEAN),
+            "COLUMN_LIST" => Ok(SqlTypeName::COLUMN_LIST),
+            "DISTINCT" => Ok(SqlTypeName::DISTINCT),
+            "CURSOR" => Ok(SqlTypeName::CURSOR),
+            "TINYINT" => Ok(SqlTypeName::TINYINT),
+            "SMALLINT" => Ok(SqlTypeName::SMALLINT),
+            "INT" => Ok(SqlTypeName::INTEGER),
+            "INTEGER" => Ok(SqlTypeName::INTEGER),
+            "BIGINT" => Ok(SqlTypeName::BIGINT),
+            "REAL" => Ok(SqlTypeName::REAL),
+            "FLOAT" => Ok(SqlTypeName::FLOAT),
+            "GEOMETRY" => Ok(SqlTypeName::GEOMETRY),
+            "DOUBLE" => Ok(SqlTypeName::DOUBLE),
+            "TIME" => Ok(SqlTypeName::TIME),
+            "TIME_WITH_LOCAL_TIME_ZONE" => Ok(SqlTypeName::TIME_WITH_LOCAL_TIME_ZONE),
+            "TIMESTAMP" => Ok(SqlTypeName::TIMESTAMP),
+            "TIMESTAMP_WITH_LOCAL_TIME_ZONE" => Ok(SqlTypeName::TIMESTAMP_WITH_LOCAL_TIME_ZONE),
+            "DATE" => Ok(SqlTypeName::DATE),
+            "INTERVAL" => Ok(SqlTypeName::INTERVAL),
+            "INTERVAL_DAY" => Ok(SqlTypeName::INTERVAL_DAY),
+            "INTERVAL_DAY_HOUR" => Ok(SqlTypeName::INTERVAL_DAY_HOUR),
+            "INTERVAL_DAY_MINUTE" => Ok(SqlTypeName::INTERVAL_DAY_MINUTE),
+            "INTERVAL_DAY_SECOND" => Ok(SqlTypeName::INTERVAL_DAY_SECOND),
+            "INTERVAL_HOUR" => Ok(SqlTypeName::INTERVAL_HOUR),
+            "INTERVAL_HOUR_MINUTE" => Ok(SqlTypeName::INTERVAL_HOUR_MINUTE),
+            "INTERVAL_HOUR_SECOND" => Ok(SqlTypeName::INTERVAL_HOUR_SECOND),
+            "INTERVAL_MINUTE" => Ok(SqlTypeName::INTERVAL_MINUTE),
+            "INTERVAL_MINUTE_SECOND" => Ok(SqlTypeName::INTERVAL_MINUTE_SECOND),
+            "INTERVAL_MONTH" => Ok(SqlTypeName::INTERVAL_MONTH),
+            "INTERVAL_SECOND" => Ok(SqlTypeName::INTERVAL_SECOND),
+            "INTERVAL_YEAR" => Ok(SqlTypeName::INTERVAL_YEAR),
+            "INTERVAL_YEAR_MONTH" => Ok(SqlTypeName::INTERVAL_YEAR_MONTH),
+            "MAP" => Ok(SqlTypeName::MAP),
+            "MULTISET" => Ok(SqlTypeName::MULTISET),
+            "OTHER" => Ok(SqlTypeName::OTHER),
+            "ROW" => Ok(SqlTypeName::ROW),
+            "SARG" => Ok(SqlTypeName::SARG),
+            "BINARY" => Ok(SqlTypeName::BINARY),
+            "VARBINARY" => Ok(SqlTypeName::VARBINARY),
+            "CHAR" => Ok(SqlTypeName::CHAR),
+            "VARCHAR" | "STRING" => Ok(SqlTypeName::VARCHAR),
+            "STRUCTURED" => Ok(SqlTypeName::STRUCTURED),
+            "SYMBOL" => Ok(SqlTypeName::SYMBOL),
+            "DECIMAL" => Ok(SqlTypeName::DECIMAL),
+            "DYNAMIC_STAT" => Ok(SqlTypeName::DYNAMIC_STAR),
+            "UNKNOWN" => Ok(SqlTypeName::UNKNOWN),
+            _ => Err(DaskPlannerError::Internal(format!("Cannot determine SQL type name for '{}'", input_type)).into()),
         }
     }
+}
+
+
+#[cfg(test)]
+mod test {
+    use crate::sql::types::SqlTypeName;
+
+    #[test]
+    fn valid_type_name() {
+        assert_eq!("", &format!("{:?}", SqlTypeName::from_string("string").unwrap()));
+    }
+
+    #[test]
+    fn invalid_type_name() {
+        assert_eq!("", SqlTypeName::from_string("42").expect_err("invalid type name").to_string());
+    }
+
 }

--- a/dask_planner/src/sql/types/rel_data_type_field.rs
+++ b/dask_planner/src/sql/types/rel_data_type_field.rs
@@ -1,7 +1,8 @@
 use crate::sql::types::DaskTypeMap;
 use crate::sql::types::SqlTypeName;
 
-use datafusion_common::{DFField, DFSchema, Result};
+use crate::error::Result;
+use datafusion_common::{DFField, DFSchema};
 
 use std::fmt;
 
@@ -28,7 +29,7 @@ impl RelDataTypeField {
             qualifier: qualifier.map(|qualifier| qualifier.to_string()),
             name: field.name().clone(),
             data_type: DaskTypeMap {
-                sql_type: SqlTypeName::from_arrow(field.data_type()),
+                sql_type: SqlTypeName::from_arrow(field.data_type())?,
                 data_type: field.data_type().clone().into(),
             },
             index: schema.index_of_column_by_name(qualifier, field.name())?,


### PR DESCRIPTION
- Improve `SqlTypeName::from_string()` to support more types, using the sql parser to parse parameterized types such as `VARCHAR(n)` and `DECIMAL(p, s)`
- Replaced some `todo!` and `unimplemented!` with `Err` and made corresponding changes in call sites