### PR TITLE
Add `/opt/cargo/bin` to gpuCI `PATH`

### DIFF
--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -34,7 +34,6 @@ gpuci_logger "Check GPU usage"
 nvidia-smi
 
 gpuci_logger "Check for rust compiler"
-ls -al /root
 which rustup
 which cargo
 which rustc

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -36,6 +36,7 @@ nvidia-smi
 gpuci_logger "Install rustup"
 curl -0 https://sh.rustup.rs -o rustup-init.sh
 sh rustup-init.sh -y --default-toolchain=stable --profile=minimal
+export PATH="${HOME}/.cargo/bin:${PATH}"
 
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -33,13 +33,9 @@ env
 gpuci_logger "Check GPU usage"
 nvidia-smi
 
-gpuci_logger "What user am I?"
-whoami
-
-gpuci_logger "Check for rust compiler"
-which rustup
-which cargo
-which rustc
+gpuci_logger "Install rustup"
+curl -0 https://sh.rustup.rs -o rustup-init.sh
+sh rustup-init.sh -y --default-toolchain=stable --profile=minimal
 
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -33,6 +33,9 @@ env
 gpuci_logger "Check GPU usage"
 nvidia-smi
 
+gpuci_logger "Can we access bins in opt?"
+which conda
+
 gpuci_logger "Try installing rustup in a shared location"
 export RUSTUP_HOME=/opt/rustup
 export CARGO_HOME=/opt/cargo

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -33,6 +33,12 @@ env
 gpuci_logger "Check GPU usage"
 nvidia-smi
 
+gpuci_logger "Check for rust compiler"
+ls -al /root
+which rustup
+which cargo
+which rustc
+
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh
 conda activate dask_sql

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -33,9 +33,9 @@ env
 gpuci_logger "Check GPU usage"
 nvidia-smi
 
-gpuci_logger "Can we access /opt/cargo?"
-which cargo
-which rustup
+gpuci_logger "Can we access /opt/cargo/bin/?"
+ls /opt/cargo/bin/
+/opt/cargo/bin/cargo
 
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -33,10 +33,12 @@ env
 gpuci_logger "Check GPU usage"
 nvidia-smi
 
-gpuci_logger "Install rustup"
+gpuci_logger "Try installing rustup in a shared location"
+export RUSTUP_HOME=/opt/rustup
+export CARGO_HOME=/opt/cargo
 curl -0 https://sh.rustup.rs -o rustup-init.sh
 sh rustup-init.sh -y --default-toolchain=stable --profile=minimal
-export PATH="${HOME}/.cargo/bin:${PATH}"
+export PATH="/opt/cargo/bin:${PATH}"
 
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -34,9 +34,8 @@ gpuci_logger "Check GPU usage"
 nvidia-smi
 
 gpuci_logger "Can we access /opt/cargo?"
-ls /opt/
-ls /opt/cargo/
-
+which cargo
+which rustup
 
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -33,9 +33,8 @@ env
 gpuci_logger "Check GPU usage"
 nvidia-smi
 
-gpuci_logger "Can we access /opt/cargo/bin/?"
-ls /opt/cargo/bin/
-/opt/cargo/bin/cargo
+gpuci_logger "Are rustup / cargo on PATH?"
+echo $PATH
 
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -33,15 +33,10 @@ env
 gpuci_logger "Check GPU usage"
 nvidia-smi
 
-gpuci_logger "Can we access bins in opt?"
-which conda
+gpuci_logger "Can we access /opt/cargo?"
+ls /opt/
+ls /opt/cargo/
 
-gpuci_logger "Try installing rustup in a shared location"
-export RUSTUP_HOME=/opt/rustup
-export CARGO_HOME=/opt/cargo
-curl -0 https://sh.rustup.rs -o rustup-init.sh
-sh rustup-init.sh -y --default-toolchain=stable --profile=minimal
-export PATH="/opt/cargo/bin:${PATH}"
 
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -33,6 +33,9 @@ env
 gpuci_logger "Check GPU usage"
 nvidia-smi
 
+gpuci_logger "What user am I?"
+whoami
+
 gpuci_logger "Check for rust compiler"
 which rustup
 which cargo

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -11,7 +11,7 @@ function hasArg {
 }
 
 # Set path and build parallel level
-export PATH=/opt/conda/bin:/usr/local/cuda/bin:$PATH
+export PATH=/opt/cargo/bin:/opt/conda/bin:/usr/local/cuda/bin:$PATH
 export PARALLEL_LEVEL=${PARALLEL_LEVEL:-4}
 
 # Set home to the job's workspace
@@ -32,9 +32,6 @@ env
 
 gpuci_logger "Check GPU usage"
 nvidia-smi
-
-gpuci_logger "Are rustup / cargo on PATH?"
-echo $PATH
 
 gpuci_logger "Activate conda env"
 . /opt/conda/etc/profile.d/conda.sh


### PR DESCRIPTION
Adds `/opt/cargo/bin` to the `PATH` in our gpuCI build script, so that we have access to the `rustup`-installed compiler tools.