### PR TITLE
Remove `nest-asyncio` from dependencies

### DIFF
--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -13,7 +13,6 @@ dependencies:
 - maturin>=0.12.8
 - mlflow
 - mock
-- nest-asyncio
 - pandas>=1.4.0
 - pre-commit
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -12,7 +12,6 @@ dependencies:
 - maturin=0.12.8
 - mlflow
 - mock
-- nest-asyncio
 - pandas=1.4.0
 - pre-commit
 - prompt_toolkit=3.0.8

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -13,7 +13,6 @@ dependencies:
 - maturin>=0.12.8
 - mlflow
 - mock
-- nest-asyncio
 - pandas>=1.4.0
 - pre-commit
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/gpuci/environment.yaml
+++ b/continuous_integration/gpuci/environment.yaml
@@ -16,7 +16,6 @@ dependencies:
 - maturin>=0.12.8
 - mlflow
 - mock
-- nest-asyncio
 - pandas>=1.4.0
 - pre-commit
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -38,7 +38,6 @@ requirements:
     - tzlocal >=2.1
     - prompt-toolkit >=3.0.8
     - pygments >=2.7.1
-    - nest-asyncio
     - tabulate
 
 test:

--- a/docker/conda.txt
+++ b/docker/conda.txt
@@ -12,7 +12,6 @@ sphinx>=3.2.1
 tzlocal>=2.1
 # FIXME: handling is needed for httpx-based fastapi>=0.87.0
 fastapi>=0.69.0,<0.87.0
-nest-asyncio>=1.4.3
 uvicorn>=0.13.4
 pyarrow>=6.0.1
 prompt_toolkit>=3.0.8

--- a/docker/main.dockerfile
+++ b/docker/main.dockerfile
@@ -25,7 +25,6 @@ RUN mamba install -y \
     "prompt_toolkit>=3.0.8" \
     "pygments>=2.7.1" \
     tabulate \
-    nest-asyncio \
     # additional dependencies
     "pyarrow>=6.0.1" \
     "scikit-learn>=1.0.0" \

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -17,7 +17,6 @@ dependencies:
   - prompt_toolkit>=3.0.8
   - pygments>=2.7.1
   - tabulate
-  - nest-asyncio
   - setuptools-rust>=1.5.2
   - ucx-proc=*=cpu
     #  - rust>=1.60.0

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -11,5 +11,4 @@ tzlocal>=2.1
 prompt_toolkit>=3.0.8
 pygments>=2.7.1
 tabulate
-nest-asyncio
 setuptools-rust>=1.5.2

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         "prompt_toolkit>=3.0.8",
         "pygments>=2.7.1",
         "tabulate",
-        "nest-asyncio",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
With #1048 we are no longer using `nest-asyncio` anywhere in the codebase and should be good to remove it from our dependencies.