### PR TITLE
Add testing for OSX

### DIFF
--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -42,14 +42,11 @@ jobs:
         run: |
           python setup.py build install
       - name: Install hive testing dependencies
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        env:
-          # `docker` isn't available on macos-latest, use colima instead
-          DOCKER_ENTRY: ${{ matrix.os == 'ubuntu-latest' && 'docker' || 'colima' }}
+        if: matrix.os == 'ubuntu-latest'
         run: |
           mamba install -c conda-forge "sasl>=0.3.1"
-          ${{ env.DOCKER_ENTRY }} pull bde2020/hive:2.3.2-postgresql-metastore
-          ${{ env.DOCKER_ENTRY }} pull bde2020/hive-metastore-postgresql:2.3.0
+          docker pull bde2020/hive:2.3.2-postgresql-metastore
+          docker pull bde2020/hive-metastore-postgresql:2.3.0
       - name: Install upstream dev Dask / dask-ml
         run: |
           mamba update dask

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -43,10 +43,13 @@ jobs:
           python setup.py build install
       - name: Install hive testing dependencies
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        env:
+          # `docker` isn't available on macos-latest, use colima instead
+          DOCKER_ENTRY: ${{ matrix.os == 'ubuntu-latest' && 'docker' || 'colima' }}
         run: |
-          mamba install -c conda-forge sasl>=0.3.1
-          docker pull bde2020/hive:2.3.2-postgresql-metastore
-          docker pull bde2020/hive-metastore-postgresql:2.3.0
+          mamba install -c conda-forge "sasl>=0.3.1"
+          ${{ env.DOCKER_ENTRY }} pull bde2020/hive:2.3.2-postgresql-metastore
+          ${{ env.DOCKER_ENTRY }} pull bde2020/hive-metastore-postgresql:2.3.0
       - name: Install upstream dev Dask / dask-ml
         run: |
           mamba update dask

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Build the Rust DataFusion bindings
         run: |
           python setup.py build install
-      - name: Install hive testing dependencies for Linux
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install hive testing dependencies
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: |
           mamba install -c conda-forge sasl>=0.3.1
           docker pull bde2020/hive:2.3.2-postgresql-metastore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,14 +59,11 @@ jobs:
         run: |
           python setup.py build install
       - name: Install hive testing dependencies
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        env:
-          # `docker` isn't available on macos-latest, use colima instead
-          DOCKER_ENTRY: ${{ matrix.os == 'ubuntu-latest' && 'docker' || 'colima' }}
+        if: matrix.os == 'ubuntu-latest'
         run: |
           mamba install -c conda-forge "sasl>=0.3.1"
-          ${{ env.DOCKER_ENTRY }} pull bde2020/hive:2.3.2-postgresql-metastore
-          ${{ env.DOCKER_ENTRY }} pull bde2020/hive-metastore-postgresql:2.3.0
+          docker pull bde2020/hive:2.3.2-postgresql-metastore
+          docker pull bde2020/hive-metastore-postgresql:2.3.0
       - name: Optionally install upstream dev Dask / dask-ml
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Build the Rust DataFusion bindings
         run: |
           python setup.py build install
-      - name: Install hive testing dependencies for Linux
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install hive testing dependencies
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         run: |
           mamba install -c conda-forge sasl>=0.3.1
           docker pull bde2020/hive:2.3.2-postgresql-metastore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,13 @@ jobs:
           python setup.py build install
       - name: Install hive testing dependencies
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+        env:
+          # `docker` isn't available on macos-latest, use colima instead
+          DOCKER_ENTRY: ${{ matrix.os == 'ubuntu-latest' && 'docker' || 'colima' }}
         run: |
-          mamba install -c conda-forge sasl>=0.3.1
-          docker pull bde2020/hive:2.3.2-postgresql-metastore
-          docker pull bde2020/hive-metastore-postgresql:2.3.0
+          mamba install -c conda-forge "sasl>=0.3.1"
+          ${{ env.DOCKER_ENTRY }} pull bde2020/hive:2.3.2-postgresql-metastore
+          ${{ env.DOCKER_ENTRY }} pull bde2020/hive-metastore-postgresql:2.3.0
       - name: Optionally install upstream dev Dask / dask-ml
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |

--- a/tests/integration/test_hive.py
+++ b/tests/integration/test_hive.py
@@ -10,7 +10,7 @@ from dask_sql.context import Context
 from tests.utils import assert_eq
 
 pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="hive testing not supported on Windows"
+    sys.platform in ("win32", "darwin"), reason="hive testing not supported on Windows/macOS"
 )
 docker = pytest.importorskip("docker")
 sqlalchemy = pytest.importorskip("sqlalchemy")
@@ -58,6 +58,8 @@ def hive_cursor():
     hive setup described by bde2020.
     """
     client = docker.from_env()
+
+    breakpoint()
 
     network = None
     hive_server = None

--- a/tests/integration/test_hive.py
+++ b/tests/integration/test_hive.py
@@ -60,8 +60,6 @@ def hive_cursor():
     """
     client = docker.from_env()
 
-    breakpoint()
-
     network = None
     hive_server = None
     hive_metastore = None

--- a/tests/integration/test_hive.py
+++ b/tests/integration/test_hive.py
@@ -10,7 +10,8 @@ from dask_sql.context import Context
 from tests.utils import assert_eq
 
 pytestmark = pytest.mark.skipif(
-    sys.platform in ("win32", "darwin"), reason="hive testing not supported on Windows/macOS"
+    sys.platform in ("win32", "darwin"),
+    reason="hive testing not supported on Windows/macOS",
 )
 docker = pytest.importorskip("docker")
 sqlalchemy = pytest.importorskip("sqlalchemy")

--- a/tests/integration/test_postgres.py
+++ b/tests/integration/test_postgres.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 pytestmark = pytest.mark.skipif(
-    sys.platform == "win32", reason="postgres testing not supported on Windows"
+    sys.platform in ("win32", "darwin"), reason="hive testing not supported on Windows/macOS"
 )
 docker = pytest.importorskip("docker")
 sqlalchemy = pytest.importorskip("sqlalchemy")

--- a/tests/integration/test_postgres.py
+++ b/tests/integration/test_postgres.py
@@ -3,7 +3,8 @@ import sys
 import pytest
 
 pytestmark = pytest.mark.skipif(
-    sys.platform in ("win32", "darwin"), reason="hive testing not supported on Windows/macOS"
+    sys.platform in ("win32", "darwin"),
+    reason="hive testing not supported on Windows/macOS",
 )
 docker = pytest.importorskip("docker")
 sqlalchemy = pytest.importorskip("sqlalchemy")


### PR DESCRIPTION
With our CI matrix significantly slimmed with the switch to DataFusion, now might be a good time to begin doing dedicated tests on OSX, since we are publishing packages for the platform.