### PR TITLE
Fix getitem bug in parquet_statistics

### DIFF
--- a/dask_sql/physical/utils/statistics.py
+++ b/dask_sql/physical/utils/statistics.py
@@ -116,8 +116,9 @@ def parquet_statistics(
         # all be in the same footer)
         groups = defaultdict(list)
         for part in parts:
-            path = part.get("piece")[0]
-            groups[path].append(part)
+            for p in [part] if isinstance(part, dict) else part:
+                path = p.get("piece")[0]
+                groups[path].append(p)
         group_keys = list(groups.keys())
 
         # Compute and return flattened result


### PR DESCRIPTION
There is a minor bug in `parquet_statistics` that is now much more likely to cause problems after https://github.com/dask/dask/pull/9637 (since `parts` is now much more likely to be `List[List[dict]]` rather than `List[dict]`)