### PR TITLE
Ignore patch updates for cibw in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "datafusion-*"
         update-types: ["version-update:semver-major"]
+      # ignore cibw patch updates
+      - dependency-name: "pypa/cibuildwheel"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Main motivation is that it takes up too much time/ci resources to test if pypi builds are working for every patch update