### PR TITLE
Add upper pin to pandas<2.0.0

### DIFF
--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -15,7 +15,7 @@ dependencies:
 - mlflow
 - mock
 - numpy>=1.21.6
-- pandas>=1.4.0
+- pandas>=1.4.0,<2.0.0
 - pre-commit
 - prompt_toolkit>=3.0.8
 - psycopg2

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -15,7 +15,7 @@ dependencies:
 - mlflow
 - mock
 - numpy>=1.21.6
-- pandas>=1.4.0
+- pandas>=1.4.0,<2.0.0
 - pre-commit
 - prompt_toolkit>=3.0.8
 - psycopg2

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -18,7 +18,7 @@ dependencies:
 - mlflow
 - mock
 - numpy>=1.21.6
-- pandas>=1.4.0
+- pandas>=1.4.0,<2.0.0
 - pre-commit
 - prompt_toolkit>=3.0.8
 - psycopg2

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -18,7 +18,7 @@ dependencies:
 - mlflow
 - mock
 - numpy>=1.21.6
-- pandas>=1.4.0
+- pandas>=1.4.0,<2.0.0
 - pre-commit
 - prompt_toolkit>=3.0.8
 - psycopg2

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
   run:
     - python
     - dask >=2022.3.0,<=2023.5.1
-    - pandas >=1.4.0
+    - pandas >=1.4.0,<2.0.0
     # FIXME: handling is needed for httpx-based fastapi>=0.87.0
     - fastapi >=0.69.0,<0.87.0
     - uvicorn >=0.13.4

--- a/docker/conda.txt
+++ b/docker/conda.txt
@@ -1,6 +1,6 @@
 python>=3.8
 dask>=2022.3.0,<=2023.5.1
-pandas>=1.4.0
+pandas>=1.4.0,<2.0.0
 jpype1>=1.0.2
 openjdk>=8
 maven>=3.6.0

--- a/docker/main.dockerfile
+++ b/docker/main.dockerfile
@@ -17,7 +17,7 @@ RUN mamba install -y \
     "setuptools-rust>=1.5.2" \
     # core dependencies
     "dask>=2022.3.0,<=2023.5.1" \
-    "pandas>=1.4.0" \
+    "pandas>=1.4.0,<2.0.0" \
     # FIXME: handling is needed for httpx-based fastapi>=0.87.0
     "fastapi>=0.69.0,<0.87.0" \
     "uvicorn>=0.13.4" \

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - sphinx-tabs
   - dask-sphinx-theme>=2.0.3
   - dask>=2022.3.0,<=2023.5.1
-  - pandas>=1.4.0
+  - pandas>=1.4.0,<2.0.0
   - fugue>=0.7.3
   # FIXME: handling is needed for httpx-based fastapi>=0.87.0
   - fastapi>=0.69.0,<0.87.0

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -2,7 +2,7 @@ sphinx>=4.0.0
 sphinx-tabs
 dask-sphinx-theme>=3.0.0
 dask>=2022.3.0,<=2023.5.1
-pandas>=1.4.0
+pandas>=1.4.0,<2.0.0
 fugue>=0.7.3
 # FIXME: handling is needed for httpx-based fastapi>=0.87.0
 fastapi>=0.69.0,<0.87.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     install_requires=[
         "dask[dataframe]>=2022.3.0,<=2023.5.1",
         "distributed>=2022.3.0,<=2023.5.1",
-        "pandas>=1.4.0",
+        "pandas>=1.4.0,<2.0.0",
         # FIXME: handling is needed for httpx-based fastapi>=0.87.0
         "fastapi>=0.69.0,<0.87.0",
         "uvicorn>=0.13.4",


### PR DESCRIPTION
While #1184 explores unblocking initial pandas2 failures. Temporarily pining to <2.0.0 to unblock CI