### PR TITLE
Ignore case sensitivity of columns for case_sensitive=False

### DIFF
--- a/dask_planner/src/sql/table.rs
+++ b/dask_planner/src/sql/table.rs
@@ -127,13 +127,14 @@ impl DaskTable {
         schema_name: &str,
         table_name: &str,
         row_count: f64,
+        columns: Option<Vec<(String, DaskTypeMap)>>,
         filepath: Option<String>,
     ) -> Self {
         Self {
             schema_name: Some(schema_name.to_owned()),
             table_name: table_name.to_owned(),
             statistics: DaskStatistics::new(row_count),
-            columns: Vec::new(),
+            columns: columns.unwrap_or_default(),
             filepath,
         }
     }

--- a/dask_sql/physical/rel/logical/table_scan.py
+++ b/dask_sql/physical/rel/logical/table_scan.py
@@ -62,9 +62,10 @@ class DaskTableScanPlugin(BaseRelPlugin):
         df = dc.df
         cc = dc.column_container
         if table_scan.containsProjections():
-            field_specifications = (
-                table_scan.getTableScanProjects()
+            field_specifications = list(
+                map(cc.get_backend_by_frontend_name, table_scan.getTableScanProjects())
             )  # Assumes these are column projections only and field names match table column names
+
             df = df[field_specifications]
         else:
             field_specifications = [

--- a/tests/integration/test_compatibility.py
+++ b/tests/integration/test_compatibility.py
@@ -1047,7 +1047,7 @@ def test_integration_1():
         pytest.param(
             True,
             marks=pytest.mark.xfail(
-                "https://github.com/dask-contrib/dask-sql/issues/1092"
+                reason="https://github.com/dask-contrib/dask-sql/issues/1092"
             ),
         ),
     ],


### PR DESCRIPTION
Fixes #1088.
This pr adds a lowercase version of column names to the DaskTable and column container mapping if `sql.identifier.case_sensitive=False` allowing all columns to be treated as lowercase.
For a table with column name `Ab` using `ab/AB/Ab/aB` will all work with the config option.

This PR doesn't enable true case sensitivity when set to `True` since datafusion implicitly ends up converting all unquoted identifiers to lowercase during logical plan creation (Ref: https://github.com/apache/arrow-datafusion/issues/5626)
