### PR TITLE
Use Mambaforge for bare requirements testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,9 +137,9 @@ jobs:
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2.2.0
         with:
+          miniforge-variant: Mambaforge
+          use-mamba: true
           python-version: "3.8"
-          mamba-version: "*"
-          channels: conda-forge,nodefaults
           channel-priority: strict
       - name: Install dependencies and nothing else
         run: |

--- a/dask_planner/src/sql/optimizer/eliminate_agg_distinct.rs
+++ b/dask_planner/src/sql/optimizer/eliminate_agg_distinct.rs
@@ -218,7 +218,7 @@ fn create_plan(
             let alias = format!("__dask_sql_count__{}", optimizer_config.next_id());
             let expr_name = expr.canonical_name();
             let count_expr = Expr::Column(Column::from_qualified_name(&expr_name));
-            let aggr_expr = vec![count(count_expr).alias(&alias)];
+            let aggr_expr = vec![count(count_expr).alias(alias)];
             LogicalPlan::Aggregate(Aggregate::try_new(input.clone(), group_expr, aggr_expr)?)
         };
 
@@ -262,7 +262,7 @@ fn create_plan(
             let alias_str = alias_str.replace('#', ""); // TODO remove this ugly hack
             let count_col = match &not_distinct_expr[0] {
                 Expr::Alias(_, alias) => count_col.alias(alias.as_str()),
-                _ => count_col.alias(&alias_str),
+                _ => count_col.alias(alias_str),
             };
 
             let count_distinct_col = col(&second_aggregate.schema().field(1).qualified_name());
@@ -271,7 +271,7 @@ fn create_plan(
                 expr => {
                     let alias_str = format!("COUNT(DISTINCT {})", expr);
                     let alias_str = alias_str.replace('#', ""); // TODO remove this ugly hack
-                    count_distinct_col.alias(&alias_str)
+                    count_distinct_col.alias(alias_str)
                 }
             };
 
@@ -338,7 +338,7 @@ fn create_plan(
                 expr => {
                     let alias_str = format!("COUNT(DISTINCT {})", expr);
                     let alias_str = alias_str.replace('#', ""); // TODO remove this ugly hack
-                    count_distinct_col.alias(&alias_str)
+                    count_distinct_col.alias(alias_str)
                 }
             };
             projected_cols.push(count_distinct_col);


### PR DESCRIPTION
It looks like our bare requirements import testing is failing on main:

https://github.com/dask-contrib/dask-sql/actions/runs/3915253264/jobs/6693236881

Looking through the failures, I was surprised to see the `defaults` channel included in the solve, since we specify `nodefaults` in the list of channels; this PR switches this check to using Mambaforge, which should successfully exclude `defaults` as intended - interested in seeing how this impacts the failures.

cc @ayushdg 