### PR TITLE
Fix code in documentation (#1315)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,7 +52,7 @@ For this example, we use some data loaded from disk and query it with a SQL comm
          result.compute()
 
          # ...or use it for another computation
-         result.sum.mean().compute()
+         result["sum"].mean().compute()
 
    .. group-tab:: GPU
 
@@ -82,7 +82,7 @@ For this example, we use some data loaded from disk and query it with a SQL comm
          result.compute()
 
          # ...or use it for another computation
-         result.sum.mean().compute()
+         result["sum"].mean().compute()
 
 
 .. toctree::


### PR DESCRIPTION
The code would throw an error because of the `sum` being left in. When replaced with `result["sum"].mean().compute()` it computes the mean correctly:

```python
>>> import dask.datasets
>>> dask.config.set({"dataframe.convert-string": False})
<dask.config.set object at 0x7feccbf70a10>
>>> from dask_sql import Context
>>> df = dask.datasets.timeseries()
>>> c = Context()
>>> c.create_table("timeseries", df)
>>> result = c.sql("""
... SELECT name, SUM(x) as "sum" FROM timeseries GROUP BY name
... """)
>>> result["sum"].mean().compute()
7.956598887824248
```

Also eager string converting needs to be turned off in order to silence the following error:
```python
>>> result = c.sql("""
... SELECT name, SUM(x) as "sum" FROM timeseries GROUP BY name
... """)
Traceback (most recent call last):
  File "/home/fila/miniconda3/envs/dask-sql/lib/python3.11/site-packages/dask_sql/mappings.py", line 118, in python_to_sql_type
    return DaskTypeMap(_PYTHON_TO_SQL[python_type])
                       ~~~~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: string[pyarrow]

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/fila/miniconda3/envs/dask-sql/lib/python3.11/site-packages/dask_sql/context.py", line 517, in sql
    rel, _ = self._get_ral(sql)
             ^^^^^^^^^^^^^^^^^^
  File "/home/fila/miniconda3/envs/dask-sql/lib/python3.11/site-packages/dask_sql/context.py", line 826, in _get_ral
    schemas = self._prepare_schemas()
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fila/miniconda3/envs/dask-sql/lib/python3.11/site-packages/dask_sql/context.py", line 773, in _prepare_schemas
    column_type_mapping = list(
                          ^^^^^
  File "/home/fila/miniconda3/envs/dask-sql/lib/python3.11/site-packages/dask_sql/mappings.py", line 120, in python_to_sql_type
    raise NotImplementedError(
NotImplementedError: The python type string is not implemented (yet)
```