### PR TITLE
Remove rust-toolchain.toml

### DIFF
--- a/dask_planner/rust-toolchain.toml
+++ b/dask_planner/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"


### PR DESCRIPTION
We should not be building using nightly Rust, so I have removed the `rust-toolchain.toml`. I hadn't noticed that we had that until recently.