### PR TITLE
Wrap `which_upstream` logic in expression syntax

### DIFF
--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -19,14 +19,16 @@ defaults:
     shell: bash -l {0}
 
 env:
-  which_upsteam: |
-    github.event_name == 'workflow_dispatch'
-    && inputs.which_upstream
-    || (
-      github.event.schedule == '0 0 * * *'
-      && 'Dask'
-      || 'DataFusion'
-    )
+  which_upsteam: >-
+    ${{
+      github.event_name == 'workflow_dispatch'
+      && inputs.which_upstream
+      || (
+        github.event.schedule == '0 0 * * *'
+        && 'Dask'
+        || 'DataFusion'
+      )
+    }}
 
 jobs:
   test-dev:


### PR DESCRIPTION
Missed this part of GHA's expression docs where expressions outside of `if:` blocks must be wrapped in `${{ ... }}` so that they aren't interpreted as strings:

https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions

cc @ayushdg apologies for the mislead on your initial PR 🙂 

