### PR TITLE
Avoid using timezone-aware datetime data in GPU tables, unpin `uvicorn` in 3.8 GPU environments

### DIFF
--- a/continuous_integration/gpuci/environment-3.8.yaml
+++ b/continuous_integration/gpuci/environment-3.8.yaml
@@ -37,7 +37,7 @@ dependencies:
 - sqlalchemy<2
 - tpot
 - tzlocal=2.1
-- uvicorn=0.13.4
+- uvicorn>=0.13.4
 # GPU-specific requirements
 - cudatoolkit=11.5
 - cudf=23.06

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -163,6 +163,11 @@ def gpu_string_table(string_table):
 
 @pytest.fixture()
 def gpu_datetime_table(datetime_table):
+    # cudf doesn't have support for timezoned datetime data
+    datetime_table["timezone"] = datetime_table["timezone"].astype("datetime64[ns]")
+    datetime_table["utc_timezone"] = datetime_table["utc_timezone"].astype(
+        "datetime64[ns]"
+    )
     return cudf.from_pandas(datetime_table) if cudf else None
 
 


### PR DESCRIPTION
It looks like https://github.com/rapidsai/cudf/pull/13086 has made it so cuDF will now error when attempting to construct a dataframe containing timezone-aware datetime data.

This PR attempts to resolve the resulting gpuCI failures by casting any affected timezone-aware datetime columns to non-aware datetime - since cuDF was seemingly ignoring this information silently before now, don't think this should have an impact on relevant GPU tests