### PR TITLE
Use aliased column names for cross joins

### DIFF
--- a/dask_sql/physical/rel/logical/cross_join.py
+++ b/dask_sql/physical/rel/logical/cross_join.py
@@ -25,18 +25,21 @@ class DaskCrossJoinPlugin(BaseRelPlugin):
     def convert(self, rel: "LogicalPlan", context: "dask_sql.Context") -> DataContainer:
         # We now have two inputs (from left and right), so we fetch them both
         dc_lhs, dc_rhs = self.assert_inputs(rel, 2, context)
+        cc_lhs = dc_lhs.column_container
+        cc_rhs = dc_rhs.column_container
 
-        df_lhs = dc_lhs.df
-        df_rhs = dc_rhs.df
+        # Rename the columns of the left and right inputs
+        df_lhs_renamed = DataContainer(dc_lhs.df, cc_lhs.make_unique("lhs")).assign()
+        df_rhs_renamed = DataContainer(dc_rhs.df, cc_rhs.make_unique("rhs")).assign()
 
         # Create a 'key' column in both DataFrames to join on
-        cross_join_key = utils.new_temporary_column(df_lhs)
-        df_lhs[cross_join_key] = 1
-        df_rhs[cross_join_key] = 1
+        cross_join_key = utils.new_temporary_column(df_lhs_renamed)
+        df_lhs_renamed[cross_join_key] = 1
+        df_rhs_renamed[cross_join_key] = 1
 
-        result = df_lhs.merge(df_rhs, on=cross_join_key, suffixes=("", "0")).drop(
-            cross_join_key, 1
-        )
+        result = df_lhs_renamed.merge(
+            df_rhs_renamed, on=cross_join_key, suffixes=("", "0")
+        ).drop(cross_join_key, 1)
         cc = ColumnContainer(result.columns)
 
         # Rename columns like the rel specifies

--- a/tests/integration/test_join.py
+++ b/tests/integration/test_join.py
@@ -588,3 +588,14 @@ def test_null_key_join(c):
     expected_df = pd.DataFrame({"a": [], "b": []})
 
     assert_eq(result_df, expected_df)
+
+
+def test_cross_join_duplicate_column_names(c):
+    c.create_table("df1", pd.DataFrame({"a": [1]}))
+    c.create_table("df2", pd.DataFrame({"a": [2]}))
+    c.create_table("df3", pd.DataFrame({"a": [3]}))
+
+    result_df = c.sql("SELECT * FROM df1, df2, df3")
+    expected_df = pd.DataFrame({"df1.a": [1], "df2.a": [2], "df3.a": [3]})
+
+    assert_eq(result_df, expected_df)


### PR DESCRIPTION
Because we were forgetting to alias/unalias column names before/after the merge operation, tables sharing column names were not being handled properly