### PR TITLE
Bump GPU CI to CUDA 11.8

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -3,7 +3,7 @@ PYTHON_VER:
 - "3.10"
 
 CUDA_VER:
-- "11.5.2"
+- "11.8.0"
 
 LINUX_VER:
 - ubuntu20.04


### PR DESCRIPTION
This addresses the planned dropping of the CUDA 11.5 `miniforge-cuda` images we currently depend on in rapidsai/miniforge-cuda#55