### PR TITLE
Disable dependabot for `datafusion` major updates, `cibuildwheel` patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,4 +21,3 @@ updates:
       # ignore cibw patch updates
       - dependency-name: "pypa/cibuildwheel"
         update-types: ["version-update:semver-patch"]
-      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,13 +8,17 @@ updates:
       # arrow and datafusion are bumped manually
       - dependency-name: "arrow"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "datafusion"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "datafusion-*"
         update-types: ["version-update:semver-major"]
-      # ignore cibw patch updates
-      - dependency-name: "pypa/cibuildwheel"
-        update-types: ["version-update:semver-patch"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "weekly"
+    ignore:
+      # ignore cibw patch updates
+      - dependency-name: "pypa/cibuildwheel"
+        update-types: ["version-update:semver-patch"]
+      


### PR DESCRIPTION
This PR modifies the dependabot configuration to ignore major updates to `datafusion` (xref https://github.com/dask-contrib/dask-sql/pull/1068), and correctly ignore patch updates to `pypa/cibuildwheel`.