### PR TITLE
Unblock P2P shuffle operations on CPU

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,7 @@ def pytest_runtest_setup(item):
         if not item.config.getoption("--rungpu"):
             pytest.skip("need --rungpu option to run")
         # FIXME: P2P shuffle isn't fully supported on GPU, so we must explicitly disable it
-        dask.config.set({"dataframe.shuffle.algorithm": "tasks"})
+        # dask.config.set({"dataframe.shuffle.algorithm": "tasks"})
     else:
         dask.config.set({"dataframe.shuffle.algorithm": None})
     if "queries" in item.keywords and not item.config.getoption("--runqueries"):

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import dask
 import pytest
 
 pytest_plugins = ["tests.integration.fixtures"]
@@ -9,7 +10,12 @@ def pytest_addoption(parser):
 
 
 def pytest_runtest_setup(item):
-    if "gpu" in item.keywords and not item.config.getoption("--rungpu"):
-        pytest.skip("need --rungpu option to run")
+    if "gpu" in item.keywords:
+        if not item.config.getoption("--rungpu"):
+            pytest.skip("need --rungpu option to run")
+        # FIXME: P2P shuffle isn't fully supported on GPU, so we must explicitly disable it
+        dask.config.set({"dataframe.shuffle.algorithm": "tasks"})
+    else:
+        dask.config.set({"dataframe.shuffle.algorithm": None})
     if "queries" in item.keywords and not item.config.getoption("--runqueries"):
         pytest.skip("need --runqueries option to run")

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,7 @@ def pytest_runtest_setup(item):
         if not item.config.getoption("--rungpu"):
             pytest.skip("need --rungpu option to run")
         # FIXME: P2P shuffle isn't fully supported on GPU, so we must explicitly disable it
-        # dask.config.set({"dataframe.shuffle.algorithm": "tasks"})
+        dask.config.set({"dataframe.shuffle.algorithm": "tasks"})
     else:
         dask.config.set({"dataframe.shuffle.algorithm": None})
     if "queries" in item.keywords and not item.config.getoption("--runqueries"):

--- a/dask_sql/_compat.py
+++ b/dask_sql/_compat.py
@@ -16,4 +16,3 @@ PIPE_INPUT_CONTEXT_MANAGER = _prompt_toolkit_version >= parseVersion("3.0.29")
 
 # TODO: remove when dask min version gets bumped
 BROADCAST_JOIN_SUPPORT_WORKING = _dask_version > parseVersion("2023.1.0")
-DASK_P2P_SHUFFLE_DEFAULT = _dask_version >= parseVersion("2023.2.1")

--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -19,7 +19,6 @@ from dask_planner.rust import (
     DFParsingException,
     LogicalPlan,
 )
-from dask_sql._compat import DASK_P2P_SHUFFLE_DEFAULT
 
 try:
     from dask_sql.physical.utils.statistics import parquet_statistics
@@ -507,20 +506,6 @@ class Context:
         Returns:
             :obj:`dask.dataframe.DataFrame`: the created data frame of this query.
         """
-        # FIXME: Remove once p2p issues are fixed
-        # https://github.com/dask-contrib/dask-sql/pull/1067
-        shuffle_algorithm = dask_config.get("dataframe.shuffle.algorithm", default=None)
-        if (
-            DASK_P2P_SHUFFLE_DEFAULT and shuffle_algorithm is None
-        ) or shuffle_algorithm == "p2p":
-            warnings.warn(
-                "Dask's p2p shuffle algorithm is not yet supported by dask-sql; "
-                "setting shuffle algorithm to `tasks` (see https://github.com/dask-contrib/dask-sql/pull/1067)"
-            )
-            if config_options is None:
-                config_options = {"dataframe.shuffle.algorithm": "tasks"}
-            else:
-                config_options["dataframe.shuffle.algorithm"] = "tasks"
         with dask_config.set(config_options):
             if dataframes is not None:
                 for df_name, df in dataframes.items():

--- a/dask_sql/physical/rel/logical/cross_join.py
+++ b/dask_sql/physical/rel/logical/cross_join.py
@@ -1,8 +1,6 @@
 import logging
 from typing import TYPE_CHECKING
 
-import dask.dataframe as dd
-
 import dask_sql.utils as utils
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.physical.rel.base import BaseRelPlugin
@@ -36,7 +34,7 @@ class DaskCrossJoinPlugin(BaseRelPlugin):
         df_lhs[cross_join_key] = 1
         df_rhs[cross_join_key] = 1
 
-        result = dd.merge(df_lhs, df_rhs, on=cross_join_key, suffixes=("", "0")).drop(
+        result = df_lhs.merge(df_rhs, on=cross_join_key, suffixes=("", "0")).drop(
             cross_join_key, 1
         )
 

--- a/dask_sql/physical/rel/logical/join.py
+++ b/dask_sql/physical/rel/logical/join.py
@@ -256,8 +256,7 @@ class DaskJoinPlugin(BaseRelPlugin):
                 "For more information refer to https://github.com/dask/dask/issues/9851"
                 " and https://github.com/dask/dask/issues/9870"
             )
-        df = dd.merge(
-            df_lhs_with_tmp,
+        df = df_lhs_with_tmp.merge(
             df_rhs_with_tmp,
             on=added_columns,
             how=join_type,

--- a/dask_sql/physical/rel/logical/window.py
+++ b/dask_sql/physical/rel/logical/window.py
@@ -384,7 +384,8 @@ class DaskWindowPlugin(BaseRelPlugin):
         else:
             temp_col = new_temporary_column(df)
             df = df.assign(**{temp_col: 1})
-            group_columns = temporary_columns = [temp_col]
+            group_columns = [temp_col]
+            temporary_columns = [temp_col]
 
         return df, group_columns, temporary_columns
 

--- a/dask_sql/physical/rel/logical/window.py
+++ b/dask_sql/physical/rel/logical/window.py
@@ -12,7 +12,6 @@ from dask_sql._compat import INDEXER_WINDOW_STEP_IMPLEMENTED
 from dask_sql.datacontainer import ColumnContainer, DataContainer
 from dask_sql.physical.rel.base import BaseRelPlugin
 from dask_sql.physical.rex.convert import RexConverter
-from dask_sql.physical.utils.groupby import get_groupby_with_nulls_cols
 from dask_sql.physical.utils.sort import sort_partition_func
 from dask_sql.utils import (
     LoggableDataFrame,
@@ -281,12 +280,12 @@ class DaskWindowPlugin(BaseRelPlugin):
             f"Before applying the function, sorting according to {sort_columns}."
         )
 
-        df, group_columns = self._extract_groupby(df, rel, window, dc, context)
+        df, group_columns, temporary_columns = self._extract_groupby(
+            df, rel, window, dc, context
+        )
         logger.debug(
             f"Before applying the function, partitioning according to {group_columns}."
         )
-        # TODO: optimize by re-using already present columns
-        temporary_columns += group_columns
 
         operations, df = self._extract_operations(rel, window, df, dc, context)
         for _, _, cols in operations:
@@ -345,7 +344,7 @@ class DaskWindowPlugin(BaseRelPlugin):
         # TODO: That is a bit of a hack. We should really use the real column dtype
         meta = df._meta.assign(**{col: 0.0 for col in newly_created_columns})
 
-        df = df.groupby(group_columns).apply(
+        df = df.groupby(group_columns, dropna=False).apply(
             make_pickable_without_dask_sql(filled_map), meta=meta
         )
         logger.debug(
@@ -375,23 +374,19 @@ class DaskWindowPlugin(BaseRelPlugin):
         context: "dask_sql.Context",
     ) -> Tuple[dd.DataFrame, str]:
         """Prepare grouping columns we can later use while applying the main function"""
-        partition_keys = list(rel.window().getPartitionExprs(window))
+        partition_keys = rel.window().getPartitionExprs(window)
         if partition_keys:
             group_columns = [
-                df[dc.column_container.get_backend_by_frontend_name(o.column_name(rel))]
+                dc.column_container.get_backend_by_frontend_name(o.column_name(rel))
                 for o in partition_keys
             ]
-            group_columns = get_groupby_with_nulls_cols(df, group_columns)
-            group_columns = {
-                new_temporary_column(df): group_col for group_col in group_columns
-            }
+            temporary_columns = []
         else:
-            group_columns = {new_temporary_column(df): 1}
+            temp_col = new_temporary_column(df)
+            df = df.assign(**{temp_col: 1})
+            group_columns = temporary_columns = [temp_col]
 
-        df = df.assign(**group_columns)
-        group_columns = list(group_columns.keys())
-
-        return df, group_columns
+        return df, group_columns, temporary_columns
 
     def _extract_ordering(
         self, rel, window, cc: ColumnContainer


### PR DESCRIPTION
Following up on #1067, this PR re-enables Dask's P2P shuffle algorithm to try and resolve the resulting test failures.