### PR TITLE
Add C compiler to conda environments / recipes

### DIFF
--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
+- c-compiler
 - dask>=2022.3.0
 # FIXME: handling is needed for httpx-based fastapi>=0.87.0
 - fastapi>=0.69.0,<0.87.0

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
+- c-compiler
 - dask=2022.3.0
 - fastapi=0.69.0
 - fugue=0.7.3

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
+- c-compiler
 - dask>=2022.3.0
 # FIXME: handling is needed for httpx-based fastapi>=0.87.0
 - fastapi>=0.69.0,<0.87.0

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -6,6 +6,7 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
+- c-compiler
 - dask>=2022.3.0
 # FIXME: handling is needed for httpx-based fastapi>=0.87.0
 - fastapi>=0.69.0,<0.87.0

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -6,6 +6,7 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
+- c-compiler
 - dask>=2022.3.0
 # FIXME: handling is needed for httpx-based fastapi>=0.87.0
 - fastapi>=0.69.0,<0.87.0

--- a/continuous_integration/recipe/conda_build_config.yaml
+++ b/continuous_integration/recipe/conda_build_config.yaml
@@ -2,3 +2,7 @@ python:
     - 3.8
     - 3.9
     - 3.10
+c_compiler_version:
+    - 11
+rust_compiler_version:
+    - '>=1.65'

--- a/continuous_integration/recipe/conda_build_config.yaml
+++ b/continuous_integration/recipe/conda_build_config.yaml
@@ -5,4 +5,4 @@ python:
 c_compiler_version:
     - 11
 rust_compiler_version:
-    - '>=1.65'
+    - 1.69

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -22,8 +22,8 @@ build:
 
 requirements:
   build:
-    - {{ compiler('c') }} =11
-    - {{ compiler('rust') }} >=1.65.0
+    - {{ compiler('c') }}
+    - {{ compiler('rust') }}
     - setuptools-rust >=1.5.2
   host:
     - pip

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -22,6 +22,7 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }} =11
     - {{ compiler('rust') }} >=1.65.0
     - setuptools-rust >=1.5.2
   host:


### PR DESCRIPTION
Adds `c-compiler` to our conda environment files and `compiler('c')` to our conda nightly recipe, so that the package can be successfully tested/built on systems that don't have `cc` pre-installed; haven't placed much thought into what version we should pin to (if any).
