### PR TITLE
Check for `np.timedelta64` in `as_timelike`

### DIFF
--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -44,9 +44,7 @@ def as_timelike(op):
         return np.timedelta64(op, "D")
     elif isinstance(op, str):
         return np.datetime64(op)
-    elif pd.api.types.is_datetime64_dtype(op):
-        return op
-    elif isinstance(op, np.timedelta64):
+    elif pd.api.types.is_datetime64_dtype(op) or isinstance(op, np.timedelta64):
         return op
     else:
         raise ValueError(f"Don't know how to make {type(op)} timelike")

--- a/dask_sql/physical/rex/core/call.py
+++ b/dask_sql/physical/rex/core/call.py
@@ -46,6 +46,8 @@ def as_timelike(op):
         return np.datetime64(op)
     elif pd.api.types.is_datetime64_dtype(op):
         return op
+    elif isinstance(op, np.timedelta64):
+        return op
     else:
         raise ValueError(f"Don't know how to make {type(op)} timelike")
 

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -59,10 +59,27 @@ def test_intervals(c):
         """SELECT INTERVAL '3' DAY as "IN"
         """
     )
-
     expected_df = pd.DataFrame(
         {
             "IN": [pd.to_timedelta("3d")],
+        }
+    )
+    assert_eq(df, expected_df)
+
+    date1 = datetime(2021, 10, 3, 15, 53, 42, 47)
+    date2 = datetime(2021, 2, 28, 15, 53, 42, 47)
+    dates = dd.from_pandas(pd.DataFrame({"d": [date1, date2]}), npartitions=1)
+    c.register_dask_table(dates, "dates")
+    df = c.sql(
+        """SELECT d + INTERVAL '5 days' AS "Plus_5_days" FROM dates
+        """
+    )
+    expected_df = pd.DataFrame(
+        {
+            "Plus_5_days": [
+                datetime(2021, 10, 8, 15, 53, 42, 47),
+                datetime(2021, 3, 5, 15, 53, 42, 47),
+            ]
         }
     )
     assert_eq(df, expected_df)


### PR DESCRIPTION
When I try:

```
from dask_sql import Context
import pandas as pd
import dask.dataframe as dd
from datetime import datetime

c = Context()

date = datetime(2021, 10, 3, 15, 53, 42, 47)
date2 = datetime(2021, 2, 3, 15, 53, 42, 47)

df = dd.from_pandas(pd.DataFrame({"d": [date, date2]}), npartitions=1)
c.register_dask_table(df, "df")

c.sql(
"""
SELECT d + INTERVAL '5 days' FROM df
"""
)
```

It fails with a `Don't know how to make <class 'numpy.timedelta64'> timelike`. This is because we are adding 5 days (432000000 milliseconds) but not checking if it's a `np.timedelta64` type (in which case, it's already in the desired format and can be returned as is). This small PR fixes the bug.