### PR TITLE
Skip `test_dask_fsql` on Python 3.8 pytests

### DIFF
--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -25,6 +25,7 @@ dependencies:
 - pygments>=2.7.1
 - pyhive
 - pytest-cov
+- pytest-rerunfailures
 - pytest-xdist
 - pytest
 - python=3.10

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -24,6 +24,7 @@ dependencies:
 - pygments=2.7.1
 - pyhive
 - pytest-cov
+- pytest-rerunfailures
 - pytest-xdist
 - pytest
 - python=3.8

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -25,6 +25,7 @@ dependencies:
 - pygments>=2.7.1
 - pyhive
 - pytest-cov
+- pytest-rerunfailures
 - pytest-xdist
 - pytest
 - python=3.9

--- a/continuous_integration/gpuci/environment.yaml
+++ b/continuous_integration/gpuci/environment.yaml
@@ -28,6 +28,7 @@ dependencies:
 - pygments>=2.7.1
 - pyhive
 - pytest-cov
+- pytest-rerunfailures
 - pytest-xdist
 - pytest
 - python=3.9

--- a/tests/integration/test_fugue.py
+++ b/tests/integration/test_fugue.py
@@ -1,3 +1,5 @@
+import sys
+
 import dask.dataframe as dd
 import pandas as pd
 import pytest
@@ -44,6 +46,10 @@ def test_fugue_fsql(client):
 # TODO: Revisit fixing this on an independant cluster (without dask-sql) based on the
 # discussion in https://github.com/dask-contrib/dask-sql/issues/407
 @xfail_if_external_scheduler
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="Intermittent AssertionError on Python 3.8 tests"
+)
 def test_dask_fsql(client):
     def assert_fsql(df: pd.DataFrame) -> None:
         assert_eq(df, pd.DataFrame({"a": [1]}))

--- a/tests/integration/test_fugue.py
+++ b/tests/integration/test_fugue.py
@@ -47,8 +47,7 @@ def test_fugue_fsql(client):
 # discussion in https://github.com/dask-contrib/dask-sql/issues/407
 @xfail_if_external_scheduler
 @pytest.mark.skipif(
-    sys.version_info < (3, 9),
-    reason="Intermittent AssertionError on Python 3.8 tests"
+    sys.version_info < (3, 9), reason="Intermittent AssertionError on Python 3.8 tests"
 )
 def test_dask_fsql(client):
     def assert_fsql(df: pd.DataFrame) -> None:

--- a/tests/integration/test_fugue.py
+++ b/tests/integration/test_fugue.py
@@ -1,5 +1,3 @@
-import sys
-
 import dask.dataframe as dd
 import pandas as pd
 import pytest

--- a/tests/integration/test_fugue.py
+++ b/tests/integration/test_fugue.py
@@ -1,3 +1,5 @@
+import sys
+
 import dask.dataframe as dd
 import pandas as pd
 import pytest
@@ -44,7 +46,7 @@ def test_fugue_fsql(client):
 # TODO: Revisit fixing this on an independant cluster (without dask-sql) based on the
 # discussion in https://github.com/dask-contrib/dask-sql/issues/407
 @xfail_if_external_scheduler
-@pytest.mark.flaky(reruns=2)
+@pytest.mark.flaky(reruns=2, condition="sys.version_info < (3, 9)")
 def test_dask_fsql(client):
     def assert_fsql(df: pd.DataFrame) -> None:
         assert_eq(df, pd.DataFrame({"a": [1]}))

--- a/tests/integration/test_fugue.py
+++ b/tests/integration/test_fugue.py
@@ -1,5 +1,3 @@
-import sys
-
 import dask.dataframe as dd
 import pandas as pd
 import pytest
@@ -46,9 +44,7 @@ def test_fugue_fsql(client):
 # TODO: Revisit fixing this on an independant cluster (without dask-sql) based on the
 # discussion in https://github.com/dask-contrib/dask-sql/issues/407
 @xfail_if_external_scheduler
-@pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="Intermittent AssertionError on Python 3.8 tests"
-)
+@pytest.mark.flaky(reruns=2)
 def test_dask_fsql(client):
     def assert_fsql(df: pd.DataFrame) -> None:
         assert_eq(df, pd.DataFrame({"a": [1]}))


### PR DESCRIPTION
For the past couple of months, `test_dask_fsql` (formerly `test_fsql`) would fail randomly on our Python 3.8 tests. I was wondering if we should just mark these cases as skips, or if there are any plans to debug this?

From what I've seen, these failures happen on Windows and MacOS, and I don't recall seeing it happen on Ubuntu. If desired, I could add an even more specific condition to skip Windows+Python3.8 and MacOS+Python3.8 and still run Ubuntu+Python3.8.