### PR TITLE
Only use upstream Dask in scheduled cluster testing if `which_upstream == 'Dask'`

### DIFF
--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -119,7 +119,11 @@ jobs:
           python -m pip install --no-deps git+https://github.com/dask/dask-ml
       - name: run a dask cluster
         run: |
-          docker-compose -f .github/cluster-upstream.yml up -d
+          if [[ $which_upstream == "Dask" ]]; then
+            docker-compose -f .github/cluster-upstream.yml up -d
+          else
+            docker-compose -f .github/cluster.yml up -d
+          fi
 
           # periodically ping logs until a connection has been established; assume failure after 2 minutes
           timeout 2m bash -c 'until docker logs dask-worker 2>&1 | grep -q "Starting established connection"; do sleep 1; done'


### PR DESCRIPTION
We're seeing failures in #871 because our scheduled cluster testing is always using upstream Dask, even for upstream DataFusion testing.

This PR adds a conditional so that upstream Dask is only installed in the cluster when `which_upstream == 'Dask'`, which should resolve these failures.