### PR TITLE
Unpin mlflow in CI

### DIFF
--- a/continuous_integration/environment-3.10-dev.yaml
+++ b/continuous_integration/environment-3.10-dev.yaml
@@ -12,9 +12,9 @@ dependencies:
 - jsonschema
 - lightgbm
 - maturin>=1.3,<1.4
-# FIXME: mlflow 2.6.0 has import issues related to pydantic
+# mlflow 2.6.0 has import issues related to pydantic
 # https://github.com/mlflow/mlflow/issues/9331
-- mlflow<2.6
+- mlflow!=2.6.0
 - mock
 - numpy>=1.21.6
 - pandas>=1.4.0

--- a/continuous_integration/environment-3.8-dev.yaml
+++ b/continuous_integration/environment-3.8-dev.yaml
@@ -12,9 +12,9 @@ dependencies:
 - jsonschema
 - lightgbm
 - maturin>=1.3,<1.4
-# FIXME: mlflow 2.6.0 has import issues related to pydantic
+# mlflow 2.6.0 has import issues related to pydantic
 # https://github.com/mlflow/mlflow/issues/9331
-- mlflow<2.6
+- mlflow!=2.6.0
 - mock
 - numpy=1.21.6
 - pandas=1.4.0

--- a/continuous_integration/environment-3.9-dev.yaml
+++ b/continuous_integration/environment-3.9-dev.yaml
@@ -12,9 +12,9 @@ dependencies:
 - jsonschema
 - lightgbm
 - maturin>=1.3,<1.4
-# FIXME: mlflow 2.6.0 has import issues related to pydantic
+# mlflow 2.6.0 has import issues related to pydantic
 # https://github.com/mlflow/mlflow/issues/9331
-- mlflow<2.6
+- mlflow!=2.6.0
 - mock
 - numpy>=1.21.6
 - pandas>=1.4.0

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -16,9 +16,9 @@ dependencies:
 - jsonschema
 - lightgbm
 - maturin>=1.3,<1.4
-# FIXME: mlflow 2.6.0 has import issues related to pydantic
+# mlflow 2.6.0 has import issues related to pydantic
 # https://github.com/mlflow/mlflow/issues/9331
-- mlflow<2.6
+- mlflow!=2.6.0
 - mock
 - numpy>=1.21.6
 - pandas>=1.4.0

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -16,9 +16,9 @@ dependencies:
 - jsonschema
 - lightgbm
 - maturin>=1.3,<1.4
-# FIXME: mlflow 2.6.0 has import issues related to pydantic
+# mlflow 2.6.0 has import issues related to pydantic
 # https://github.com/mlflow/mlflow/issues/9331
-- mlflow<2.6
+- mlflow!=2.6.0
 - mock
 - numpy>=1.21.6
 - pandas>=1.4.0


### PR DESCRIPTION
Looks like we should be good now to unpin from `mlflow<2.6` now that the bug in 2.6.0 has been resolved
