### PR TITLE
Remove `numpy` constraint, update `tpot` min version in CI environments

### DIFF
--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -14,9 +14,6 @@ dependencies:
 - maturin>=0.12.8
 - mlflow
 - mock
-# tpot imports fail with numpy >=1.24.0
-# https://github.com/EpistasisLab/tpot/issues/1281
-- numpy<1.24.0
 - pandas>=1.4.0
 - pre-commit
 - prompt_toolkit>=3.0.8
@@ -33,7 +30,7 @@ dependencies:
 - setuptools-rust>=1.5.2
 - sphinx
 - sqlalchemy<2
-- tpot
+- tpot>=0.12
 - tzlocal>=2.1
 - uvicorn>=0.13.4
 - libprotobuf=3

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -13,9 +13,6 @@ dependencies:
 - maturin=0.12.8
 - mlflow
 - mock
-# tpot imports fail with numpy >=1.24.0
-# https://github.com/EpistasisLab/tpot/issues/1281
-- numpy<1.24.0
 - pandas=1.4.0
 - pre-commit
 - prompt_toolkit=3.0.8
@@ -32,7 +29,7 @@ dependencies:
 - setuptools-rust=1.5.2
 - sphinx
 - sqlalchemy<2
-- tpot
+- tpot>=0.12
 - tzlocal=2.1
 - uvicorn=0.13.4
 - libprotobuf=3

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -14,9 +14,6 @@ dependencies:
 - maturin>=0.12.8
 - mlflow
 - mock
-# tpot imports fail with numpy >=1.24.0
-# https://github.com/EpistasisLab/tpot/issues/1281
-- numpy<1.24.0
 - pandas>=1.4.0
 - pre-commit
 - prompt_toolkit>=3.0.8
@@ -33,7 +30,7 @@ dependencies:
 - setuptools-rust>=1.5.2
 - sphinx
 - sqlalchemy<2
-- tpot
+- tpot>=0.12
 - tzlocal>=2.1
 - uvicorn>=0.13.4
 - libprotobuf=3

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -33,7 +33,7 @@ dependencies:
 - setuptools-rust>=1.5.2
 - sphinx
 - sqlalchemy<2
-- tpot
+- tpot>=0.12
 - tzlocal>=2.1
 - uvicorn>=0.13.4
 # GPU-specific requirements
@@ -42,9 +42,7 @@ dependencies:
 - cuml=23.06
 - dask-cudf=23.06
 - dask-cuda=23.06
-# tpot imports fail with numpy >=1.24.0
-# https://github.com/EpistasisLab/tpot/issues/1281
-- numpy>=1.20.1, <1.24.0
+- numpy>=1.20.1
 - ucx-proc=*=gpu
 - ucx-py=0.32
 - xgboost=*rapidsai23.06

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -33,7 +33,7 @@ dependencies:
 - setuptools-rust>=1.5.2
 - sphinx
 - sqlalchemy<2
-- tpot
+- tpot>=0.12
 - tzlocal>=2.1
 - uvicorn>=0.13.4
 # GPU-specific requirements
@@ -42,9 +42,7 @@ dependencies:
 - cuml=23.06
 - dask-cudf=23.06
 - dask-cuda=23.06
-# tpot imports fail with numpy >=1.24.0
-# https://github.com/EpistasisLab/tpot/issues/1281
-- numpy>=1.20.1, <1.24.0
+- numpy>=1.20.1
 - ucx-proc=*=gpu
 - ucx-py=0.32
 - xgboost=*rapidsai23.06


### PR DESCRIPTION
It looks like the fix to https://github.com/EpistasisLab/tpot/issues/1281 is now out in `tpot=0.12`, so we should be good to remove our constraint on `numpy` and bump to using this new `tpot` release in CI; relevant now because this constraint seems to conflict with the latest cuDF nightlies, so we need to remove it in order to continue testing against latest RAPIDS.

cc @sarahyurick @ayushdg 