### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: dask_planner
+          shared-key: test
       - name: Build the Rust DataFusion bindings
         run: |
           python setup.py build install
@@ -100,6 +101,11 @@ jobs:
           channel-priority: strict
           activate-environment: dask-sql
           environment-file: continuous_integration/environment-3.9-dev.yaml
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: dask_planner
+          shared-key: test
       - name: Build the Rust DataFusion bindings
         run: |
           python setup.py build install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,6 @@ defaults:
   run:
     shell: bash -l {0}
 
-env:
-  # Disable full debug symbol generation to speed up CI build and keep memory down
-  # "1" means line tables only, which is useful for panic tracebacks.
-  RUSTFLAGS: "-C debuginfo=1"
-
 jobs:
   detect-ci-trigger:
     name: Check for upstream trigger phrase

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,10 @@ jobs:
           channel-priority: strict
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: dask_planner
       - name: Build the Rust DataFusion bindings
         run: |
           python setup.py build install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,7 @@ jobs:
           channel-priority: strict
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
+          run-post: ${{ matrix.os != 'windows-latest' && 'true' || 'false' }}
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ defaults:
   run:
     shell: bash -l {0}
 
+env:
+  # Disable full debug symbol generation to speed up CI build and keep memory down
+  # "1" means line tables only, which is useful for panic tracebacks.
+  RUSTFLAGS: "-C debuginfo=1"
+
 jobs:
   detect-ci-trigger:
     name: Check for upstream trigger phrase

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,7 @@ build:
   os: ubuntu-20.04
   tools:
     python: "mambaforge-4.10"
+    rust: "1.64"
 
 sphinx:
   configuration: docs/source/conf.py

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - dask>=2022.3.0,<=2023.1.1
   - pandas>=1.4.0
   - fugue>=0.7.3
-  - jpype1>=1.0.2
   # FIXME: handling is needed for httpx-based fastapi>=0.87.0
   - fastapi>=0.69.0,<0.87.0
   - uvicorn>=0.13.4
@@ -20,4 +19,4 @@ dependencies:
   - tabulate
   - nest-asyncio
   - setuptools-rust>=1.4.1
-  - rust>=1.60.0
+    #  - rust>=1.60.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,4 +19,5 @@ dependencies:
   - tabulate
   - nest-asyncio
   - setuptools-rust>=1.4.1
+  - ucx-proc=*=cpu
     #  - rust>=1.60.0


### PR DESCRIPTION
This PR improves CI runtimes for the longer running jobs in the current pipeline.
- Uses the [rust-cache](https://github.com/marketplace/actions/rust-cache) action to cache cargo dependencies and target files for before building for python tests. 
  - For a cache hit (which should happen unless the cargo files change) build times go from:
    - Ubuntu: 7-10mins -> ~40s
    - Mac-os: 17-20mins -> ~2 mins
    - Windows 10-12mins -> ~1.5 mins
- Skip post python cleanup actions on windows
  - Windows conda cache cleanup is surprisingly slow compared to Mac/ubuntu and ends up taking ~5-6minutes. Skipping this step should save this time.
- RTD build setup
  - Remove rust from conda env and add it to the build setup
    - Conda env creation goes from 250->200s
  - Add ucx-proc=*=cpu to avoid cudatoolkit being pulled due to ucx dependency from fugue (pyarrow)
    - 200s -> 145s