### PR TITLE
Set `n_jobs=-1` in `test_ml_experiment`

### DIFF
--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -708,7 +708,6 @@ def test_ml_experiment(c, client, training_df):
         ValueError,
         match="Parameters must include a 'model_class' " "or 'automl_class' parameter.",
     ):
-
         c.sql(
             """
         CREATE EXPERIMENT my_exp WITH (
@@ -723,6 +722,7 @@ def test_ml_experiment(c, client, training_df):
         )
         """
         )
+
     with pytest.raises(
         ValueError,
         match="Parameters must include a 'experiment_class' "
@@ -784,6 +784,7 @@ def test_ml_experiment(c, client, training_df):
         )
         """
         )
+
     with pytest.raises(
         ValueError,
         match="Can not import automl model that.is.not.a.python.class. "
@@ -810,6 +811,7 @@ def test_ml_experiment(c, client, training_df):
             )
             """
         )
+
     # happy flow
     c.sql(
         """
@@ -818,6 +820,7 @@ def test_ml_experiment(c, client, training_df):
         experiment_class = 'sklearn.model_selection.GridSearchCV',
         tune_parameters = (n_estimators = ARRAY [16, 32, 2],learning_rate = ARRAY [0.1,0.01,0.001],
                            max_depth = ARRAY [3,4,5,10]),
+        experiment_kwargs = (n_jobs = -1),
         target_column = 'target'
     ) AS (
             SELECT x, y, x*y > 0 AS target
@@ -826,9 +829,7 @@ def test_ml_experiment(c, client, training_df):
         )
         """
     )
-
     assert "my_exp" in c.schema[c.schema_name].models, "Best model was not registered"
-
     check_trained_model(c, "my_exp")
 
     with pytest.raises(RuntimeError):
@@ -848,6 +849,7 @@ def test_ml_experiment(c, client, training_df):
         )
             """
         )
+
     c.sql(
         """
         CREATE EXPERIMENT IF NOT EXISTS my_exp WITH (
@@ -855,15 +857,16 @@ def test_ml_experiment(c, client, training_df):
             experiment_class = 'sklearn.model_selection.GridSearchCV',
             tune_parameters = (n_estimators = ARRAY [16, 32, 2],learning_rate = ARRAY [0.1,0.01,0.001],
                                max_depth = ARRAY [3,4,5,10]),
+            experiment_kwargs = (n_jobs = -1),
             target_column = 'target'
         ) AS (
             SELECT x, y, x*y > 0 AS target
             FROM timeseries
             LIMIT 100
         )
-
         """
     )
+
     c.sql(
         """
         CREATE OR REPLACE EXPERIMENT my_exp WITH (
@@ -871,6 +874,7 @@ def test_ml_experiment(c, client, training_df):
             experiment_class = 'sklearn.model_selection.GridSearchCV',
             tune_parameters = (n_estimators = ARRAY [16, 32, 2],learning_rate = ARRAY [0.1,0.01,0.001],
                                max_depth = ARRAY [3,4,5,10]),
+            experiment_kwargs = (n_jobs = -1),
             target_column = 'target'
         ) AS (
             SELECT x, y, x*y > 0 AS target


### PR DESCRIPTION
Closes #970 

Without these changes, I got a runtime of ~182 seconds. By adding `experiment_kwargs = (n_jobs = -1)`, I got a runtime of ~34 seconds. I ran the tests with the changes from this PR first, then without, to make sure the improved runtime wasn't due to caching. Command:
```
pytest tests/integration/test_model.py --durations=0
```
Looking at the call time.

@ayushdg 