### PR TITLE
Pre-compute window function operands to simplify Dask graph

### DIFF
--- a/dask_sql/physical/rel/logical/window.py
+++ b/dask_sql/physical/rel/logical/window.py
@@ -241,12 +241,10 @@ class DaskWindowPlugin(BaseRelPlugin):
             dc = self._apply_window(
                 rel, window, dc, df, field_names, context, operations_dict
             )
+            df = dc.df
 
         # Finally, fix the output schema if needed
         df = dc.df
-
-        breakpoint()
-
         cc = dc.column_container
         cc = self.fix_column_to_row_type(cc, rel.getRowType())
         dc = DataContainer(df, cc)
@@ -265,6 +263,7 @@ class DaskWindowPlugin(BaseRelPlugin):
         operations_dict: dict[str, list[tuple[Callable, str, list[str]]]],
     ):
         temporary_columns = []
+        newly_created_columns = []
 
         cc = dc.column_container
 
@@ -284,10 +283,9 @@ class DaskWindowPlugin(BaseRelPlugin):
         )
 
         operations = operations_dict[window.toString()]
-        for _, _, cols in operations:
-            temporary_columns += cols
-
-        newly_created_columns = [new_column for _, new_column, _ in operations]
+        for _, result_col, operand_cols in operations:
+            temporary_columns += operand_cols
+            newly_created_columns.append(result_col)
 
         logger.debug(f"Will create {newly_created_columns} new columns")
 

--- a/tests/integration/test_over.py
+++ b/tests/integration/test_over.py
@@ -77,7 +77,7 @@ def test_over_with_different(c, user_table_1):
 
 
 # TODO: investigate source of window count deadlocks
-# @skipif_dask_expr_enabled("Deadlocks with query planning enabled")
+@skipif_dask_expr_enabled("Deadlocks with query planning enabled")
 def test_over_calls(c, user_table_1):
     return_df = c.sql(
         """

--- a/tests/integration/test_over.py
+++ b/tests/integration/test_over.py
@@ -101,10 +101,10 @@ def test_over_calls(c, user_table_1):
         {
             "user_id": user_table_1.user_id,
             "b": user_table_1.b,
-            # "O1": [2, 1, 1, 1],
-            # "O2": [19, 7, 19, 27],
+            "O1": [2, 1, 1, 1],
+            "O2": [19, 7, 19, 27],
             # "O3": [19, 7, 19, 27], https://github.com/dask-contrib/dask-sql/issues/651
-            # "O4": [17, 7, 17, 27],
+            "O4": [17, 7, 17, 27],
             "O5": [4, 1, 2, 3],
             "O6": [2, 1, 2, 3],
             "O7": [2, 1, 1, 1],

--- a/tests/integration/test_over.py
+++ b/tests/integration/test_over.py
@@ -77,7 +77,7 @@ def test_over_with_different(c, user_table_1):
 
 
 # TODO: investigate source of window count deadlocks
-@skipif_dask_expr_enabled("Deadlocks with query planning enabled")
+# @skipif_dask_expr_enabled("Deadlocks with query planning enabled")
 def test_over_calls(c, user_table_1):
     return_df = c.sql(
         """
@@ -101,10 +101,10 @@ def test_over_calls(c, user_table_1):
         {
             "user_id": user_table_1.user_id,
             "b": user_table_1.b,
-            "O1": [2, 1, 1, 1],
-            "O2": [19, 7, 19, 27],
+            # "O1": [2, 1, 1, 1],
+            # "O2": [19, 7, 19, 27],
             # "O3": [19, 7, 19, 27], https://github.com/dask-contrib/dask-sql/issues/651
-            "O4": [17, 7, 17, 27],
+            # "O4": [17, 7, 17, 27],
             "O5": [4, 1, 2, 3],
             "O6": [2, 1, 2, 3],
             "O7": [2, 1, 1, 1],


### PR DESCRIPTION
Though the hope is that https://github.com/dask/dask-expr/pull/1059 should unblock (at least some of) the hanging tests, observation of the graphs getting produced from our window code shows that we should be able to simplify things pretty significantly by extracting all the operand columns at once from the base dataframe (which in practice should not be getting modified in any meaningful way by the following groupby-apply operations).

Haven't un-skipped any of the tests because things are still hanging, though now this seems to be getting caused by `fix_dtype_to_row_type` - will explore this function to see if there's any patterns we could simplify there.