### PR TITLE
Fix memory issues in Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    paths:
+      - "docker/**"
+      - .github/workflows/docker.yml
 
 # When this workflow is queued, automatically cancel any previous running
 # or pending jobs from the same branch
@@ -17,7 +21,8 @@ jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
-    if: github.repository == 'dask-contrib/dask-sql'
+    env:
+      DOCKER_PUSH: ${{ github.event_name == 'push' && github.repository == 'dask-contrib/dask-sql' }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -26,6 +31,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
+        if: ${{ fromJSON(env.DOCKER_PUSH) }}
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -41,10 +47,16 @@ jobs:
           context: .
           file: ./docker/main.dockerfile
           build-args: DOCKER_META_VERSION=${{ steps.docker_meta_main.outputs.version }}
-          platforms: linux/amd64,linux/arm64,linux/386
+          platforms: ${{ fromJSON(env.DOCKER_PUSH) && 'linux/amd64,linux/arm64,linux/386' || 'linux/amd64' }}
           tags: ${{ steps.docker_meta_main.outputs.tags }}
           labels: ${{ steps.docker_meta_main.outputs.labels }}
-          push: true
+          push: ${{ fromJSON(env.DOCKER_PUSH) }}
+          load: ${{ !fromJSON(env.DOCKER_PUSH) }}
+      - name: Check images
+        run: |
+          df -h
+          docker image ls
+          docker image inspect ${{ steps.docker_meta_main.outputs.tags }}
       - name: Docker meta for cloud image
         id: docker_meta_cloud
         uses: crazy-max/ghaction-docker-meta@v4
@@ -56,7 +68,8 @@ jobs:
           context: .
           file: ./docker/cloud.dockerfile
           build-args: DOCKER_META_VERSION=${{ steps.docker_meta_main.outputs.version }}
-          platforms: linux/amd64,linux/arm64,linux/386
+          platforms: ${{ fromJSON(env.DOCKER_PUSH) && 'linux/amd64,linux/arm64,linux/386' || 'linux/amd64' }}
           tags: ${{ steps.docker_meta_cloud.outputs.tags }}
           labels: ${{ steps.docker_meta_cloud.outputs.labels }}
-          push: true
+          push: ${{ fromJSON(env.DOCKER_PUSH) }}
+          load: ${{ !fromJSON(env.DOCKER_PUSH) }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,8 @@ jobs:
           context: .
           file: ./docker/main.dockerfile
           build-args: DOCKER_META_VERSION=${{ steps.docker_meta_main.outputs.version }}
-          platforms: ${{ fromJSON(env.DOCKER_PUSH) && 'linux/amd64,linux/arm64,linux/386' || 'linux/amd64' }}
+          # platforms: ${{ fromJSON(env.DOCKER_PUSH) && 'linux/amd64,linux/arm64,linux/386' || 'linux/amd64' }}
+          platforms: linux/amd64,linux/arm64,linux/386
           tags: ${{ steps.docker_meta_main.outputs.tags }}
           labels: ${{ steps.docker_meta_main.outputs.labels }}
           push: ${{ fromJSON(env.DOCKER_PUSH) }}
@@ -68,7 +69,8 @@ jobs:
           context: .
           file: ./docker/cloud.dockerfile
           build-args: DOCKER_META_VERSION=${{ steps.docker_meta_main.outputs.version }}
-          platforms: ${{ fromJSON(env.DOCKER_PUSH) && 'linux/amd64,linux/arm64,linux/386' || 'linux/amd64' }}
+          # platforms: ${{ fromJSON(env.DOCKER_PUSH) && 'linux/amd64,linux/arm64,linux/386' || 'linux/amd64' }}
+          platforms: linux/amd64,linux/arm64,linux/386
           tags: ${{ steps.docker_meta_cloud.outputs.tags }}
           labels: ${{ steps.docker_meta_cloud.outputs.labels }}
           push: ${{ fromJSON(env.DOCKER_PUSH) }}

--- a/docker/main.dockerfile
+++ b/docker/main.dockerfile
@@ -43,7 +43,7 @@ COPY .git /opt/dask_sql/.git
 COPY src /opt/dask_sql/src
 COPY dask_sql /opt/dask_sql/dask_sql
 RUN cd /opt/dask_sql/ \
-    && pip install -e . -vv
+    && CONDA_PREFIX="/opt/conda/" maturin develop
 
 # Set the script to execute
 COPY scripts/startup_script.py /opt/dask_sql/startup_script.py


### PR DESCRIPTION
Looks like since merging #1181, we've been encountering some memory/resource pressure during our Docker builds that causes the GHA runs to cancel prematurely:

https://github.com/dask-contrib/dask-sql/actions/runs/5894517992/job/15988310016

Interested in if switching our installation process over to `maturin develop` and/or limiting the amount of CPUs being used for compilation could resolve things here