### PR TITLE
Add `filepath` fields in Python and Rust

### DIFF
--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -133,22 +133,15 @@ impl ContextProvider for DaskSQLContext {
                 // If the Table is not found return None. DataFusion will handle the error propagation
                 match resp {
                     Some(e) => {
-                        let statistics = &self
+                        let table_ref = &self
                             .schemas
                             .get(reference.schema.as_ref())
                             .unwrap()
                             .tables
                             .get(reference.table.as_ref())
-                            .unwrap()
-                            .statistics;
-                        let filepath = &self
-                            .schemas
-                            .get(reference.schema.as_ref())
-                            .unwrap()
-                            .tables
-                            .get(reference.table.as_ref())
-                            .unwrap()
-                            .filepath;
+                            .unwrap();
+                        let statistics = &table_ref.statistics;
+                        let filepath = &table_ref.filepath;
                         if statistics.get_row_count() == 0.0 {
                             Ok(Arc::new(table::DaskTableSource::new(
                                 Arc::new(e),

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -150,7 +150,10 @@ impl ContextProvider for DaskSQLContext {
                             .unwrap()
                             .filepath;
                         if statistics.get_row_count() == 0.0 {
-                            Ok(Arc::new(table::DaskTableSource::new(Arc::new(e), None, filepath.clone())))
+                            Ok(Arc::new(table::DaskTableSource::new(
+                                Arc::new(e),
+                                None, filepath.clone(),
+                            )))
                         } else {
                             Ok(Arc::new(table::DaskTableSource::new(
                                 Arc::new(e),

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -141,12 +141,21 @@ impl ContextProvider for DaskSQLContext {
                             .get(reference.table.as_ref())
                             .unwrap()
                             .statistics;
+                        let filepath = &self
+                            .schemas
+                            .get(reference.schema.as_ref())
+                            .unwrap()
+                            .tables
+                            .get(reference.table.as_ref())
+                            .unwrap()
+                            .filepath;
                         if statistics.get_row_count() == 0.0 {
-                            Ok(Arc::new(table::DaskTableSource::new(Arc::new(e), None)))
+                            Ok(Arc::new(table::DaskTableSource::new(Arc::new(e), None, filepath.clone())))
                         } else {
                             Ok(Arc::new(table::DaskTableSource::new(
                                 Arc::new(e),
                                 Some(statistics.clone()),
+                                filepath.clone(),
                             )))
                         }
                     }

--- a/dask_planner/src/sql.rs
+++ b/dask_planner/src/sql.rs
@@ -152,7 +152,8 @@ impl ContextProvider for DaskSQLContext {
                         if statistics.get_row_count() == 0.0 {
                             Ok(Arc::new(table::DaskTableSource::new(
                                 Arc::new(e),
-                                None, filepath.clone(),
+                                None,
+                                filepath.clone(),
                             )))
                         } else {
                             Ok(Arc::new(table::DaskTableSource::new(

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -32,8 +32,16 @@ pub struct DaskTableSource {
 
 impl DaskTableSource {
     /// Initialize a new `EmptyTable` from a schema
-    pub fn new(schema: SchemaRef, statistics: Option<DaskStatistics>, filepath: Option<String>) -> Self {
-        Self { schema, statistics, filepath }
+    pub fn new(
+        schema: SchemaRef,
+        statistics: Option<DaskStatistics>,
+        filepath: Option<String>,
+    ) -> Self {
+        Self {
+            schema,
+            statistics,
+            filepath,
+        }
     }
 
     /// Access optional statistics associated with this table source

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -123,13 +123,18 @@ pub struct DaskTable {
 #[pymethods]
 impl DaskTable {
     #[new]
-    pub fn new(schema_name: &str, table_name: &str, row_count: f64, filepath: &str) -> Self {
+    pub fn new(
+        schema_name: &str,
+        table_name: &str,
+        row_count: f64,
+        filepath: Option<String>,
+    ) -> Self {
         Self {
             schema_name: Some(schema_name.to_owned()),
             table_name: table_name.to_owned(),
             statistics: DaskStatistics::new(row_count),
             columns: Vec::new(),
-            filepath: Some(filepath.to_owned()),
+            filepath,
         }
     }
 

--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -27,18 +27,25 @@ pub struct DaskTableSource {
     schema: SchemaRef,
     #[allow(dead_code)]
     statistics: Option<DaskStatistics>,
+    filepath: Option<String>,
 }
 
 impl DaskTableSource {
     /// Initialize a new `EmptyTable` from a schema
-    pub fn new(schema: SchemaRef, statistics: Option<DaskStatistics>) -> Self {
-        Self { schema, statistics }
+    pub fn new(schema: SchemaRef, statistics: Option<DaskStatistics>, filepath: Option<String>) -> Self {
+        Self { schema, statistics, filepath }
     }
 
     /// Access optional statistics associated with this table source
     #[allow(dead_code)]
     pub fn statistics(&self) -> Option<&DaskStatistics> {
         self.statistics.as_ref()
+    }
+
+    /// Access optional filepath associated with this table source
+    #[allow(dead_code)]
+    pub fn filepath(&self) -> Option<&String> {
+        self.filepath.as_ref()
     }
 }
 
@@ -102,17 +109,19 @@ pub struct DaskTable {
     pub(crate) table_name: String,
     pub(crate) statistics: DaskStatistics,
     pub(crate) columns: Vec<(String, DaskTypeMap)>,
+    pub(crate) filepath: Option<String>,
 }
 
 #[pymethods]
 impl DaskTable {
     #[new]
-    pub fn new(schema_name: &str, table_name: &str, row_count: f64) -> Self {
+    pub fn new(schema_name: &str, table_name: &str, row_count: f64, filepath: &str) -> Self {
         Self {
             schema_name: Some(schema_name.to_owned()),
             table_name: table_name.to_owned(),
             statistics: DaskStatistics::new(row_count),
             columns: Vec::new(),
+            filepath: Some(filepath.to_owned()),
         }
     }
 
@@ -202,6 +211,7 @@ pub(crate) fn table_from_logical_plan(
                 table_name: String::from(tbl),
                 statistics: DaskStatistics { row_count: 0.0 },
                 columns: cols,
+                filepath: None,
             }))
         }
         LogicalPlan::Join(join) => {
@@ -230,6 +240,7 @@ pub(crate) fn table_from_logical_plan(
                 table_name: String::from("EmptyRelation"),
                 statistics: DaskStatistics { row_count: 0.0 },
                 columns: cols,
+                filepath: None,
             }))
         }
         LogicalPlan::Extension(ex) => {
@@ -240,6 +251,7 @@ pub(crate) fn table_from_logical_plan(
                     table_name: e.table_name.clone(),
                     statistics: DaskStatistics { row_count: 0.0 },
                     columns: vec![],
+                    filepath: None,
                 }))
             } else if let Some(e) = node.downcast_ref::<PredictModelPlanNode>() {
                 Ok(Some(DaskTable {
@@ -247,6 +259,7 @@ pub(crate) fn table_from_logical_plan(
                     table_name: e.model_name.clone(),
                     statistics: DaskStatistics { row_count: 0.0 },
                     columns: vec![],
+                    filepath: None,
                 }))
             } else {
                 Err(DaskPlannerError::Internal(format!(

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -255,7 +255,7 @@ class Context:
             dc.filepath = input_table
             self.schema[schema_name].filepaths[table_name.lower()] = input_table
         else:
-            filepath = ""
+            filepath = None
 
         self.schema[schema_name].tables[table_name.lower()] = dc
 

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -255,7 +255,7 @@ class Context:
             dc.filepath = input_table
             self.schema[schema_name].filepaths[table_name.lower()] = input_table
         else:
-            filepath = None
+            filepath = ""
 
         self.schema[schema_name].tables[table_name.lower()] = dc
 
@@ -777,7 +777,7 @@ class Context:
                     else float(0)
                 )
 
-                filepath = schema.filepaths[name] if name in schema.filepaths else None
+                filepath = schema.filepaths[name] if name in schema.filepaths else ""
 
                 table = DaskTable(schema_name, name, row_count, filepath)
                 df = dc.df

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -792,7 +792,7 @@ class Context:
                     else float(0)
                 )
 
-                filepath = schema.filepaths[name] if name in schema.filepaths else ""
+                filepath = schema.filepaths[name] if name in schema.filepaths else None
 
                 table = DaskTable(schema_name, name, row_count, filepath)
                 df = dc.df

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -250,6 +250,13 @@ class Context:
             **kwargs,
         )
 
+        if type(input_table) == str:
+            filepath = input_table
+            dc.filepath = input_table
+            self.schema[schema_name].filepaths[table_name.lower()] = input_table
+        else:
+            filepath = None
+
         self.schema[schema_name].tables[table_name.lower()] = dc
 
         if statistics:
@@ -269,7 +276,7 @@ class Context:
 
         # Register the table with the Rust DaskSQLContext
         self.context.register_table(
-            schema_name, DaskTable(schema_name, table_name, statistics.row_count)
+            schema_name, DaskTable(schema_name, table_name, statistics.row_count, filepath)
         )
 
     def register_dask_table(self, df: dd.DataFrame, name: str, *args, **kwargs):
@@ -769,7 +776,13 @@ class Context:
                     else float(0)
                 )
 
-                table = DaskTable(schema_name, name, row_count)
+                filepath = (
+                    schema.filepaths[name]
+                    if name in schema.filepaths
+                    else None
+                )
+
+                table = DaskTable(schema_name, name, row_count, filepath)
                 df = dc.df
 
                 for column in df.columns:

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -276,7 +276,8 @@ class Context:
 
         # Register the table with the Rust DaskSQLContext
         self.context.register_table(
-            schema_name, DaskTable(schema_name, table_name, statistics.row_count, filepath)
+            schema_name,
+            DaskTable(schema_name, table_name, statistics.row_count, filepath),
         )
 
     def register_dask_table(self, df: dd.DataFrame, name: str, *args, **kwargs):
@@ -776,11 +777,7 @@ class Context:
                     else float(0)
                 )
 
-                filepath = (
-                    schema.filepaths[name]
-                    if name in schema.filepaths
-                    else None
-                )
+                filepath = schema.filepaths[name] if name in schema.filepaths else None
 
                 table = DaskTable(schema_name, name, row_count, filepath)
                 df = dc.df

--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -202,10 +202,12 @@ class DataContainer:
         df: dd.DataFrame,
         column_container: ColumnContainer,
         statistics: Statistics = None,
+        filepath: str = None,
     ):
         self.df = df
         self.column_container = column_container
         self.statistics = statistics
+        self.filepath = filepath
 
     def assign(self) -> dd.DataFrame:
         """
@@ -280,3 +282,4 @@ class SchemaContainer:
         self.models: Dict[str, Tuple[Any, List[str]]] = {}
         self.functions: Dict[str, UDF] = {}
         self.function_lists: List[FunctionDescription] = []
+        self.filepaths: Dict[str, str] = {}

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -336,7 +336,7 @@ def test_filepath(tmpdir):
     c = Context()
 
     parquet_path = os.path.join(tmpdir, "parquet")
-    df = pd.DataFrame(
+    parquet_df = pd.DataFrame(
         {
             "a": [1, 2, 3] * 5,
             "b": range(15),
@@ -350,11 +350,11 @@ def test_filepath(tmpdir):
             "index": range(15),
         },
     )
-    dd.from_pandas(df, npartitions=3).to_parquet(parquet_path)
-    c.create_table("df", parquet_path, format="parquet")
+    dd.from_pandas(parquet_df, npartitions=3).to_parquet(parquet_path)
+    c.create_table("parquet_df", parquet_path, format="parquet")
 
-    assert c.schema["root"].tables["df"].filepath == parquet_path
-    assert c.schema["root"].filepaths["df"] == parquet_path
+    assert c.schema["root"].tables["parquet_df"].filepath == parquet_path
+    assert c.schema["root"].filepaths["parquet_df"] == parquet_path
 
     df = pd.DataFrame({"a": [2, 1, 2, 3], "b": [3, 3, 1, 3]})
     c.create_table("df", df)

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -332,9 +332,27 @@ def test_alter_table(c, df_simple):
     del c.schema[c.schema_name].tables["physics"]
 
 
-def test_filepath(parquet_ddf, tmpdir):
+def test_filepath(tmpdir):
     c = Context()
-    c.create_table("df", parquet_ddf)
 
-    assert c.schema["root"].tables["df"].filepath == os.path.join(tmpdir, "parquet")
-    assert c.schema["root"].filepaths["df"] == os.path.join(tmpdir, "parquet")
+    parquet_path = os.path.join(tmpdir, "parquet")
+    df = pd.DataFrame(
+        {
+            "a": [1, 2, 3] * 5,
+            "b": range(15),
+            "c": ["A"] * 15,
+            "d": [
+                pd.Timestamp("2013-08-01 23:00:00"),
+                pd.Timestamp("2014-09-01 23:00:00"),
+                pd.Timestamp("2015-10-01 23:00:00"),
+            ]
+            * 5,
+            "index": range(15),
+        },
+    )
+    dd.from_pandas(df, npartitions=3).to_parquet(parquet_path)
+
+    c.create_table("df", parquet_path, format="parquet")
+
+    assert c.schema["root"].tables["df"].filepath == parquet_path
+    assert c.schema["root"].filepaths["df"] == parquet_path

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import warnings
 
@@ -329,3 +330,11 @@ def test_alter_table(c, df_simple):
     c.sql("ALTER TABLE IF EXISTS alien RENAME TO humans")
 
     del c.schema[c.schema_name].tables["physics"]
+
+
+def test_filepath(parquet_ddf, tmpdir):
+    c = Context()
+    c.create_table("df", parquet_ddf)
+
+    assert c.schema["root"].tables["df"].filepath == os.path.join(tmpdir, "parquet")
+    assert c.schema["root"].filepaths["df"] == os.path.join(tmpdir, "parquet")

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -359,6 +359,6 @@ def test_filepath(tmpdir):
     df = pd.DataFrame({"a": [2, 1, 2, 3], "b": [3, 3, 1, 3]})
     c.create_table("df", df)
 
-    assert c.schema["root"].tables["df"].filepath == None
+    assert c.schema["root"].tables["df"].filepath is None
     with pytest.raises(KeyError):
         c.schema["root"].filepaths["df"]

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -351,8 +351,14 @@ def test_filepath(tmpdir):
         },
     )
     dd.from_pandas(df, npartitions=3).to_parquet(parquet_path)
-
     c.create_table("df", parquet_path, format="parquet")
 
     assert c.schema["root"].tables["df"].filepath == parquet_path
     assert c.schema["root"].filepaths["df"] == parquet_path
+
+    df = pd.DataFrame({"a": [2, 1, 2, 3], "b": [3, 3, 1, 3]})
+    c.create_table("df", df)
+
+    assert c.schema["root"].tables["df"].filepath == None
+    with pytest.raises(KeyError):
+        c.schema["root"].filepaths["df"]


### PR DESCRIPTION
As part of the dynamic partition pruning optimizer rule, we'll be reading in Parquet files on the Rust side. To do this, we need to obtain information about the file paths, when available, to pass into Rust. Here, I use similar logic as the statistics logic from https://github.com/dask-contrib/dask-sql/pull/1061 and https://github.com/dask-contrib/dask-sql/pull/1027.