### PR TITLE
Add `xz` to conda `host` dependencies

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -61,6 +61,7 @@ jobs:
           conda mambabuild continuous_integration/recipe \
                            --python ${{ matrix.python }} \
                            --variants "{target_platform: [${{ matrix.arch }}]}" \
+                           --error-overlinking \
                            --no-test \
                            --no-anaconda-upload \
                            --output-folder packages

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - python
     - setuptools-rust
     - libprotobuf
-    - xz  # [linux-64]
+    - xz  # [linux64]
   run:
     - python
     - dask >=2022.3.0

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - python
     - setuptools-rust
     - libprotobuf
+    - xz  # [linux-64]
   run:
     - python
     - dask >=2022.3.0


### PR DESCRIPTION
This should resolve the overlink warnings we get during the linux-64 builds:

```
WARNING (dask-sql,lib/python3.10/site-packages/dask_planner/rust.cpython-310-x86_64-linux-gnu.so): Needed DSO lib/liblzma.so.5 found in ['xz']
WARNING (dask-sql,lib/python3.10/site-packages/dask_planner/rust.cpython-310-x86_64-linux-gnu.so): .. but ['xz'] not in reqs/run, (i.e. it is overlinking) (likely) or a missing dependency (less likely)
```

I've also added the `--error-overlinking` flag to the builds which should catch any potential overlink issues moving forward.