### PR TITLE
Remove `np.float` in PyTest and skip new NumPy failures

### DIFF
--- a/tests/integration/test_function.py
+++ b/tests/integration/test_function.py
@@ -118,7 +118,7 @@ def test_custom_function_row_two_args(c, df, k1, k2, op, retty):
     c.register_function(
         f,
         "f",
-        [("a", np.float), ("k1", const_type_k1), ("k2", const_type_k2)],
+        [("a", np.float64), ("k1", const_type_k1), ("k2", const_type_k2)],
         retty,
         row_udf=True,
     )

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -899,6 +899,7 @@ def test_ml_experiment(c, client, training_df):
 
 # TODO - many ML tests fail on clusters without sklearn - can we avoid this?
 @skip_if_external_scheduler
+@pytest.mark.skip(reason="Waiting on https://github.com/EpistasisLab/tpot/pull/1280")
 def test_experiment_automl_classifier(c, client, training_df):
     tpot = pytest.importorskip("tpot", reason="tpot not installed")
     # currently tested with tpot==
@@ -924,6 +925,7 @@ def test_experiment_automl_classifier(c, client, training_df):
 
 # TODO - many ML tests fail on clusters without sklearn - can we avoid this?
 @skip_if_external_scheduler
+@pytest.mark.skip(reason="Waiting on https://github.com/EpistasisLab/tpot/pull/1280")
 def test_experiment_automl_regressor(c, client, training_df):
     tpot = pytest.importorskip("tpot", reason="tpot not installed")
     # test regressor

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from tests.integration.fixtures import skip_if_external_scheduler
 from tests.utils import assert_eq
 
 
@@ -140,6 +141,8 @@ def test_literal_null(c):
     assert_eq(df, expected_df)
 
 
+# TODO - https://github.com/dask-contrib/dask-sql/issues/978
+@skip_if_external_scheduler
 def test_random(c):
     query_with_seed = """
             SELECT


### PR DESCRIPTION
[NumPy 1.24.0](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations) removed the `np.float` alias, so we have to replace `np.float` with `np.float64` in PyTest `test_custom_function_row_two_args`.

Another option is to replace `np.float` with Python's `float`, although the NumPy version may be useful for consistency with NumPy arrays ([source](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations)).