### PR TITLE
Refactor assignment logic to aliasing same column multiple times on GPU

### DIFF
--- a/dask_sql/datacontainer.py
+++ b/dask_sql/datacontainer.py
@@ -220,15 +220,27 @@ class DataContainer:
         a dataframe which has the the columns specified in the
         stored ColumnContainer.
         """
-        df = self.df[
-            [
-                self.column_container._frontend_backend_mapping[out_col]
-                for out_col in self.column_container.columns
-            ]
-        ]
-        df.columns = self.column_container.columns
+        # df = self.df[
+        #     [
+        #         self.column_container._frontend_backend_mapping[out_col]
+        #         for out_col in self.column_container.columns
+        #     ]
+        # ]
+        # df.columns = self.column_container.columns
 
-        return df
+        return self.df.assign(
+            **dict(
+                zip(
+                    self.column_container.columns,
+                    [
+                        self.df[
+                            self.column_container._frontend_backend_mapping[out_col]
+                        ]
+                        for out_col in self.column_container.columns
+                    ],
+                )
+            )
+        )[self.column_container.columns]
 
 
 class UDF:


### PR DESCRIPTION
Refactors our `DataContainer.assign` logic to avoid creating a dataframe with multiple columns on GPU, which silently fails and causes errors later down the road.

Closes #1133 