### PR TITLE
Remove deprecated `file_format` argument, `register_dask_table` function

### DIFF
--- a/dask_sql/context.py
+++ b/dask_sql/context.py
@@ -1,7 +1,6 @@
 import asyncio
 import inspect
 import logging
-import warnings
 from collections import Counter
 from typing import Any, Callable, Dict, List, Tuple, Union
 
@@ -233,9 +232,6 @@ class Context:
         logger.debug(
             f"Creating table: '{table_name}' of format type '{format}' in schema '{schema_name}'"
         )
-        if "file_format" in kwargs:  # pragma: no cover
-            warnings.warn("file_format is renamed to format", DeprecationWarning)
-            format = kwargs.pop("file_format")
 
         schema_name = schema_name or self.schema_name
 
@@ -265,16 +261,6 @@ class Context:
 
         self.schema[schema_name].tables[table_name.lower()] = dc
         self.schema[schema_name].statistics[table_name.lower()] = statistics
-
-    def register_dask_table(self, df: dd.DataFrame, name: str, *args, **kwargs):
-        """
-        Outdated version of :func:`create_table()`.
-        """
-        warnings.warn(
-            "register_dask_table is deprecated, use the more general create_table instead.",
-            DeprecationWarning,
-        )
-        return self.create_table(name, df, *args, **kwargs)
 
     def drop_table(self, table_name: str, schema_name: str = None):
         """

--- a/tests/integration/test_rex.py
+++ b/tests/integration/test_rex.py
@@ -66,7 +66,7 @@ def test_intervals(c):
     date1 = datetime(2021, 10, 3, 15, 53, 42, 47)
     date2 = datetime(2021, 2, 28, 15, 53, 42, 47)
     dates = dd.from_pandas(pd.DataFrame({"d": [date1, date2]}), npartitions=1)
-    c.register_dask_table(dates, "dates")
+    c.create_table("dates", dates)
     df = c.sql(
         """SELECT d + INTERVAL '5 days' AS "Plus_5_days" FROM dates
         """
@@ -700,7 +700,7 @@ def test_date_functions(c):
     date = datetime(2021, 10, 3, 15, 53, 42, 47)
 
     df = dd.from_pandas(pd.DataFrame({"d": [date]}), npartitions=1)
-    c.register_dask_table(df, "df")
+    c.create_table("df", df)
 
     df = c.sql(
         """
@@ -811,7 +811,7 @@ def test_timestampdiff(c):
         pd.DataFrame({"ts_literal1": [ts_literal1], "ts_literal2": [ts_literal2]}),
         npartitions=1,
     )
-    c.register_dask_table(df, "df")
+    c.create_table("df", df)
 
     query = """
         SELECT timestampdiff(NANOSECOND, ts_literal1, ts_literal2) as res0,

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import warnings
 
 import dask.dataframe as dd
 import pandas as pd
@@ -37,25 +36,6 @@ def test_add_remove_tables(gpu):
 
     c.create_table("table", [data_frame], gpu=gpu)
     assert "table" in c.schema[c.schema_name].tables
-
-
-@pytest.mark.parametrize("gpu", [False, pytest.param(True, marks=pytest.mark.gpu)])
-def test_deprecation_warning(gpu):
-    c = Context()
-    data_frame = dd.from_pandas(pd.DataFrame(), npartitions=1)
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-
-        c.register_dask_table(data_frame, "table", gpu=gpu)
-
-        assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
-
-    assert "table" in c.schema[c.schema_name].tables
-
-    c.drop_table("table")
-    assert "table" not in c.schema[c.schema_name].tables
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Looks like these were deprecated quite some time ago, think we should be safe at this point to remove these warnings and raise.