### PR TITLE
Extend attempt_predicate_pushdown to accept additional filters as arguments

### DIFF
--- a/dask_sql/physical/utils/filter.py
+++ b/dask_sql/physical/utils/filter.py
@@ -1,6 +1,7 @@
 import itertools
 import logging
 import operator
+from typing import List
 
 import dask.dataframe as dd
 import numpy as np
@@ -14,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 def attempt_predicate_pushdown(
     ddf: dd.DataFrame,
-    conjunctive_filters: list[tuple] = None,
-    disjunctive_filters: list[tuple] = None,
+    conjunctive_filters: List[tuple] = None,
+    disjunctive_filters: List[tuple] = None,
 ) -> dd.DataFrame:
     """Use graph information to update IO-level filters
 


### PR DESCRIPTION
To build on top of some of the work in #1130, this pr adds the `conjunctive_filters` and `disjunctive_filters` arguments to `attempt_predicate_pushdown`.
This allow applying the provided arguments in addition to everything that can be inferred from the HLG, allowing us to expand the predicate pushdown coverage to cases that cannot be inferred from the HLG.

Ideally in the future we'd expand the table_scan filter logic to generate a dnf instead of a hlg to better express more kinds of complex predicates.