### PR TITLE
Increase number of `test_dask_fsql` reruns

### DIFF
--- a/tests/integration/test_fugue.py
+++ b/tests/integration/test_fugue.py
@@ -44,7 +44,7 @@ def test_fugue_fsql(client):
 # TODO: Revisit fixing this on an independant cluster (without dask-sql) based on the
 # discussion in https://github.com/dask-contrib/dask-sql/issues/407
 @xfail_if_external_scheduler
-@pytest.mark.flaky(reruns=2, condition="sys.version_info < (3, 9)")
+@pytest.mark.flaky(reruns=4, condition="sys.version_info < (3, 9)")
 def test_dask_fsql(client):
     def assert_fsql(df: pd.DataFrame) -> None:
         assert_eq(df, pd.DataFrame({"a": [1]}))


### PR DESCRIPTION
In https://github.com/dask-contrib/dask-sql/pull/1021, we added reruns for the pytest `test_dask_fsql`. Although it has mostly helped, there are still cases where the test occasionally fails, such as in https://github.com/dask-contrib/dask-sql/pull/1060 (see [job](https://github.com/dask-contrib/dask-sql/actions/runs/4366811668/jobs/7637313363)). Maybe we should double the number of reruns?