### PR TITLE
Add columns data type creation arguments to server response for `CHAR`/`VARCHAR` columns

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -9,7 +9,6 @@ import dask.dataframe as dd
 import pandas as pd
 from dask import config as dask_config
 from dask.base import optimize
-from dask.distributed import Client
 
 from dask_planner.rust import (
     DaskSchema,
@@ -690,14 +689,7 @@ class Context:
             self, auto_include=auto_include, disable_highlighting=disable_highlighting
         )
 
-    def run_server(
-        self,
-        client: Client = None,
-        host: str = "0.0.0.0",
-        port: int = 8080,
-        log_level=None,
-        blocking: bool = True,
-    ):  # pragma: no cover
+    def run_server(self, **kwargs):  # pragma: no cover
         """
         Run a HTTP server for answering SQL queries using ``dask-sql``.
 
@@ -712,14 +704,7 @@ class Context:
         from dask_sql.server.app import run_server
 
         self.stop_server()
-        self.server = run_server(
-            context=self,
-            client=client,
-            host=host,
-            port=port,
-            log_level=log_level,
-            blocking=blocking,
-        )
+        self.server = run_server(**kwargs)
 
     def stop_server(self):  # pragma: no cover
         """

--- a/dask_sql/server/responses.py
+++ b/dask_sql/server/responses.py
@@ -75,7 +75,7 @@ class DataResults(QueryResults):
                     "rawType": sql_type,
                     "arguments": []
                     if sql_type not in ("char", "varchar")
-                    else [{"type": "LONG", "value": 10}],
+                    else [{"kind": "LONG", "value": 10}],
                 },
             }
             for column_name, sql_type in zip(column_names, sql_types)

--- a/dask_sql/server/responses.py
+++ b/dask_sql/server/responses.py
@@ -65,13 +65,18 @@ class QueryResults:
 class DataResults(QueryResults):
     @staticmethod
     def get_column_description(df):
-        sql_types = [str(python_to_sql_type(t)) for t in df.dtypes]
+        sql_types = [str(python_to_sql_type(t)).lower() for t in df.dtypes]
         column_names = df.columns
         return [
             {
                 "name": column_name,
-                "type": sql_type.lower(),
-                "typeSignature": {"rawType": sql_type.lower(), "arguments": []},
+                "type": sql_type,
+                "typeSignature": {
+                    "rawType": sql_type,
+                    "arguments": []
+                    if sql_type not in ("char", "varchar")
+                    else [{"type": "LONG", "value": 10}],
+                },
             }
             for column_name, sql_type in zip(column_names, sql_types)
         ]


### PR DESCRIPTION
Some SQL clients (such as DBeaver and Looker) expect servers to send along the creation arguments for a column's data type; for example, `VARCHAR(10)` would map to:

```json
"typeSignature": {
    "rawType": "VARCHAR",
    "arguments": [{"type": "LONG", "value": 10}],
},
```

This PR adds these arguments to the response for `CHAR` and `VARCHAR` columns, which are 2 of the 3 types where this would be an issue (the third being `DECIMAL`, which is in progress in https://github.com/dask-contrib/dask-sql/pull/1073).