### PR TITLE
Temporarily fix gpuci

### DIFF
--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -52,8 +52,8 @@ python -m pip install git+https://github.com/dask/dask
 gpuci_logger "Install distributed"
 python -m pip install git+https://github.com/dask/distributed
 
-gpuci_logger "Install latedt dask-cuda"
-gpuci_mamba_retry install -y -c rapidsai-nightly dask-cuda
+gpuci_logger "Install latest dask-cuda"
+gpuci_mamba_retry update -y -c rapidsai-nightly dask-cuda
 
 gpuci_logger "Install dask-sql"
 pip install -e ".[dev]"

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -52,6 +52,9 @@ python -m pip install git+https://github.com/dask/dask
 gpuci_logger "Install distributed"
 python -m pip install git+https://github.com/dask/distributed
 
+gpuci_logger "Install latedt dask-cuda"
+gpuci_mamba_retry install -y -c rapidsai-nightly dask-cuda
+
 gpuci_logger "Install dask-sql"
 pip install -e ".[dev]"
 


### PR DESCRIPTION
Fixes gpuci failures by installing latest dask-cuda from conda (instead of relying on the image) which contains a fix compatible with the latest dask.