### PR TITLE
More restrictive input validation during predicate pushdown filter extraction

### DIFF
--- a/dask_sql/physical/utils/filter.py
+++ b/dask_sql/physical/utils/filter.py
@@ -518,6 +518,10 @@ def _inv(symbol: str):
 def _blockwise_comparison_dnf(op, indices: list, dsk: RegenerableGraph) -> DNF:
     # Return DNF expression pattern for a simple comparison
     left = _get_blockwise_input(0, indices, dsk)
+
+    # at this point, RHS must be a scalar and not a column name (i.e. getitem task)
+    if indices[1][1] is not None:
+        raise ValueError
     right = _get_blockwise_input(1, indices, dsk)
 
     if is_arraylike(left) and hasattr(left, "item") and left.size == 1:

--- a/dask_sql/physical/utils/filter.py
+++ b/dask_sql/physical/utils/filter.py
@@ -517,11 +517,10 @@ def _inv(symbol: str):
 
 def _blockwise_comparison_dnf(op, indices: list, dsk: RegenerableGraph) -> DNF:
     # Return DNF expression pattern for a simple comparison
-    left = _get_blockwise_input(0, indices, dsk)
+    if indices[0][1] is not None and indices[1][1] is not None:
+        raise ValueError("Comparisons between columns are not supported")
 
-    # at this point, RHS must be a scalar and not a column name (i.e. getitem task)
-    if indices[1][1] is not None:
-        raise ValueError
+    left = _get_blockwise_input(0, indices, dsk)
     right = _get_blockwise_input(1, indices, dsk)
 
     if is_arraylike(left) and hasattr(left, "item") and left.size == 1:


### PR DESCRIPTION
While running some TPC-H queries using dask-sql + dask-cudf, I noticed some failures around predicate pushdown that seemed to be caused by us incorrectly pushing down blockwise comparisons between columns.

This PR attempts to tighten the logic of `_blockwise_comparison_dnf` to block this edge case; marking this as draft as I'm not sure if we want to block all RHS `getitem` calls yet.

cc @rjzamora