### PR TITLE
Resolve YAML parsing issues in gpuCI updating workflow

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -48,8 +48,8 @@ jobs:
           FULL_CUML_VER: ${{ steps.cuml_latest.outputs.version }}
           FULL_UCX_PY_VER: ${{ steps.ucx_py_latest.outputs.version }}
         run: |
-          echo RAPIDS_VER=$RAPIDS_VER_0 >> $GITHUB_ENV
-          echo UCX_PY_VER=$(curl -sL https://version.gpuci.io/rapids/$RAPIDS_VER_0) >> $GITHUB_ENV
+          echo RAPIDS_VER=${{ steps.rapids_current.outputs.RAPIDS_VER_0 }} >> $GITHUB_ENV
+          echo UCX_PY_VER=$(curl -sL https://version.gpuci.io/rapids/${{ steps.rapids_current.outputs.RAPIDS_VER_0 }}) >> $GITHUB_ENV
           echo NEW_CUDF_VER=${FULL_CUDF_VER::-10} >> $GITHUB_ENV
           echo NEW_CUML_VER=${FULL_CUML_VER::-10} >> $GITHUB_ENV
           echo NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-10} >> $GITHUB_ENV

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Parse current axis YAML
+        id: rapids_current
         uses: the-coding-turtle/ga-yaml-parser@v0.1.2
         with:
           file: continuous_integration/gpuci/axis.yaml


### PR DESCRIPTION
With the bump to `ga-yaml-parser@v0.1.2` in our gpuCI updating workflow, the behavior of the action's outputs changed, causing failures; this PR makes the necessary changes to get things working again.