### PR TITLE
Remove `dask/gpu` team from gpuCI bump PR reviewers

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -83,7 +83,6 @@ jobs:
           draft: true
           commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_CUDF_VER }}`"
           title: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_CUDF_VER }}`"
-          reviewers: "charlesbluca"
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: "upgrade-gpuci-rapids"
           body: |

--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -83,7 +83,7 @@ jobs:
           draft: true
           commit-message: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_CUDF_VER }}`"
           title: "Update gpuCI `RAPIDS_VER` to `${{ env.NEW_CUDF_VER }}`"
-          team-reviewers: "dask/gpu"
+          reviewers: "charlesbluca"
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           branch: "upgrade-gpuci-rapids"
           body: |


### PR DESCRIPTION
Resolves failures that started cropping up in the gpuCI updating workflow due to the fact that the `dask/gpu` team isn't a collaborator on this repo - ended removing the reviewers from the PR altogether since it ends up getting decided by the codeowners file anyways.