### PR TITLE
[do-not-merge] Pass additional dnf filters in table_scan 

### DIFF
--- a/dask_sql/physical/rel/logical/filter.py
+++ b/dask_sql/physical/rel/logical/filter.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, List, Union
 
 import dask.config as dask_config
 import dask.dataframe as dd
@@ -17,7 +17,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def filter_or_scalar(df: dd.DataFrame, filter_condition: Union[np.bool_, dd.Series]):
+def filter_or_scalar(
+    df: dd.DataFrame,
+    filter_condition: Union[np.bool_, dd.Series],
+    conjunctive_filters: List[tuple] = None,
+):
     """
     Some (complex) SQL queries can lead to a strange condition which is always true or false.
     We do not need to filter in this case.
@@ -35,7 +39,7 @@ def filter_or_scalar(df: dd.DataFrame, filter_condition: Union[np.bool_, dd.Seri
     filter_condition = filter_condition.fillna(False)
     out = df[filter_condition]
     if dask_config.get("sql.predicate_pushdown"):
-        return attempt_predicate_pushdown(out)
+        return attempt_predicate_pushdown(out, conjunctive_filters)
     else:
         return out
 

--- a/dask_sql/physical/rel/logical/table_scan.py
+++ b/dask_sql/physical/rel/logical/table_scan.py
@@ -7,7 +7,6 @@ from dask_sql.datacontainer import DataContainer
 from dask_sql.physical.rel.base import BaseRelPlugin
 from dask_sql.physical.rel.logical.filter import filter_or_scalar
 from dask_sql.physical.rex import RexConverter
-from dask_sql.utils import is_cudf_type
 
 if TYPE_CHECKING:
     import dask_sql
@@ -93,7 +92,7 @@ class DaskTableScanPlugin(BaseRelPlugin):
             df = filter_or_scalar(
                 df, df_condition, conjunctive_filters=conjunctive_dnf_filters
             )
-            if is_cudf_type(df) and all_filters:
+            if conjunctive_dnf_filters:
                 df_condition = reduce(
                     operator.and_,
                     [

--- a/dask_sql/physical/rel/logical/table_scan.py
+++ b/dask_sql/physical/rel/logical/table_scan.py
@@ -101,16 +101,16 @@ class DaskTableScanPlugin(BaseRelPlugin):
                     df, conjunctive_filters=conjunctive_dnf_filters
                 )
 
-            df_condition = reduce(
-                operator.and_,
-                [
-                    RexConverter.convert(
-                        rel, rex, DataContainer(df, cc), context=context
-                    )
-                    for rex in all_filters
-                ],
-            )
-            df = filter_or_scalar(df, df_condition)
+            # df_condition = reduce(
+            #     operator.and_,
+            #     [
+            #         RexConverter.convert(
+            #             rel, rex, DataContainer(df, cc), context=context
+            #         )
+            #         for rex in all_filters
+            #     ],
+            # )
+            # df = filter_or_scalar(df, df_condition)
         elif all_filters:
             df_condition = reduce(
                 operator.and_,

--- a/dask_sql/physical/rel/logical/table_scan.py
+++ b/dask_sql/physical/rel/logical/table_scan.py
@@ -3,10 +3,13 @@ import operator
 from functools import reduce
 from typing import TYPE_CHECKING
 
+from dask.utils_test import hlg_layer
+
 from dask_sql.datacontainer import DataContainer
 from dask_sql.physical.rel.base import BaseRelPlugin
 from dask_sql.physical.rel.logical.filter import filter_or_scalar
 from dask_sql.physical.rex import RexConverter
+from dask_sql.physical.utils.filter import attempt_predicate_pushdown
 
 if TYPE_CHECKING:
     import dask_sql
@@ -81,25 +84,45 @@ class DaskTableScanPlugin(BaseRelPlugin):
         conjunctive_dnf_filters = table_scan.getDNFFilters().filtered_exprs
         non_dnf_filters = table_scan.getDNFFilters().io_unfilterable_exprs
         # All filters here are applied in conjunction (&)
-        if non_dnf_filters or conjunctive_dnf_filters:
-            df_condition = reduce(
-                operator.and_,
-                [
-                    RexConverter.convert(rel, rex, dc, context=context)
-                    for rex in non_dnf_filters
-                ],
-            )
-            df = filter_or_scalar(
-                df, df_condition, conjunctive_filters=conjunctive_dnf_filters
-            )
-            if conjunctive_dnf_filters:
+        if conjunctive_dnf_filters:
+            if non_dnf_filters:
                 df_condition = reduce(
                     operator.and_,
                     [
                         RexConverter.convert(rel, rex, dc, context=context)
-                        for rex in all_filters
+                        for rex in non_dnf_filters
                     ],
                 )
-                df = filter_or_scalar(df, df_condition)
+                df = filter_or_scalar(
+                    df, df_condition, conjunctive_filters=conjunctive_dnf_filters
+                )
+            else:
+                df = attempt_predicate_pushdown(
+                    df, conjunctive_filters=conjunctive_dnf_filters
+                )
+
+            df_condition = reduce(
+                operator.and_,
+                [
+                    RexConverter.convert(
+                        rel, rex, DataContainer(df, cc), context=context
+                    )
+                    for rex in all_filters
+                ],
+            )
+            df = filter_or_scalar(df, df_condition)
+        elif all_filters:
+            df_condition = reduce(
+                operator.and_,
+                [
+                    RexConverter.convert(rel, rex, dc, context=context)
+                    for rex in all_filters
+                ],
+            )
+            df = filter_or_scalar(df, df_condition)
+        try:
+            logger.debug(hlg_layer(df.dask, "read-parquet").creation_info)
+        except KeyError:
+            pass
 
         return DataContainer(df, cc)


### PR DESCRIPTION
Extends the work in #1130 and #1138 to pass additional dnf filters from the rust side to python.