### PR TITLE
Pin `sqlalchemy<2` in CI environments

### DIFF
--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -31,6 +31,7 @@ dependencies:
 - scikit-learn>=1.0.0
 - setuptools-rust>=1.5.2
 - sphinx
+- sqlalchemy<2
 - tpot
 - tzlocal>=2.1
 - uvicorn>=0.13.4

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -30,6 +30,7 @@ dependencies:
 - scikit-learn=1.0.0
 - setuptools-rust=1.5.2
 - sphinx
+- sqlalchemy<2
 - tpot
 - tzlocal=2.1
 - uvicorn=0.13.4

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -31,6 +31,7 @@ dependencies:
 - scikit-learn>=1.0.0
 - setuptools-rust>=1.5.2
 - sphinx
+- sqlalchemy<2
 - tpot
 - tzlocal>=2.1
 - uvicorn>=0.13.4

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -34,6 +34,7 @@ dependencies:
 - scikit-learn>=1.0.0
 - setuptools-rust>=1.5.2
 - sphinx
+- sqlalchemy<2
 - tpot
 - tzlocal>=2.1
 - uvicorn>=0.13.4

--- a/continuous_integration/gpuci/environment-3.8.yaml
+++ b/continuous_integration/gpuci/environment-3.8.yaml
@@ -34,6 +34,7 @@ dependencies:
 - scikit-learn=1.0.0
 - setuptools-rust=1.5.2
 - sphinx
+- sqlalchemy<2
 - tpot
 - tzlocal=2.1
 - uvicorn=0.13.4


### PR DESCRIPTION
Looks like our test code is incompatible with API changes made in SQLAlchemy v2; this PR pins CI environments to `sqlalchemy<2` to unblock CI. Since there aren't any immediate reasons to bump to using SQLAlchemy v2, I'm okay with maintaining this pinning versus updating the test code.

Closes https://github.com/dask-contrib/dask-sql/issues/1078
