### PR TITLE
Ignore all cibuildwheel dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,5 @@ updates:
       # Check for updates to GitHub Actions every weekday
       interval: "weekly"
     ignore:
-      # ignore cibw patch updates
+      # prefer updating cibuildwheel manually as needed
       - dependency-name: "pypa/cibuildwheel"
-        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Since things are working as is with our cibuildwheel setup, think we should be good to disable automatic updates altogether and update it manually as needed.

cc @ayushdg 