### PR TITLE
Add is_distributed implementation for fugue DaskSQLEngine

### DIFF
--- a/dask_sql/integrations/fugue.py
+++ b/dask_sql/integrations/fugue.py
@@ -52,6 +52,10 @@ class DaskSQLEngine(fugue.execution.execution_engine.SQLEngine):
         """Create a new instance."""
         super().__init__(*args, **kwargs)
 
+    @property
+    def is_distributed(self) -> bool:
+        return True
+
     def select(
         self, dfs: fugue.dataframe.DataFrames, statement: str
     ) -> fugue.dataframe.DataFrame:


### PR DESCRIPTION
Fixes CI failures that started with the fugue `0.8.1` release.

Fugue in their latest release added https://github.com/fugue-project/fugue/issues/420 a `is_distributed` abstract method to the SQLEngine and ExecutionEngine classes. 

This pr implements that abstract method in the DaskSQLEngine integration class.