### PR TITLE
Bump py-xgboost CI dep to 2.0.3

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -26,7 +26,7 @@ dependencies:
 - pytest-xdist
 - pytest
 - python=3.10
-- py-xgboost>=1.7.0
+- py-xgboost>=2.0.3
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -26,7 +26,7 @@ dependencies:
 - pytest-xdist
 - pytest
 - python=3.11
-- py-xgboost>=1.7.0
+- py-xgboost>=2.0.3
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -27,7 +27,7 @@ dependencies:
 - pytest-xdist
 - pytest
 - python=3.12
-- py-xgboost>=1.7.0
+- py-xgboost>=2.0.3
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -26,7 +26,7 @@ dependencies:
 - pytest-xdist
 - pytest
 - python=3.9
-- py-xgboost=1.7.0
+- py-xgboost=2.0.3
 - scikit-learn=1.0.0
 - sphinx
 # TODO: remove this constraint when we require pandas>2

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -32,7 +32,7 @@ dependencies:
 - pytest-xdist
 - pytest
 - python=3.10
-- py-xgboost>=1.7.0
+- py-xgboost>=2.0.3
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -32,7 +32,7 @@ dependencies:
 - pytest-xdist
 - pytest
 - python=3.9
-- py-xgboost>=1.7.0
+- py-xgboost==2.0.3
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy


### PR DESCRIPTION
Testing the viability of this suggestion from @jakirkham:

https://github.com/rapidsai/dask-build-environment/pull/87#issuecomment-1974225587