### PR TITLE
Install `x86_64-apple-darwin` target before building bindings on `macos-latest`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      # TODO: do we need to install this target?
+      # - name: Install x86_64-apple-darwin target
+      #   run: rustup target add x86_64-apple-darwin
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,9 +108,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      # TODO: do we need to install this target?
-      # - name: Install x86_64-apple-darwin target
-      #   run: rustup target add x86_64-apple-darwin
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -56,6 +56,9 @@ jobs:
           channel-priority: strict
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
+      - name: Install x86_64-apple-darwin target
+        if: matrix.os == 'macos-latest'
+        run: rustup target add x86_64-apple-darwin
       - name: Build the Rust DataFusion bindings
         run: |
           maturin develop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,9 @@ jobs:
         with:
           workspaces: dask_planner
           shared-key: test
+      - name: Install x86_64-apple-darwin target
+        if: matrix.os == 'macos-latest'
+        run: rustup target add x86_64-apple-darwin
       - name: Build the Rust DataFusion bindings
         run: |
           maturin develop


### PR DESCRIPTION
Looks like we're starting to see failures in our macOS test builds:

https://github.com/dask-contrib/dask-sql/actions/runs/8852325552/job/24312113450?pr=1328

Taking the suggestion from the error logs seems to resolve things:

```
  = note: the `x86_64-apple-darwin` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-apple-darwin`
```