### PR TITLE
Remove `glibc` constraint from aarch64 packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,18 +82,6 @@ jobs:
           use-mamba: true
           python-version: "3.8"
           channel-priority: strict
-      # FIXME: aarch64 builds require glibc>=2.32 to prevent TLS allocation error when importing;
-      # is there any way we could modify the TLS model of its shared object to avoid this?
-      # https://bugzilla.redhat.com/show_bug.cgi?id=1722181
-      # xref: https://github.com/dask-contrib/dask-sql/issues/1169
-      - name: Update platform tag for aarch64 wheel
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          mamba install wheel
-
-          wheel tags --platform-tag=manylinux_2_32_aarch64 \
-                     --remove \
-                     dist/*_aarch64.whl
       - name: Check dist files
         run: |
           mamba install twine

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -43,12 +43,6 @@ requirements:
     - prompt-toolkit >=3.0.8
     - pygments >=2.7.1
     - tabulate
-  run_constrained:
-    # FIXME: aarch64 builds require glibc>=2.32 to prevent TLS allocation error when importing;
-    # is there any way we could modify the TLS model of its shared object to avoid this?
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1722181
-    # xref: https://github.com/dask-contrib/dask-sql/issues/1169
-    - __glibc >=2.32  # [aarch64]
 
 test:
   imports:

--- a/dask_sql/__init__.py
+++ b/dask_sql/__init__.py
@@ -1,3 +1,7 @@
+# load in shared rust object first to minimize risk of aarch64 glibc TLS allocation bug
+# https://bugzilla.redhat.com/show_bug.cgi?id=1722181
+import dask_planner.rust
+
 from . import _version, config
 from .cmd import cmd_loop
 from .context import Context

--- a/dask_sql/__init__.py
+++ b/dask_sql/__init__.py
@@ -1,5 +1,5 @@
-# load in shared rust object first to minimize risk of aarch64 glibc TLS allocation bug
-# https://bugzilla.redhat.com/show_bug.cgi?id=1722181
+# FIXME: can we modify TLS model of Rust object to avoid aarch64 glibc bug?
+# https://github.com/dask-contrib/dask-sql/issues/1169
 import dask_planner.rust
 
 from . import _version, config


### PR DESCRIPTION
Addresses https://github.com/conda-forge/dask-sql-feedstock/issues/66 by reordering imports to avoid the [aarch64 `glibc` TLS allocation bug](https://bugzilla.redhat.com/show_bug.cgi?id=1722181) and removing the `glibc` from the conda / pip packages.

