### PR TITLE
Configure dependabot to ignore `arrow` and `datafusion`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,6 @@ updates:
     ignore:
       # arrow and datafusion are bumped manually
       - dependency-name: "arrow"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "datafusion-*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/dask_planner"
     schedule:
       interval: "daily"
+    ignore:
+      # arrow and datafusion are bumped manually
+      - dependency-name: "arrow"
+      - dependency-name: "datafusion-*"


### PR DESCRIPTION
Makes it so new releases of `arrow` or `datafusion` will not trigger a dependabot PR, as we intend to update these dependencies manually