### PR TITLE
Split gpuCI environment into 3.8/3.10 environments

### DIFF
--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -1,0 +1,50 @@
+name: dask-sql
+channels:
+- rapidsai
+- rapidsai-nightly
+- nvidia
+- conda-forge
+- nodefaults
+dependencies:
+- dask>=2022.3.0
+# FIXME: handling is needed for httpx-based fastapi>=0.87.0
+- fastapi>=0.69.0,<0.87.0
+- fugue>=0.7.3
+- intake>=0.6.0
+- jsonschema
+- lightgbm
+- maturin>=0.12.8
+- mlflow
+- mock
+- nest-asyncio
+- pandas>=1.4.0
+- pre-commit
+- prompt_toolkit>=3.0.8
+# TODO: remove once py is added to pytest downstream libraries
+# https://github.com/pytest-dev/pytest-xdist/issues/832
+- py
+- psycopg2
+- pyarrow>=6.0.1
+- pygments>=2.7.1
+- pyhive
+- pytest-cov
+- pytest-rerunfailures
+- pytest-xdist
+- pytest
+- python=3.10
+- scikit-learn>=1.0.0
+- setuptools-rust>=1.5.2
+- sphinx
+- tpot
+- tzlocal>=2.1
+- uvicorn>=0.13.4
+# GPU-specific requirements
+- cudatoolkit=11.5
+- cudf=23.04
+- cuml=23.04
+- dask-cudf=23.04
+- dask-cuda=23.04
+- numpy>=1.20.1
+- ucx-proc=*=gpu
+- ucx-py=0.31
+- xgboost=*=cuda_*

--- a/continuous_integration/gpuci/environment-3.8.yaml
+++ b/continuous_integration/gpuci/environment-3.8.yaml
@@ -7,37 +7,36 @@ channels:
 - nodefaults
 dependencies:
 - dask>=2022.3.0
-# FIXME: handling is needed for httpx-based fastapi>=0.87.0
-- fastapi>=0.69.0,<0.87.0
-- fugue>=0.7.3
-- intake>=0.6.0
+- fastapi=0.69.0
+- fugue=0.7.3
+- intake=0.6.0
 - jsonschema
 - lightgbm
-- maturin>=0.12.8
+- maturin=0.12.8
 - mlflow
 - mock
 - nest-asyncio
-- pandas>=1.4.0
+- pandas=1.4.0
 - pre-commit
-- prompt_toolkit>=3.0.8
+- prompt_toolkit=3.0.8
 # TODO: remove once py is added to pytest downstream libraries
 # https://github.com/pytest-dev/pytest-xdist/issues/832
 - py
 - psycopg2
 - pyarrow>=6.0.1
-- pygments>=2.7.1
+- pygments=2.7.1
 - pyhive
 - pytest-cov
 - pytest-rerunfailures
 - pytest-xdist
 - pytest
-- python=3.9
-- scikit-learn>=1.0.0
-- setuptools-rust>=1.5.2
+- python=3.8
+- scikit-learn=1.0.0
+- setuptools-rust=1.5.2
 - sphinx
 - tpot
-- tzlocal>=2.1
-- uvicorn>=0.13.4
+- tzlocal=2.1
+- uvicorn=0.13.4
 # GPU-specific requirements
 - cudatoolkit=11.5
 - cudf=23.04


### PR DESCRIPTION
With #1042, we now run GPU tests on python 3.8/3.10; this PR splits our existing 3.9 environment file to recreate the GPU CI environment into 2 files for the 3.8 and 3.10 environments.