### PR TITLE
Fix update cargo dependencies script for Mac OS X

### DIFF
--- a/dask_planner/update-dependencies.sh
+++ b/dask_planner/update-dependencies.sh
@@ -2,7 +2,7 @@
 
 UPDATE_ALL_CARGO_DEPS="${UPDATE_ALL_CARGO_DEPS:-true}"
 # Update datafusion dependencies in the dask-planner to the latest revision from the default branch
-sed -i -r 's/^datafusion-([a-z]+).*/datafusion-\1 = { git = "https:\/\/github.com\/apache\/arrow-datafusion\/" }/g' Cargo.toml
+sed -i -r -E 's/^datafusion-([a-z]+).*/datafusion-\1 = { git = "https:\/\/github.com\/apache\/arrow-datafusion\/" }/g' Cargo.toml
 
 if [ "$UPDATE_ALL_CARGO_DEPS" = true ] ; then
     cargo update


### PR DESCRIPTION
The existing update-dependencies.sh script fails on Mac OS X as seen in [these](https://github.com/dask-contrib/dask-sql/actions/runs/4006405130/jobs/6877888985) runs. This updates the script to use the `-E` as discussed in the comments [here](https://stackoverflow.com/a/24717687).