### PR TITLE
Resolve tests in `test_server.py`

### DIFF
--- a/dask_planner/src/sql/types.rs
+++ b/dask_planner/src/sql/types.rs
@@ -120,6 +120,10 @@ impl DaskTypeMap {
         })
     }
 
+    fn __str__(&self) -> String {
+        format!("{:?}", self.sql_type)
+    }
+
     #[pyo3(name = "getSqlType")]
     pub fn sql_type(&self) -> SqlTypeName {
         self.sql_type.clone()

--- a/dask_sql/physical/rel/custom/analyze_table.py
+++ b/dask_sql/physical/rel/custom/analyze_table.py
@@ -56,9 +56,7 @@ class AnalyzeTablePlugin(BaseRelPlugin):
         statistics = statistics.append(
             pd.Series(
                 {
-                    col: str(python_to_sql_type(df[mapping(col)].dtype).getSqlType())
-                    .rpartition(".")[2]
-                    .lower()
+                    col: str(python_to_sql_type(df[mapping(col)].dtype)).lower()
                     for col in columns
                 },
                 name="data_type",

--- a/dask_sql/physical/rel/custom/show_columns.py
+++ b/dask_sql/physical/rel/custom/show_columns.py
@@ -35,9 +35,7 @@ class ShowColumnsPlugin(BaseRelPlugin):
         cols = dc.column_container.columns
         dtypes = list(
             map(
-                lambda x: str(python_to_sql_type(x).getSqlType())
-                .rpartition(".")[2]
-                .lower(),
+                lambda x: str(python_to_sql_type(x)).lower(),
                 dc.df.dtypes,
             )
         )

--- a/dask_sql/server/responses.py
+++ b/dask_sql/server/responses.py
@@ -64,9 +64,7 @@ class QueryResults:
 class DataResults(QueryResults):
     @staticmethod
     def get_column_description(df):
-        sql_types = [
-            str(python_to_sql_type(t).getSqlType()).partition(".")[2] for t in df.dtypes
-        ]
+        sql_types = [str(python_to_sql_type(t)) for t in df.dtypes]
         column_names = df.columns
         return [
             {

--- a/dask_sql/server/responses.py
+++ b/dask_sql/server/responses.py
@@ -64,7 +64,9 @@ class QueryResults:
 class DataResults(QueryResults):
     @staticmethod
     def get_column_description(df):
-        sql_types = [str(python_to_sql_type(t)) for t in df.dtypes]
+        sql_types = [
+            str(python_to_sql_type(t).getSqlType()).partition(".")[2] for t in df.dtypes
+        ]
         column_names = df.columns
         return [
             {
@@ -131,10 +133,11 @@ class QueryError:
         self.errorName = str(type(error))
         self.errorType = "USER_ERROR"
 
-        try:
-            self.errorLocation = {
-                "lineNumber": error.from_line + 1,
-                "columnNumber": error.from_col + 1,
-            }
-        except AttributeError:  # pragma: no cover
-            pass
+        # FIXME: ParserErrors currently don't contain information on where the syntax error occurred
+        # try:
+        #     self.errorLocation = {
+        #         "lineNumber": error.from_line + 1,
+        #         "columnNumber": error.from_col + 1,
+        #     }
+        # except AttributeError:  # pragma: no cover
+        #     pass

--- a/tests/integration/test_analyze.py
+++ b/tests/integration/test_analyze.py
@@ -14,9 +14,7 @@ def test_analyze(c, df):
         .append(
             pd.Series(
                 {
-                    col: str(python_to_sql_type(df[col].dtype).getSqlType())
-                    .rpartition(".")[2]
-                    .lower()
+                    col: str(python_to_sql_type(df[col].dtype)).lower()
                     for col in df.columns
                 },
                 name="data_type",

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -48,7 +48,6 @@ def test_sql_query_cancel(app_client):
     assert response.status_code == 404
 
 
-@pytest.mark.xfail(reason="WIP DataFusion")
 def test_sql_query(app_client):
     response = app_client.post("/v1/statement", data="SELECT 1 + 1")
     assert response.status_code == 200
@@ -62,15 +61,14 @@ def test_sql_query(app_client):
 
     assert result["columns"] == [
         {
-            "name": "1 + 1",
-            "type": "integer",
-            "typeSignature": {"rawType": "integer", "arguments": []},
+            "name": "Int64(1) + Int64(1)",
+            "type": "bigint",
+            "typeSignature": {"rawType": "bigint", "arguments": []},
         }
     ]
     assert result["data"] == [[2]]
 
 
-@pytest.mark.xfail(reason="WIP DataFusion")
 def test_wrong_sql_query(app_client):
     response = app_client.post("/v1/statement", data="SELECT 1 + ")
     assert response.status_code == 200
@@ -81,14 +79,14 @@ def test_wrong_sql_query(app_client):
     assert "data" not in result
     assert "error" in result
     assert "message" in result["error"]
-    assert "errorLocation" in result["error"]
-    assert result["error"]["errorLocation"] == {
-        "lineNumber": 1,
-        "columnNumber": 10,
-    }
+    # FIXME: ParserErrors currently don't contain information on where the syntax error occurred
+    # assert "errorLocation" in result["error"]
+    # assert result["error"]["errorLocation"] == {
+    #     "lineNumber": 1,
+    #     "columnNumber": 10,
+    # }
 
 
-@pytest.mark.xfail(reason="WIP DataFusion")
 def test_add_and_query(app_client, df, temporary_data_file):
     df.to_csv(temporary_data_file, index=False)
 
@@ -131,7 +129,6 @@ def test_add_and_query(app_client, df, temporary_data_file):
     assert "error" not in result
 
 
-@pytest.mark.xfail(reason="WIP DataFusion")
 def test_register_and_query(app_client, df):
     df["a"] = df["a"].astype("UInt8")
     app_client.app.c.create_table("new_table", df)
@@ -160,7 +157,6 @@ def test_register_and_query(app_client, df):
     assert "error" not in result
 
 
-@pytest.mark.xfail(reason="WIP DataFusion")
 def test_inf_table(app_client, user_table_inf):
     app_client.app.c.create_table("new_table", user_table_inf)
 
@@ -184,7 +180,6 @@ def test_inf_table(app_client, user_table_inf):
     assert "error" not in result
 
 
-@pytest.mark.xfail(reason="WIP DataFusion")
 def get_result_or_error(app_client, response):
     result = response.json()
 

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 
 import dask.dataframe as dd
@@ -13,6 +14,9 @@ try:
 except ImportError:
     cudf = None
     dask_cudf = None
+
+# default integer type varies by platform
+DEFAULT_INT_TYPE = "INTEGER" if sys.platform == "win32" else "BIGINT"
 
 
 @pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
@@ -177,12 +181,18 @@ def test_function_adding():
     assert len(c.schema[c.schema_name].function_lists) == 2
     assert c.schema[c.schema_name].function_lists[0].name == "F"
     assert c.schema[c.schema_name].function_lists[0].parameters[0][0] == "x"
-    assert str(c.schema[c.schema_name].function_lists[0].parameters[0][1]) == "BIGINT"
+    assert (
+        str(c.schema[c.schema_name].function_lists[0].parameters[0][1])
+        == DEFAULT_INT_TYPE
+    )
     assert str(c.schema[c.schema_name].function_lists[0].return_type) == "DOUBLE"
     assert not c.schema[c.schema_name].function_lists[0].aggregation
     assert c.schema[c.schema_name].function_lists[1].name == "f"
     assert c.schema[c.schema_name].function_lists[1].parameters[0][0] == "x"
-    assert str(c.schema[c.schema_name].function_lists[1].parameters[0][1]) == "BIGINT"
+    assert (
+        str(c.schema[c.schema_name].function_lists[1].parameters[0][1])
+        == DEFAULT_INT_TYPE
+    )
     assert str(c.schema[c.schema_name].function_lists[1].return_type) == "DOUBLE"
     assert not c.schema[c.schema_name].function_lists[1].aggregation
 
@@ -195,12 +205,16 @@ def test_function_adding():
     assert c.schema[c.schema_name].function_lists[2].name == "F"
     assert c.schema[c.schema_name].function_lists[2].parameters[0][0] == "x"
     assert str(c.schema[c.schema_name].function_lists[2].parameters[0][1]) == "DOUBLE"
-    assert str(c.schema[c.schema_name].function_lists[2].return_type) == "BIGINT"
+    assert (
+        str(c.schema[c.schema_name].function_lists[2].return_type) == DEFAULT_INT_TYPE
+    )
     assert not c.schema[c.schema_name].function_lists[2].aggregation
     assert c.schema[c.schema_name].function_lists[3].name == "f"
     assert c.schema[c.schema_name].function_lists[3].parameters[0][0] == "x"
     assert str(c.schema[c.schema_name].function_lists[3].parameters[0][1]) == "DOUBLE"
-    assert str(c.schema[c.schema_name].function_lists[3].return_type) == "BIGINT"
+    assert (
+        str(c.schema[c.schema_name].function_lists[3].return_type) == DEFAULT_INT_TYPE
+    )
     assert not c.schema[c.schema_name].function_lists[3].aggregation
 
     # With replacement
@@ -236,12 +250,18 @@ def test_aggregation_adding():
     assert len(c.schema[c.schema_name].function_lists) == 2
     assert c.schema[c.schema_name].function_lists[0].name == "F"
     assert c.schema[c.schema_name].function_lists[0].parameters[0][0] == "x"
-    assert str(c.schema[c.schema_name].function_lists[0].parameters[0][1]) == "BIGINT"
+    assert (
+        str(c.schema[c.schema_name].function_lists[0].parameters[0][1])
+        == DEFAULT_INT_TYPE
+    )
     assert str(c.schema[c.schema_name].function_lists[0].return_type) == "DOUBLE"
     assert c.schema[c.schema_name].function_lists[0].aggregation
     assert c.schema[c.schema_name].function_lists[1].name == "f"
     assert c.schema[c.schema_name].function_lists[1].parameters[0][0] == "x"
-    assert str(c.schema[c.schema_name].function_lists[1].parameters[0][1]) == "BIGINT"
+    assert (
+        str(c.schema[c.schema_name].function_lists[1].parameters[0][1])
+        == DEFAULT_INT_TYPE
+    )
     assert str(c.schema[c.schema_name].function_lists[1].return_type) == "DOUBLE"
     assert c.schema[c.schema_name].function_lists[1].aggregation
 
@@ -254,12 +274,16 @@ def test_aggregation_adding():
     assert c.schema[c.schema_name].function_lists[2].name == "F"
     assert c.schema[c.schema_name].function_lists[2].parameters[0][0] == "x"
     assert str(c.schema[c.schema_name].function_lists[2].parameters[0][1]) == "DOUBLE"
-    assert str(c.schema[c.schema_name].function_lists[2].return_type) == "BIGINT"
+    assert (
+        str(c.schema[c.schema_name].function_lists[2].return_type) == DEFAULT_INT_TYPE
+    )
     assert c.schema[c.schema_name].function_lists[2].aggregation
     assert c.schema[c.schema_name].function_lists[3].name == "f"
     assert c.schema[c.schema_name].function_lists[3].parameters[0][0] == "x"
     assert str(c.schema[c.schema_name].function_lists[3].parameters[0][1]) == "DOUBLE"
-    assert str(c.schema[c.schema_name].function_lists[3].return_type) == "BIGINT"
+    assert (
+        str(c.schema[c.schema_name].function_lists[3].return_type) == DEFAULT_INT_TYPE
+    )
     assert c.schema[c.schema_name].function_lists[3].aggregation
 
     # With replacement

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 
 from dask_sql import Context
-from dask_sql.mappings import python_to_sql_type
 from tests.utils import assert_eq
 
 try:
@@ -164,11 +163,6 @@ def test_tables_from_stack(gpu):
     g(gpu=gpu)
 
 
-int_sql_type = python_to_sql_type(int).getSqlType()
-float_sql_type = python_to_sql_type(float).getSqlType()
-str_sql_type = python_to_sql_type(str).getSqlType()
-
-
 def test_function_adding():
     c = Context()
 
@@ -183,25 +177,13 @@ def test_function_adding():
     assert len(c.schema[c.schema_name].function_lists) == 2
     assert c.schema[c.schema_name].function_lists[0].name == "F"
     assert c.schema[c.schema_name].function_lists[0].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[0].parameters[0][1].getSqlType()
-        == int_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[0].return_type.getSqlType()
-        == float_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[0].parameters[0][1]) == "BIGINT"
+    assert str(c.schema[c.schema_name].function_lists[0].return_type) == "DOUBLE"
     assert not c.schema[c.schema_name].function_lists[0].aggregation
     assert c.schema[c.schema_name].function_lists[1].name == "f"
     assert c.schema[c.schema_name].function_lists[1].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[1].parameters[0][1].getSqlType()
-        == int_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[1].return_type.getSqlType()
-        == float_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[1].parameters[0][1]) == "BIGINT"
+    assert str(c.schema[c.schema_name].function_lists[1].return_type) == "DOUBLE"
     assert not c.schema[c.schema_name].function_lists[1].aggregation
 
     # Without replacement
@@ -212,25 +194,13 @@ def test_function_adding():
     assert len(c.schema[c.schema_name].function_lists) == 4
     assert c.schema[c.schema_name].function_lists[2].name == "F"
     assert c.schema[c.schema_name].function_lists[2].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[2].parameters[0][1].getSqlType()
-        == float_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[2].return_type.getSqlType()
-        == int_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[2].parameters[0][1]) == "DOUBLE"
+    assert str(c.schema[c.schema_name].function_lists[2].return_type) == "BIGINT"
     assert not c.schema[c.schema_name].function_lists[2].aggregation
     assert c.schema[c.schema_name].function_lists[3].name == "f"
     assert c.schema[c.schema_name].function_lists[3].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[3].parameters[0][1].getSqlType()
-        == float_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[3].return_type.getSqlType()
-        == int_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[3].parameters[0][1]) == "DOUBLE"
+    assert str(c.schema[c.schema_name].function_lists[3].return_type) == "BIGINT"
     assert not c.schema[c.schema_name].function_lists[3].aggregation
 
     # With replacement
@@ -242,25 +212,13 @@ def test_function_adding():
     assert len(c.schema[c.schema_name].function_lists) == 2
     assert c.schema[c.schema_name].function_lists[0].name == "F"
     assert c.schema[c.schema_name].function_lists[0].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[0].parameters[0][1].getSqlType()
-        == str_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[0].return_type.getSqlType()
-        == str_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[0].parameters[0][1]) == "VARCHAR"
+    assert str(c.schema[c.schema_name].function_lists[0].return_type) == "VARCHAR"
     assert not c.schema[c.schema_name].function_lists[0].aggregation
     assert c.schema[c.schema_name].function_lists[1].name == "f"
     assert c.schema[c.schema_name].function_lists[1].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[1].parameters[0][1].getSqlType()
-        == str_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[1].return_type.getSqlType()
-        == str_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[1].parameters[0][1]) == "VARCHAR"
+    assert str(c.schema[c.schema_name].function_lists[1].return_type) == "VARCHAR"
     assert not c.schema[c.schema_name].function_lists[1].aggregation
 
 
@@ -278,25 +236,13 @@ def test_aggregation_adding():
     assert len(c.schema[c.schema_name].function_lists) == 2
     assert c.schema[c.schema_name].function_lists[0].name == "F"
     assert c.schema[c.schema_name].function_lists[0].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[0].parameters[0][1].getSqlType()
-        == int_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[0].return_type.getSqlType()
-        == float_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[0].parameters[0][1]) == "BIGINT"
+    assert str(c.schema[c.schema_name].function_lists[0].return_type) == "DOUBLE"
     assert c.schema[c.schema_name].function_lists[0].aggregation
     assert c.schema[c.schema_name].function_lists[1].name == "f"
     assert c.schema[c.schema_name].function_lists[1].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[1].parameters[0][1].getSqlType()
-        == int_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[1].return_type.getSqlType()
-        == float_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[1].parameters[0][1]) == "BIGINT"
+    assert str(c.schema[c.schema_name].function_lists[1].return_type) == "DOUBLE"
     assert c.schema[c.schema_name].function_lists[1].aggregation
 
     # Without replacement
@@ -307,25 +253,13 @@ def test_aggregation_adding():
     assert len(c.schema[c.schema_name].function_lists) == 4
     assert c.schema[c.schema_name].function_lists[2].name == "F"
     assert c.schema[c.schema_name].function_lists[2].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[2].parameters[0][1].getSqlType()
-        == float_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[2].return_type.getSqlType()
-        == int_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[2].parameters[0][1]) == "DOUBLE"
+    assert str(c.schema[c.schema_name].function_lists[2].return_type) == "BIGINT"
     assert c.schema[c.schema_name].function_lists[2].aggregation
     assert c.schema[c.schema_name].function_lists[3].name == "f"
     assert c.schema[c.schema_name].function_lists[3].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[3].parameters[0][1].getSqlType()
-        == float_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[3].return_type.getSqlType()
-        == int_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[3].parameters[0][1]) == "DOUBLE"
+    assert str(c.schema[c.schema_name].function_lists[3].return_type) == "BIGINT"
     assert c.schema[c.schema_name].function_lists[3].aggregation
 
     # With replacement
@@ -337,25 +271,13 @@ def test_aggregation_adding():
     assert len(c.schema[c.schema_name].function_lists) == 2
     assert c.schema[c.schema_name].function_lists[0].name == "F"
     assert c.schema[c.schema_name].function_lists[0].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[0].parameters[0][1].getSqlType()
-        == str_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[0].return_type.getSqlType()
-        == str_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[0].parameters[0][1]) == "VARCHAR"
+    assert str(c.schema[c.schema_name].function_lists[0].return_type) == "VARCHAR"
     assert c.schema[c.schema_name].function_lists[0].aggregation
     assert c.schema[c.schema_name].function_lists[1].name == "f"
     assert c.schema[c.schema_name].function_lists[1].parameters[0][0] == "x"
-    assert (
-        c.schema[c.schema_name].function_lists[1].parameters[0][1].getSqlType()
-        == str_sql_type
-    )
-    assert (
-        c.schema[c.schema_name].function_lists[1].return_type.getSqlType()
-        == str_sql_type
-    )
+    assert str(c.schema[c.schema_name].function_lists[1].parameters[0][1]) == "VARCHAR"
+    assert str(c.schema[c.schema_name].function_lists[1].return_type) == "VARCHAR"
     assert c.schema[c.schema_name].function_lists[1].aggregation
 
 

--- a/tests/unit/test_mapping.py
+++ b/tests/unit/test_mapping.py
@@ -8,12 +8,11 @@ from dask_sql.mappings import python_to_sql_type, similar_type, sql_to_python_va
 
 
 def test_python_to_sql():
-    assert python_to_sql_type(np.dtype("int32")).getSqlType() == SqlTypeName.INTEGER
-    assert python_to_sql_type(np.dtype(">M8[ns]")).getSqlType() == SqlTypeName.TIMESTAMP
-    thing = python_to_sql_type(pd.DatetimeTZDtype(unit="ns", tz="UTC")).getSqlType()
+    assert str(python_to_sql_type(np.dtype("int32"))) == "INTEGER"
+    assert str(python_to_sql_type(np.dtype(">M8[ns]"))) == "TIMESTAMP"
     assert (
-        python_to_sql_type(pd.DatetimeTZDtype(unit="ns", tz="UTC")).getSqlType()
-        == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE
+        str(python_to_sql_type(pd.DatetimeTZDtype(unit="ns", tz="UTC")))
+        == "TIMESTAMP_WITH_LOCAL_TIME_ZONE"
     )
 
 


### PR DESCRIPTION
This PR resolves the failures in `test_server.py` by:

- modifying the method of extracting the string SQL type for columns in `get_column_description `
- commenting out `errorLocation` functionality/checks for now
- modifying `test_sql_query` to account for changes to scalar integer behavior with the DataFusion parser