### PR TITLE
Add parser support for `timestampadd`

### DIFF
--- a/dask_planner/src/parser.rs
+++ b/dask_planner/src/parser.rs
@@ -1236,6 +1236,23 @@ mod test {
     use crate::parser::{DaskParser, DaskStatement};
 
     #[test]
+    fn timestampadd() {
+        let sql = "SELECT TIMESTAMPADD(YEAR, 2, d) FROM t";
+        let statements = DaskParser::parse_sql(sql).unwrap();
+        assert_eq!(1, statements.len());
+        let actual = format!("{:?}", statements[0]);
+        let expected = "projection: [\
+        UnnamedExpr(Function(Function { name: ObjectName([Ident { value: \"TIMESTAMPADD\", quote_style: None }]), \
+        args: [\
+        Unnamed(Expr(Value(SingleQuotedString(\"YEAR\")))), \
+        Unnamed(Expr(Value(Number(\"2\", false)))), \
+        Unnamed(Expr(Identifier(Ident { value: \"d\", quote_style: None })))\
+        ], over: None, distinct: false, special: false }))\
+        ]";
+        assert!(actual.contains(expected));
+    }
+
+    #[test]
     fn create_model() {
         let sql = r#"CREATE MODEL my_model WITH (
             model_class = 'mock.MagicMock',


### PR DESCRIPTION
DataFusion's parser cannot parse `timestampadd(year, 2, d)` because `year` is not a keyword, so it assumes that this is an identifier and looks for a column with this name.

This PR works around the issue by providing a custom prefix parser in the `DaskSqlDialect` where we can override parsing of just this expression and then fall back to DataFusion. This is a new feature that was added to sqlparser relatively recently.



