### PR TITLE
Fix CI failures

### DIFF
--- a/.github/cluster.yml
+++ b/.github/cluster.yml
@@ -7,6 +7,10 @@ services:
         command: dask-scheduler
         ports:
             - "8786:8786"
+        environment:
+            USE_MAMBA: "true"
+            # p2p shuffling requires pyarrow>=7.0.0
+            EXTRA_CONDA_PACKAGES: "pyarrow>=7.0.0"
     dask-worker:
         container_name: dask-worker
         image: daskdev/dask:dev-py3.9

--- a/dask_sql/_compat.py
+++ b/dask_sql/_compat.py
@@ -16,3 +16,4 @@ PIPE_INPUT_CONTEXT_MANAGER = _prompt_toolkit_version >= parseVersion("3.0.29")
 
 # TODO: remove when dask min version gets bumped
 BROADCAST_JOIN_SUPPORT_WORKING = _dask_version > parseVersion("2023.1.0")
+DASK_P2P_SHUFFLE_DEFAULT = _dask_version >= parseVersion("2023.2.1")

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -509,11 +509,12 @@ class Context:
         """
         # FIXME: Remove once p2p issues are fixed
         # https://github.com/dask-contrib/dask-sql/pull/1067
-        if DASK_P2P_SHUFFLE_DEFAULT and dask_config.get(
-            "dataframe.shuffle.algorithm", default=None
-        ) in (None, "p2p"):
+        shuffle_algorithm = dask_config.get("dataframe.shuffle.algorithm", default=None)
+        if (
+            DASK_P2P_SHUFFLE_DEFAULT and shuffle_algorithm is None
+        ) or shuffle_algorithm == "p2p":
             warnings.warn(
-                "dask>=2023.2.1 defaults to using a p2p shuffle algorithm which is not fully supported by dask-sql; "
+                "Dask's p2p shuffle algorithm is not yet supported by dask-sql; "
                 "setting shuffle algorithm to `tasks` (see https://github.com/dask-contrib/dask-sql/pull/1067)"
             )
             if config_options is None:

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -508,7 +508,7 @@ class Context:
         """
         # FIXME: Remove once p2p issues are fixed
         # https://github.com/dask-contrib/dask-sql/pull/1067
-        if dask_config.get("dataframe.shuffle.algorithm") is None:
+        if dask_config.get("dataframe.shuffle.algorithm", default=None) is None:
             if config_options is None:
                 config_options = {"dataframe.shuffle.algorithm": "tasks"}
             else:

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -19,6 +19,7 @@ from dask_planner.rust import (
     DFParsingException,
     LogicalPlan,
 )
+from dask_sql._compat import DASK_P2P_SHUFFLE_DEFAULT
 
 try:
     from dask_sql.physical.utils.statistics import parquet_statistics
@@ -508,7 +509,13 @@ class Context:
         """
         # FIXME: Remove once p2p issues are fixed
         # https://github.com/dask-contrib/dask-sql/pull/1067
-        if dask_config.get("dataframe.shuffle.algorithm", default=None) is None:
+        if DASK_P2P_SHUFFLE_DEFAULT and dask_config.get(
+            "dataframe.shuffle.algorithm", default=None
+        ) in (None, "p2p"):
+            warnings.warn(
+                "dask>=2023.2.1 defaults to using a p2p shuffle algorithm which is not fully supported by dask-sql; "
+                "setting shuffle algorithm to `tasks` (see https://github.com/dask-contrib/dask-sql/pull/1067)"
+            )
             if config_options is None:
                 config_options = {"dataframe.shuffle.algorithm": "tasks"}
             else:

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -506,6 +506,13 @@ class Context:
         Returns:
             :obj:`dask.dataframe.DataFrame`: the created data frame of this query.
         """
+        # FIXME: Remove once p2p issues are fixed
+        # https://github.com/dask-contrib/dask-sql/pull/1067
+        if dask_config.get("dataframe.shuffle.algorithm") is None:
+            if config_options is None:
+                config_options = {"dataframe.shuffle.algorithm": "tasks"}
+            else:
+                config_options["dataframe.shuffle.algorithm"] = "tasks"
         with dask_config.set(config_options):
             if dataframes is not None:
                 for df_name, df in dataframes.items():

--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -248,15 +248,13 @@ class DaskJoinPlugin(BaseRelPlugin):
         added_columns = list(lhs_columns_to_add.keys())
 
         broadcast = dask_config.get("sql.join.broadcast")
-        if (
-            not BROADCAST_JOIN_SUPPORT_WORKING
-            and isinstance(broadcast, float)
-            or broadcast
+        if not BROADCAST_JOIN_SUPPORT_WORKING and (
+            isinstance(broadcast, float) or broadcast
         ):
             warnings.warn(
                 "Broadcast Joins may not work as expected with dask<2023.1.1"
                 "For more information refer to https://github.com/dask/dask/issues/9851"
-                "and https://github.com/dask/dask/issues/9870"
+                " and https://github.com/dask/dask/issues/9870"
             )
         df = dd.merge(
             df_lhs_with_tmp,

--- a/tests/integration/test_join.py
+++ b/tests/integration/test_join.py
@@ -424,27 +424,40 @@ def test_broadcast_join(c, client, gpu):
     FROM df1, df2
     WHERE df1.user_id = df2.user_id
     """
+
     expected_df = df1.merge(df2, on="user_id", how="inner")
 
     res_df = c.sql(query_string, config_options={"sql.join.broadcast": True})
     assert hlg_layer(res_df.dask, "bcast-join")
-    assert_eq(res_df, expected_df, check_divisions=False, check_index=False)
+    assert_eq(
+        res_df,
+        expected_df,
+        check_divisions=False,
+        check_index=False,
+        scheduler="distributed",
+    )
 
     res_df = c.sql(query_string, config_options={"sql.join.broadcast": 1.0})
     assert hlg_layer(res_df.dask, "bcast-join")
-    assert_eq(res_df, expected_df, check_divisions=False, check_index=False)
+    assert_eq(
+        res_df,
+        expected_df,
+        check_divisions=False,
+        check_index=False,
+        scheduler="distributed",
+    )
 
     res_df = c.sql(query_string, config_options={"sql.join.broadcast": 0.5})
     with pytest.raises(KeyError):
         hlg_layer(res_df.dask, "bcast-join")
-    assert_eq(res_df, expected_df, check_index=False)
+    assert_eq(res_df, expected_df, check_index=False, scheduler="distributed")
 
     res_df = c.sql(query_string, config_options={"sql.join.broadcast": False})
     with pytest.raises(KeyError):
         hlg_layer(res_df.dask, "bcast-join")
-    assert_eq(res_df, expected_df, check_index=False)
+    assert_eq(res_df, expected_df, check_index=False, scheduler="distributed")
 
     res_df = c.sql(query_string, config_options={"sql.join.broadcast": None})
     with pytest.raises(KeyError):
         hlg_layer(res_df.dask, "bcast-join")
-    assert_eq(res_df, expected_df, check_index=False)
+    assert_eq(res_df, expected_df, check_index=False, scheduler="distributed")


### PR DESCRIPTION
Fixes #1066 
Fixes #1064 
The latest dask update defaults to using `p2p` shuffles which iiic isn't supported on the sync scheduler https://github.com/dask/dask/issues/9996, which is our default when calling `assert_eq` in our tests.

This pr updates the relevant tests to use a distributed scheduler instead for those cases.