### PR TITLE
Remove some pandas compat code

### DIFF
--- a/dask_sql/_compat.py
+++ b/dask_sql/_compat.py
@@ -7,8 +7,6 @@ _pandas_version = parseVersion(pd.__version__)
 _prompt_toolkit_version = parseVersion(prompt_toolkit.__version__)
 _dask_version = parseVersion(dask.__version__)
 
-FLOAT_NAN_IMPLEMENTED = _pandas_version >= parseVersion("1.2.0")
-INT_NAN_IMPLEMENTED = _pandas_version >= parseVersion("1.0.0")
 INDEXER_WINDOW_STEP_IMPLEMENTED = _pandas_version >= parseVersion("1.5.0")
 
 # TODO: remove if prompt-toolkit min version gets bumped

--- a/dask_sql/mappings.py
+++ b/dask_sql/mappings.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 
 from dask_planner.rust import DaskTypeMap, SqlTypeName
-from dask_sql._compat import FLOAT_NAN_IMPLEMENTED
 
 try:
     import cudf
@@ -21,8 +20,10 @@ logger = logging.getLogger(__name__)
 # Default mapping between python types and SQL types
 _PYTHON_TO_SQL = {
     np.float64: SqlTypeName.DOUBLE,
+    pd.Float64Dtype(): SqlTypeName.DOUBLE,
     float: SqlTypeName.FLOAT,
     np.float32: SqlTypeName.FLOAT,
+    pd.Float32Dtype(): SqlTypeName.FLOAT,
     np.int64: SqlTypeName.BIGINT,
     pd.Int64Dtype(): SqlTypeName.BIGINT,
     int: SqlTypeName.INTEGER,
@@ -47,11 +48,6 @@ _PYTHON_TO_SQL = {
     pd.StringDtype(): SqlTypeName.VARCHAR,
     np.datetime64: SqlTypeName.TIMESTAMP,
 }
-
-if FLOAT_NAN_IMPLEMENTED:  # pragma: no cover
-    _PYTHON_TO_SQL.update(
-        {pd.Float32Dtype(): SqlTypeName.FLOAT, pd.Float64Dtype(): SqlTypeName.DOUBLE}
-    )
 
 # Default mapping between SQL types and python types
 # for values

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -84,13 +84,7 @@ def user_table_inf():
 
 @pytest.fixture()
 def user_table_nan():
-    # Lazy import, otherwise pytest segfaults
-    from dask_sql._compat import INT_NAN_IMPLEMENTED
-
-    if INT_NAN_IMPLEMENTED:
-        return pd.DataFrame({"c": [3, pd.NA, 1]}).astype("UInt8")
-    else:
-        return pd.DataFrame({"c": [3, float("nan"), 1]}).astype("float")
+    return pd.DataFrame({"c": [3, pd.NA, 1]}).astype("UInt8")
 
 
 @pytest.fixture()

--- a/tests/integration/test_filter.py
+++ b/tests/integration/test_filter.py
@@ -5,7 +5,6 @@ import pytest
 from dask.utils_test import hlg_layer
 from packaging.version import parse as parseVersion
 
-from dask_sql._compat import INT_NAN_IMPLEMENTED
 from tests.utils import assert_eq
 
 DASK_GT_2022_4_2 = parseVersion(dask.__version__) >= parseVersion("2022.4.2")
@@ -52,11 +51,8 @@ def test_filter_complicated(c, df):
 
 def test_filter_with_nan(c):
     return_df = c.sql("SELECT * FROM user_table_nan WHERE c = 3")
+    expected_df = pd.DataFrame({"c": [3]}, dtype="Int8")
 
-    if INT_NAN_IMPLEMENTED:
-        expected_df = pd.DataFrame({"c": [3]}, dtype="Int8")
-    else:
-        expected_df = pd.DataFrame({"c": [3]}, dtype="float")
     assert_eq(
         return_df,
         expected_df,


### PR DESCRIPTION
With our pandas min version bumped to 1.4, we should be safe to remove some compatibility code meant for `pandas>=1.0,<1.2`.