### PR TITLE
Add support for optional catalog name to `SHOW SCHEMAS | TABLES`

### DIFF
--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -52,9 +52,6 @@ python -m pip install git+https://github.com/dask/dask
 gpuci_logger "Install distributed"
 python -m pip install git+https://github.com/dask/distributed
 
-gpuci_logger "Install latest dask-cuda"
-gpuci_mamba_retry update -y -c rapidsai-nightly dask-cuda
-
 gpuci_logger "Install dask-sql"
 pip install -e ".[dev]"
 

--- a/dask_planner/src/parser.rs
+++ b/dask_planner/src/parser.rs
@@ -1247,17 +1247,16 @@ impl<'a> DaskParser<'a> {
 
     /// Parse Dask-SQL SHOW TABLES [FROM] statement
     fn parse_show_tables(&mut self) -> Result<DaskStatement, ParserError> {
-        let mut catalog_name = None;
-        let mut schema_name = None;
-        if !self.parser.consume_token(&Token::EOF) {
-            let (obj_catalog_name, obj_schema_name) =
-                DaskParserUtils::elements_from_object_name(&self.parser.parse_object_name()?)?;
-            catalog_name = obj_catalog_name;
-            schema_name = Some(obj_schema_name);
+        if let Ok(obj_name) = &self.parser.parse_object_name() {
+            let (catalog_name, schema_name) = DaskParserUtils::elements_from_object_name(obj_name)?;
+            return Ok(DaskStatement::ShowTables(Box::new(ShowTables {
+                catalog_name,
+                schema_name: Some(schema_name),
+            })));
         }
         Ok(DaskStatement::ShowTables(Box::new(ShowTables {
-            catalog_name,
-            schema_name,
+            catalog_name: None,
+            schema_name: None,
         })))
     }
 

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -59,7 +59,7 @@ use crate::{
             predict_model::PredictModelPlanNode,
             show_columns::ShowColumnsPlanNode,
             show_models::ShowModelsPlanNode,
-            show_schema::ShowSchemasPlanNode,
+            show_schemas::ShowSchemasPlanNode,
             show_tables::ShowTablesPlanNode,
             PyLogicalPlan,
         },
@@ -617,6 +617,7 @@ impl DaskSQLContext {
             DaskStatement::ShowSchemas(show_schemas) => Ok(LogicalPlan::Extension(Extension {
                 node: Arc::new(ShowSchemasPlanNode {
                     schema: Arc::new(DFSchema::empty()),
+                    from: show_schemas.from,
                     like: show_schemas.like,
                 }),
             })),

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -623,13 +623,14 @@ impl DaskSQLContext {
             DaskStatement::ShowSchemas(show_schemas) => Ok(LogicalPlan::Extension(Extension {
                 node: Arc::new(ShowSchemasPlanNode {
                     schema: Arc::new(DFSchema::empty()),
-                    from: show_schemas.from,
+                    catalog_name: show_schemas.catalog_name,
                     like: show_schemas.like,
                 }),
             })),
             DaskStatement::ShowTables(show_tables) => Ok(LogicalPlan::Extension(Extension {
                 node: Arc::new(ShowTablesPlanNode {
                     schema: Arc::new(DFSchema::empty()),
+                    catalog_name: show_tables.catalog_name,
                     schema_name: show_tables.schema_name,
                 }),
             })),

--- a/dask_planner/src/sql/logical.rs
+++ b/dask_planner/src/sql/logical.rs
@@ -27,7 +27,7 @@ pub mod projection;
 pub mod repartition_by;
 pub mod show_columns;
 pub mod show_models;
-pub mod show_schema;
+pub mod show_schemas;
 pub mod show_tables;
 pub mod sort;
 pub mod subquery_alias;
@@ -54,7 +54,7 @@ use self::{
     predict_model::PredictModelPlanNode,
     show_columns::ShowColumnsPlanNode,
     show_models::ShowModelsPlanNode,
-    show_schema::ShowSchemasPlanNode,
+    show_schemas::ShowSchemasPlanNode,
     show_tables::ShowTablesPlanNode,
     use_schema::UseSchemaPlanNode,
 };
@@ -177,7 +177,7 @@ impl PyLogicalPlan {
     }
 
     /// LogicalPlan::Extension::ShowSchemas as PyShowSchemas
-    pub fn show_schemas(&self) -> PyResult<show_schema::PyShowSchema> {
+    pub fn show_schemas(&self) -> PyResult<show_schemas::PyShowSchema> {
         to_py_plan(self.current_node.as_ref())
     }
 

--- a/dask_planner/src/sql/logical/show_schemas.rs
+++ b/dask_planner/src/sql/logical/show_schemas.rs
@@ -14,6 +14,7 @@ use crate::sql::{exceptions::py_type_err, logical};
 #[derive(Clone)]
 pub struct ShowSchemasPlanNode {
     pub schema: DFSchemaRef,
+    pub from: Option<String>,
     pub like: Option<String>,
 }
 
@@ -54,6 +55,7 @@ impl UserDefinedLogicalNode for ShowSchemasPlanNode {
     ) -> Arc<dyn UserDefinedLogicalNode> {
         Arc::new(ShowSchemasPlanNode {
             schema: Arc::new(DFSchema::empty()),
+            from: self.from.clone(),
             like: self.like.clone(),
         })
     }
@@ -66,9 +68,14 @@ pub struct PyShowSchema {
 
 #[pymethods]
 impl PyShowSchema {
+    #[pyo3(name = "getFrom")]
+    fn get_from(&self) -> PyResult<Option<String>> {
+        Ok(self.show_schema.from.clone())
+    }
+
     #[pyo3(name = "getLike")]
-    fn get_like(&self) -> PyResult<String> {
-        Ok(self.show_schema.like.as_ref().cloned().unwrap_or_default())
+    fn get_like(&self) -> PyResult<Option<String>> {
+        Ok(self.show_schema.like.clone())
     }
 }
 

--- a/dask_planner/src/sql/logical/show_schemas.rs
+++ b/dask_planner/src/sql/logical/show_schemas.rs
@@ -14,7 +14,7 @@ use crate::sql::{exceptions::py_type_err, logical};
 #[derive(Clone)]
 pub struct ShowSchemasPlanNode {
     pub schema: DFSchemaRef,
-    pub from: Option<String>,
+    pub catalog_name: Option<String>,
     pub like: Option<String>,
 }
 
@@ -45,7 +45,7 @@ impl UserDefinedLogicalNode for ShowSchemasPlanNode {
     }
 
     fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ShowSchema")
+        write!(f, "ShowSchema: catalog_name: {:?}", self.catalog_name)
     }
 
     fn from_template(
@@ -55,7 +55,7 @@ impl UserDefinedLogicalNode for ShowSchemasPlanNode {
     ) -> Arc<dyn UserDefinedLogicalNode> {
         Arc::new(ShowSchemasPlanNode {
             schema: Arc::new(DFSchema::empty()),
-            from: self.from.clone(),
+            catalog_name: self.catalog_name.clone(),
             like: self.like.clone(),
         })
     }
@@ -68,9 +68,9 @@ pub struct PyShowSchema {
 
 #[pymethods]
 impl PyShowSchema {
-    #[pyo3(name = "getFrom")]
+    #[pyo3(name = "getCatalogName")]
     fn get_from(&self) -> PyResult<Option<String>> {
-        Ok(self.show_schema.from.clone())
+        Ok(self.show_schema.catalog_name.clone())
     }
 
     #[pyo3(name = "getLike")]

--- a/dask_planner/src/sql/logical/show_tables.rs
+++ b/dask_planner/src/sql/logical/show_tables.rs
@@ -14,6 +14,7 @@ use crate::sql::{exceptions::py_type_err, logical};
 #[derive(Clone)]
 pub struct ShowTablesPlanNode {
     pub schema: DFSchemaRef,
+    pub catalog_name: Option<String>,
     pub schema_name: Option<String>,
 }
 
@@ -44,7 +45,11 @@ impl UserDefinedLogicalNode for ShowTablesPlanNode {
     }
 
     fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ShowTables: schema_name: {:?}", self.schema_name)
+        write!(
+            f,
+            "ShowTables: catalog_name: {:?}, schema_name: {:?}",
+            self.catalog_name, self.schema_name
+        )
     }
 
     fn from_template(
@@ -54,6 +59,7 @@ impl UserDefinedLogicalNode for ShowTablesPlanNode {
     ) -> Arc<dyn UserDefinedLogicalNode> {
         Arc::new(ShowTablesPlanNode {
             schema: Arc::new(DFSchema::empty()),
+            catalog_name: self.catalog_name.clone(),
             schema_name: self.schema_name.clone(),
         })
     }
@@ -66,6 +72,11 @@ pub struct PyShowTables {
 
 #[pymethods]
 impl PyShowTables {
+    #[pyo3(name = "getCatalogName")]
+    fn get_catalog_name(&self) -> PyResult<Option<String>> {
+        Ok(self.show_tables.catalog_name.clone())
+    }
+
     #[pyo3(name = "getSchemaName")]
     fn get_schema_name(&self) -> PyResult<Option<String>> {
         Ok(self.show_tables.schema_name.clone())

--- a/dask_sql/physical/rel/custom/__init__.py
+++ b/dask_sql/physical/rel/custom/__init__.py
@@ -12,9 +12,9 @@ from .drop_schema import DropSchemaPlugin
 from .drop_table import DropTablePlugin
 from .export_model import ExportModelPlugin
 from .predict_model import PredictModelPlugin
-from .schemas import ShowSchemasPlugin
 from .show_columns import ShowColumnsPlugin
 from .show_models import ShowModelsPlugin
+from .show_schemas import ShowSchemasPlugin
 from .show_tables import ShowTablesPlugin
 from .use_schema import UseSchemaPlugin
 

--- a/dask_sql/physical/rel/custom/show_schemas.py
+++ b/dask_sql/physical/rel/custom/show_schemas.py
@@ -32,7 +32,7 @@ class ShowSchemasPlugin(BaseRelPlugin):
         df = pd.DataFrame({"Schema": schemas})
 
         # currently catalogs other than the default `dask_sql` are not supported
-        catalog_name = show_schemas.getFrom() or context.catalog_name
+        catalog_name = show_schemas.getCatalogName() or context.catalog_name
         if catalog_name != context.catalog_name:
             raise RuntimeError(
                 f"A catalog with the name {catalog_name} is not present."

--- a/dask_sql/physical/rel/custom/show_schemas.py
+++ b/dask_sql/physical/rel/custom/show_schemas.py
@@ -16,7 +16,7 @@ class ShowSchemasPlugin(BaseRelPlugin):
     Show all schemas.
     The SQL is:
 
-        SHOW SCHEMAS
+        SHOW SCHEMAS [FROM <catalog-name>] [LIKE <>]
 
     The result is also a table, although it is created on the fly.
     """
@@ -24,7 +24,6 @@ class ShowSchemasPlugin(BaseRelPlugin):
     class_name = "ShowSchemas"
 
     def convert(self, rel: "LogicalPlan", context: "dask_sql.Context") -> DataContainer:
-
         show_schemas = rel.show_schemas()
 
         # "information_schema" is a schema which is found in every presto database
@@ -32,7 +31,14 @@ class ShowSchemasPlugin(BaseRelPlugin):
         schemas.append("information_schema")
         df = pd.DataFrame({"Schema": schemas})
 
-        # We currently do not use the passed additional parameter FROM.
+        # currently catalogs other than the default `dask_sql` are not supported
+        catalog_name = show_schemas.getFrom() or context.catalog_name
+        if catalog_name != context.catalog_name:
+            raise RuntimeError(
+                f"A catalog with the name {catalog_name} is not present."
+            )
+
+        # filter by LIKE value
         like = str(show_schemas.getLike()).strip("'")
         if like and like != "None":
             df = df[df.Schema == like]

--- a/dask_sql/server/app.py
+++ b/dask_sql/server/app.py
@@ -74,7 +74,6 @@ async def query(request: Request):
     """
     try:
         sql = (await request.body()).decode().strip()
-        breakpoint()
         # required for PrestoDB JDBC driver compatibility
         # replaces queries to unsupported `system` catalog with queries to `system_jdbc`
         # schema created by `create_meta_data(context)` when `jdbc_metadata=True`

--- a/dask_sql/server/app.py
+++ b/dask_sql/server/app.py
@@ -74,6 +74,7 @@ async def query(request: Request):
     """
     try:
         sql = (await request.body()).decode().strip()
+        breakpoint()
         # required for PrestoDB JDBC driver compatibility
         # replaces queries to unsupported `system` catalog with queries to `system_jdbc`
         # schema created by `create_meta_data(context)` when `jdbc_metadata=True`

--- a/tests/integration/test_show.py
+++ b/tests/integration/test_show.py
@@ -59,14 +59,23 @@ def test_wrong_input(c):
         c.sql(f'SHOW COLUMNS FROM "{c.schema_name}"."table"')
     with pytest.raises(AttributeError):
         c.sql('SHOW TABLES FROM "wrong"')
+    with pytest.raises(RuntimeError):
+        c.sql(f'SHOW TABLES FROM "wrong"."{c.schema_name}"')
 
 
-def test_show_tables_no_schema(c):
+def test_show_tables(c):
     c = Context()
 
     df = pd.DataFrame({"id": [0, 1]})
     c.create_table("test", df)
 
-    actual_df = c.sql("show tables").compute()
     expected_df = pd.DataFrame({"Table": ["test"]})
-    assert_eq(actual_df, expected_df)
+
+    # no schema specified
+    assert_eq(c.sql("show tables"), expected_df)
+
+    # unqualified schema
+    assert_eq(c.sql("show tables from root"), expected_df)
+
+    # qualified schema
+    assert_eq(c.sql("show tables from dask_sql.root"), expected_df)


### PR DESCRIPTION
WIP to unblock some of the functionality of Metabase using its deprecated Presto driver with our server implementation.

TODO:

- [x] Add support for `SHOW TABLES FROM <catalog-name>.<schema-name>`