### PR TITLE
Use `flexible` channel priority for upstream testing

### DIFF
--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -55,7 +55,8 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: ${{ matrix.python }}
-          channel-priority: strict
+          # need flexible channel priority to force-install Dask nightlies
+          channel-priority: ${{ env.which_upstream == 'Dask' && 'flexible' || 'strict' }}
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
       - name: Optionally update upstream cargo dependencies
@@ -91,7 +92,8 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: "3.9"
-          channel-priority: strict
+          # need flexible channel priority to force-install Dask nightlies
+          channel-priority: ${{ env.which_upstream == 'Dask' && 'flexible' || 'strict' }}
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.9-dev.yaml
       - name: Optionally update upstream cargo dependencies

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -55,8 +55,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: ${{ matrix.python }}
-          # need flexible channel priority to force-install Dask nightlies
-          channel-priority: ${{ env.which_upstream == 'Dask' && 'flexible' || 'strict' }}
+          channel-priority: strict
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
       - name: Optionally update upstream cargo dependencies
@@ -92,8 +91,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: "3.9"
-          # need flexible channel priority to force-install Dask nightlies
-          channel-priority: ${{ env.which_upstream == 'Dask' && 'flexible' || 'strict' }}
+          channel-priority: strict
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.9-dev.yaml
       - name: Optionally update upstream cargo dependencies

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install upstream dev Dask
         if: env.which_upstream == 'Dask'
         run: |
-          mamba install dask/label/dev::dask
+          mamba install --no-channel-priority dask/label/dev::dask
       - name: Test with pytest
         run: |
           pytest --junitxml=junit/test-results.xml --cov-report=xml -n auto tests --dist loadfile
@@ -112,7 +112,7 @@ jobs:
       - name: Install upstream dev Dask
         if: env.which_upstream == 'Dask'
         run: |
-          mamba install  dask/label/dev::dask
+          mamba install --no-channel-priority dask/label/dev::dask
       - name: run a dask cluster
         run: |
           if [[ $which_upstream == "Dask" ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: ${{ matrix.python }}
-          # need flexible channel priority to force-install Dask nightlies
-          channel-priority: ${{ needs.detect-ci-trigger.outputs.triggered == 'true' && 'flexible' || 'strict' }}
+          channel-priority: strict
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
       - name: Build the Rust DataFusion bindings
@@ -93,8 +92,7 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: "3.9"
-          # need flexible channel priority to force-install Dask nightlies
-          channel-priority: ${{ needs.detect-ci-trigger.outputs.triggered == 'true' && 'flexible' || 'strict' }}
+          channel-priority: strict
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.9-dev.yaml
       - name: Build the Rust DataFusion bindings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,8 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: ${{ matrix.python }}
-          channel-priority: strict
+          # need flexible channel priority to force-install Dask nightlies
+          channel-priority: ${{ needs.detect-ci-trigger.outputs.triggered == 'true' && 'flexible' || 'strict' }}
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
       - name: Build the Rust DataFusion bindings
@@ -92,7 +93,8 @@ jobs:
           miniforge-variant: Mambaforge
           use-mamba: true
           python-version: "3.9"
-          channel-priority: strict
+          # need flexible channel priority to force-install Dask nightlies
+          channel-priority: ${{ needs.detect-ci-trigger.outputs.triggered == 'true' && 'flexible' || 'strict' }}
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.9-dev.yaml
       - name: Build the Rust DataFusion bindings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Optionally install upstream dev Dask
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
-          mamba install dask/label/dev::dask
+          mamba install --no-channel-priority dask/label/dev::dask
       - name: Test with pytest
         run: |
           pytest --junitxml=junit/test-results.xml --cov-report=xml -n auto tests --dist loadfile
@@ -108,7 +108,7 @@ jobs:
       - name: Optionally install upstream dev Dask
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
-          mamba install dask/label/dev::dask
+          mamba install --no-channel-priority dask/label/dev::dask
       - name: run a dask cluster
         env:
           UPSTREAM: ${{ needs.detect-ci-trigger.outputs.triggered }}


### PR DESCRIPTION
Follow up to #960

Looks like we can't force-install Dask nightlies with `strict` chanel priority in our conda environment; this PR conditionally sets channel priority to `flexible` for upstream testing so that we can successfully install `dask/label/dev::dask`. 