### PR TITLE
See what happens if we ignore `libprotobuf`'s runtime exports

### DIFF
--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -19,6 +19,8 @@ build:
     - dask-sql = dask_sql.cmd:main
   string: py{{ python | replace(".", "") }}_{{ GIT_DESCRIBE_HASH }}_{{ GIT_DESCRIBE_NUMBER }}
   script: RUST_BACKTRACE=full {{ PYTHON }} -m pip install . --no-deps -vv
+  ignore_run_exports:
+    - libprotobuf
 
 requirements:
   build:
@@ -47,9 +49,6 @@ requirements:
     - prompt-toolkit >=3.0.8
     - pygments >=2.7.1
     - tabulate
-
-  ignore_run_exports:
-    - libprotobuf
 
 test:
   imports:

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -48,6 +48,9 @@ requirements:
     - pygments >=2.7.1
     - tabulate
 
+  ignore_run_exports:
+    - libprotobuf
+
 test:
   imports:
     - dask_sql


### PR DESCRIPTION
Exploring alternatives to https://github.com/conda-forge/dask-sql-feedstock/pull/74

cc @bdice @jakirkham 