### PR TITLE
Remove unnecessary `first` aggregation from groupby agg code

### DIFF
--- a/dask_sql/physical/rel/logical/aggregate.py
+++ b/dask_sql/physical/rel/logical/aggregate.py
@@ -495,9 +495,7 @@ class DaskAggregatePlugin(BaseRelPlugin):
     ):
         tmp_df = dc.df
 
-        # format aggregations for Dask; also check if we can use fast path for
-        # groupby, which is only supported if we are not using any custom aggregations
-        # and our pandas version support dropna for groupbys
+        # format aggregations for Dask
         aggregations_dict = defaultdict(dict)
         for aggregation in aggregations:
             input_col, output_col, aggregation_f = aggregation


### PR DESCRIPTION
Right now, if group columns are specified for a groupby aggregation (e.g. `select name, sum(x) from df group by name`), we include a `first` aggregation to grab the relevant row values for each grouping. This shouldn't be necessary, as Dask groupby aggregations already provide this info in the resulting index.

This PR removes this `first` aggregation and retains the lost information by instead dropping the groupby agg index with `reset_index(drop=False)` when group columns are specified.