### PR TITLE
Install upstream dask with dependencies in import testing

### DIFF
--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -182,8 +182,8 @@ jobs:
       - name: Install upstream dev Dask
         if: env.which_upstream == 'Dask'
         run: |
-          python -m pip install --no-deps git+https://github.com/dask/dask
-          python -m pip install --no-deps git+https://github.com/dask/distributed
+          python -m pip install git+https://github.com/dask/dask
+          python -m pip install git+https://github.com/dask/distributed
       - name: Try to import dask-sql
         run: |
           python -c "import dask_sql; print('ok')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,8 +163,8 @@ jobs:
       - name: Optionally install upstream dev Dask
         if: needs.detect-ci-trigger.outputs.triggered == 'true'
         run: |
-          python -m pip install --no-deps git+https://github.com/dask/dask
-          python -m pip install --no-deps git+https://github.com/dask/distributed
+          python -m pip install git+https://github.com/dask/dask
+          python -m pip install git+https://github.com/dask/distributed
       - name: Try to import dask-sql
         run: |
           python -c "import dask_sql; print('ok')"


### PR DESCRIPTION
Removes the `--no-deps` flag from the upstream Dask/Distributed installs in our bare import testing, since it's possible for Dask to introduce new dependencies/pinnings that aren't covered in the initial pip install.

Closes https://github.com/dask-contrib/dask-sql/issues/1083