### PR TITLE
Force nightly Dask install for upstream testing

### DIFF
--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install upstream dev Dask
         if: env.which_upstream == 'Dask'
         run: |
-          mamba update -c dask/label/dev dask
+          mamba update dask/label/dev::dask
       - name: Test with pytest
         run: |
           pytest --junitxml=junit/test-results.xml --cov-report=xml -n auto tests --dist loadfile
@@ -112,7 +112,7 @@ jobs:
       - name: Install upstream dev Dask
         if: env.which_upstream == 'Dask'
         run: |
-          mamba update -c dask/label/dev dask
+          mamba update  dask/label/dev::dask
       - name: run a dask cluster
         run: |
           if [[ $which_upstream == "Dask" ]]; then

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -56,7 +56,6 @@ jobs:
           use-mamba: true
           python-version: ${{ matrix.python }}
           channel-priority: strict
-          channels: dask/label/dev,conda-forge,nodefaults
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
       - name: Optionally update upstream cargo dependencies
@@ -76,7 +75,7 @@ jobs:
       - name: Install upstream dev Dask
         if: env.which_upstream == 'Dask'
         run: |
-          mamba update dask
+          mamba update -c dask/label/dev dask
       - name: Test with pytest
         run: |
           pytest --junitxml=junit/test-results.xml --cov-report=xml -n auto tests --dist loadfile
@@ -93,7 +92,6 @@ jobs:
           use-mamba: true
           python-version: "3.9"
           channel-priority: strict
-          channels: dask/label/dev,conda-forge,nodefaults
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.9-dev.yaml
       - name: Optionally update upstream cargo dependencies
@@ -114,7 +112,7 @@ jobs:
       - name: Install upstream dev Dask
         if: env.which_upstream == 'Dask'
         run: |
-          mamba update dask
+          mamba update -c dask/label/dev dask
       - name: run a dask cluster
         run: |
           if [[ $which_upstream == "Dask" ]]; then

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install upstream dev Dask
         if: env.which_upstream == 'Dask'
         run: |
-          mamba update dask/label/dev::dask
+          mamba install dask/label/dev::dask
       - name: Test with pytest
         run: |
           pytest --junitxml=junit/test-results.xml --cov-report=xml -n auto tests --dist loadfile
@@ -112,7 +112,7 @@ jobs:
       - name: Install upstream dev Dask
         if: env.which_upstream == 'Dask'
         run: |
-          mamba update  dask/label/dev::dask
+          mamba install  dask/label/dev::dask
       - name: run a dask cluster
         run: |
           if [[ $which_upstream == "Dask" ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Optionally install upstream dev Dask
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
-          mamba update -c dask/label/dev dask
+          mamba update dask/label/dev::dask
       - name: Test with pytest
         run: |
           pytest --junitxml=junit/test-results.xml --cov-report=xml -n auto tests --dist loadfile
@@ -108,7 +108,7 @@ jobs:
       - name: Optionally install upstream dev Dask
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
-          mamba update -c dask/label/dev dask
+          mamba update dask/label/dev::dask
       - name: run a dask cluster
         env:
           UPSTREAM: ${{ needs.detect-ci-trigger.outputs.triggered }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Optionally install upstream dev Dask
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
-          mamba update dask/label/dev::dask
+          mamba install dask/label/dev::dask
       - name: Test with pytest
         run: |
           pytest --junitxml=junit/test-results.xml --cov-report=xml -n auto tests --dist loadfile
@@ -108,7 +108,7 @@ jobs:
       - name: Optionally install upstream dev Dask
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
-          mamba update dask/label/dev::dask
+          mamba install dask/label/dev::dask
       - name: run a dask cluster
         env:
           UPSTREAM: ${{ needs.detect-ci-trigger.outputs.triggered }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
           use-mamba: true
           python-version: ${{ matrix.python }}
           channel-priority: strict
-          channels: ${{ needs.detect-ci-trigger.outputs.triggered == 'true' && 'dask/label/dev,conda-forge,nodefaults' || 'conda-forge,nodefaults' }}
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
       - name: Build the Rust DataFusion bindings
@@ -67,7 +66,7 @@ jobs:
       - name: Optionally install upstream dev Dask
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
-          mamba update dask
+          mamba update -c dask/label/dev dask
       - name: Test with pytest
         run: |
           pytest --junitxml=junit/test-results.xml --cov-report=xml -n auto tests --dist loadfile
@@ -94,7 +93,6 @@ jobs:
           use-mamba: true
           python-version: "3.9"
           channel-priority: strict
-          channels: ${{ needs.detect-ci-trigger.outputs.triggered == 'true' && 'dask/label/dev,conda-forge,nodefaults' || 'conda-forge,nodefaults' }}
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.9-dev.yaml
       - name: Build the Rust DataFusion bindings
@@ -110,7 +108,7 @@ jobs:
       - name: Optionally install upstream dev Dask
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
-          mamba update dask
+          mamba update -c dask/label/dev dask
       - name: run a dask cluster
         env:
           UPSTREAM: ${{ needs.detect-ci-trigger.outputs.triggered }}


### PR DESCRIPTION
It looks like our scheduled Dask nightly testing is sometimes failing to update to nightly Dask packages:

https://github.com/dask-contrib/dask-sql/actions/runs/3625488882/jobs/6113589823

This PR refactors the relevant workflows to more explicitly update to nightly Dask using the `-c dask/label/dev` option