### PR TITLE
Fix upstream failures and workflow

### DIFF
--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -13,7 +13,6 @@ on:
         options:
           - Dask
           - DataFusion
-  pull_request:
 
 # Required shell entrypoint to have properly activated conda environments
 defaults:

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -13,6 +13,7 @@ on:
         options:
           - Dask
           - DataFusion
+  pull_request:
 
 # Required shell entrypoint to have properly activated conda environments
 defaults:
@@ -138,12 +139,11 @@ jobs:
 
   report-failures:
     name: Open issue for upstream dev failures
-    needs: [test-dev, cluster-dev, import-dev]
+    needs: [test-dev, import-dev]
     if: |
       always()
       && (
         needs.test-dev.result == 'failure'
-        || needs.cluster-dev.result == 'failure'
         || needs.import-dev.result == 'failure'
       )
       && github.repository == 'dask-contrib/dask-sql'

--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -13,6 +13,9 @@ dependencies:
 - maturin>=0.12.8
 - mlflow
 - mock
+# tpot imports fail with numpy >=1.24.0
+# https://github.com/EpistasisLab/tpot/issues/1281
+- numpy<1.24.0
 - pandas>=1.4.0
 - pre-commit
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -12,6 +12,9 @@ dependencies:
 - maturin=0.12.8
 - mlflow
 - mock
+# tpot imports fail with numpy >=1.24.0
+# https://github.com/EpistasisLab/tpot/issues/1281
+- numpy<1.24.0
 - pandas=1.4.0
 - pre-commit
 - prompt_toolkit=3.0.8

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -13,6 +13,9 @@ dependencies:
 - maturin>=0.12.8
 - mlflow
 - mock
+# tpot imports fail with numpy >=1.24.0
+# https://github.com/EpistasisLab/tpot/issues/1281
+- numpy<1.24.0
 - pandas>=1.4.0
 - pre-commit
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -41,7 +41,9 @@ dependencies:
 - cuml=23.06
 - dask-cudf=23.06
 - dask-cuda=23.06
-- numpy>=1.20.1
+# tpot imports fail with numpy >=1.24.0
+# https://github.com/EpistasisLab/tpot/issues/1281
+- numpy>=1.20.1, <1.24.0
 - ucx-proc=*=gpu
 - ucx-py=0.32
 - xgboost=*rapidsai23.06

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -16,7 +16,6 @@ dependencies:
 - maturin>=0.12.8
 - mlflow
 - mock
-- numpy<1.24.1
 - pandas>=1.4.0
 - pre-commit
 - prompt_toolkit>=3.0.8

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -16,6 +16,7 @@ dependencies:
 - maturin>=0.12.8
 - mlflow
 - mock
+- numpy<1.24.1
 - pandas>=1.4.0
 - pre-commit
 - prompt_toolkit>=3.0.8
@@ -41,7 +42,9 @@ dependencies:
 - cuml=23.06
 - dask-cudf=23.06
 - dask-cuda=23.06
-- numpy>=1.20.1
+# tpot imports fail with numpy >=1.24.0
+# https://github.com/EpistasisLab/tpot/issues/1281
+- numpy>=1.20.1, <1.24.0
 - ucx-proc=*=gpu
 - ucx-py=0.32
 - xgboost=*rapidsai23.06


### PR DESCRIPTION
Temporarily pin to numpy<1.24.0 due to tpot erroring on import because of an updated numpy version (1.24.2) being picked up by CI.
There are a few issues on tpot: 
https://github.com/EpistasisLab/tpot/issues/1281
https://github.com/EpistasisLab/tpot/pull/1280

Also noticed that the upstream workflow tests are broken due to dangling references to the cluster-dev tests. 