### PR TITLE
Constrain `anyio<3.7` to unblock conda builds

### DIFF
--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -3,6 +3,9 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
+# TODO: remove once anyio fixes its runtime dependencies on conda-forge
+# https://github.com/conda-forge/anyio-feedstock/issues/47
+- anyio<3.7
 - c-compiler
 - dask>=2022.3.0
 # FIXME: handling is needed for httpx-based fastapi>=0.87.0

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -3,6 +3,9 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
+# TODO: remove once anyio fixes its runtime dependencies on conda-forge
+# https://github.com/conda-forge/anyio-feedstock/issues/47
+- anyio<3.7
 - c-compiler
 - dask=2022.3.0
 - fastapi=0.69.0

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -3,6 +3,9 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
+# TODO: remove once anyio fixes its runtime dependencies on conda-forge
+# https://github.com/conda-forge/anyio-feedstock/issues/47
+- anyio<3.7
 - c-compiler
 - dask>=2022.3.0
 # FIXME: handling is needed for httpx-based fastapi>=0.87.0

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -6,6 +6,9 @@ channels:
 - nvidia
 - nodefaults
 dependencies:
+# TODO: remove once anyio fixes its runtime dependencies on conda-forge
+# https://github.com/conda-forge/anyio-feedstock/issues/47
+- anyio<3.7
 - c-compiler
 - dask>=2022.3.0
 # FIXME: handling is needed for httpx-based fastapi>=0.87.0

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -6,6 +6,9 @@ channels:
 - nvidia
 - nodefaults
 dependencies:
+# TODO: remove once anyio fixes its runtime dependencies on conda-forge
+# https://github.com/conda-forge/anyio-feedstock/issues/47
+- anyio<3.7
 - c-compiler
 - dask>=2022.3.0
 # FIXME: handling is needed for httpx-based fastapi>=0.87.0

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -36,6 +36,9 @@ requirements:
     - pandas >=1.4.0
     # FIXME: handling is needed for httpx-based fastapi>=0.87.0
     - fastapi >=0.69.0,<0.87.0
+    # TODO: remove once anyio fixes its runtime dependencies on conda-forge
+    # https://github.com/conda-forge/anyio-feedstock/issues/47
+    - anyio<3.7
     - uvicorn >=0.13.4
     - tzlocal >=2.1
     - prompt-toolkit >=3.0.8

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,6 +12,9 @@ dependencies:
   - fugue>=0.7.3
   # FIXME: handling is needed for httpx-based fastapi>=0.87.0
   - fastapi>=0.69.0,<0.87.0
+  # TODO: remove once anyio fixes its runtime dependencies on conda-forge
+  # https://github.com/conda-forge/anyio-feedstock/issues/47
+  - anyio<3.7
   - uvicorn>=0.13.4
   - tzlocal>=2.1
   - prompt_toolkit>=3.0.8


### PR DESCRIPTION
It looks like there are some problems with the runtime dependencies of the latest `anyio` release on conda-forge that are causing us issues in our conda builds:

https://github.com/dask-contrib/dask-sql/actions/runs/5124690983/jobs/9216865588

Currently exploring if we can fix this in a new build in https://github.com/conda-forge/anyio-feedstock/pull/48, but this should unblock us in the meantime.