### PR TITLE
Switch to pinned conda Rust dependency

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,10 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: 1.72
-            default: true
       - name: Cache Cargo
         uses: actions/cache@v3
         with:
@@ -67,10 +63,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: 1.72
-            default: true
       - name: Cache Cargo
         uses: actions/cache@v3
         with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,8 +26,10 @@ jobs:
           use-mamba: true
           python-version: "3.9"
           channel-priority: strict
-      - name: Install dependencies
+      - name: Ensure we use conda rust toolchain
         run: |
+          rustup self uninstall -y
+
           mamba install -c conda-forge rust=1.77
 
           which python

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,31 +8,15 @@ concurrency:
   group: style-${{ github.head_ref }}
   cancel-in-progress: true
 
-# Required shell entrypoint to have properly activated conda environments
-defaults:
-  run:
-    shell: bash -l {0}
-
 jobs:
   pre-commit:
     name: Run pre-commit hooks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: conda-incubator/setup-miniconda@v2.3.0
+      - uses: actions/setup-python@v4
+      - uses: actions-rs/toolchain@v1
         with:
-          miniforge-variant: Mambaforge
-          use-mamba: true
-          python-version: "3.9"
-          channel-priority: strict
-      - name: Ensure we use conda rust toolchain
-        run: |
-          rustup self uninstall -y
-
-          mamba install -c conda-forge rust=1.77
-
-          which python
-          pip list
-          mamba list
+            toolchain: 1.77
+            default: true
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,8 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
-            components: rustfmt
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -18,5 +18,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: 1.77
+            components: clippy
             default: true
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,6 +8,11 @@ concurrency:
   group: style-${{ github.head_ref }}
   cancel-in-progress: true
 
+# Required shell entrypoint to have properly activated conda environments
+defaults:
+  run:
+    shell: bash -l {0}
+
 jobs:
   pre-commit:
     name: Run pre-commit hooks
@@ -23,8 +28,6 @@ jobs:
           channel-priority: strict
       - name: Install dependencies
         run: |
-          rustup self uninstall -y
-
           mamba install -c conda-forge rust=1.77
 
           which python

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,6 +23,8 @@ jobs:
           channel-priority: strict
       - name: Install dependencies
         run: |
+          rustup self uninstall -y
+
           mamba install -c conda-forge rust=1.77
 
           which python

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,5 +14,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: conda-incubator/setup-miniconda@v2.3.0
+        with:
+          miniforge-variant: Mambaforge
+          use-mamba: true
+          python-version: "3.9"
+          channel-priority: strict
+      - name: Install dependencies
+        run: |
+          mamba install -c conda-forge rust=1.77
+
+          which python
+          pip list
+          mamba list
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test-upstream.yml
+++ b/.github/workflows/test-upstream.yml
@@ -56,10 +56,6 @@ jobs:
           channel-priority: strict
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: 1.72
-            default: true
       - name: Install x86_64-apple-darwin target
         if: matrix.os == 'macos-latest'
         run: rustup target add x86_64-apple-darwin
@@ -107,10 +103,6 @@ jobs:
           use-mamba: true
           python-version: "3.9"
           channel-priority: strict
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: 1.72
-            default: true
       - name: Install dependencies and nothing else
         run: |
           pip install -e . -vv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,10 @@ jobs:
             query-planning: false
     steps:
       - uses: actions/checkout@v4
+      - name: Don't install sysroot on Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          sed -i '/^.*- sysroot_linux-64/s/^/#/' ${{ env.CONDA_FILE }}
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v2.3.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,10 +78,6 @@ jobs:
           activate-environment: dask-sql
           environment-file: ${{ env.CONDA_FILE }}
           run-post: ${{ matrix.os != 'windows-latest' && 'true' || 'false' }}
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: 1.72
-            default: true
       - name: Install x86_64-apple-darwin target
         if: matrix.os == 'macos-latest'
         run: rustup target add x86_64-apple-darwin
@@ -127,10 +123,6 @@ jobs:
           use-mamba: true
           python-version: "3.9"
           channel-priority: strict
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: 1.72
-            default: true
       - name: Install dependencies and nothing else
         run: |
           pip install -e . -vv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,12 +31,3 @@ repos:
       - id: check-yaml
         exclude: ^continuous_integration/recipe/
       - id: check-added-large-files
-  - repo: local
-    hooks:
-      - id: cargo-fmt
-        name: cargo fmt
-        description: Format files with cargo fmt.
-        entry: cargo +nightly fmt
-        language: system
-        types: [rust]
-        args: ['--manifest-path', './Cargo.toml', '--verbose', '--']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Bindings for DataFusion used by Dask-SQL"
 readme = "README.md"
 license = "Apache-2.0"
 edition = "2021"
-rust-version = "1.72"
+rust-version = "1.77"
 include = ["/src", "/dask_sql", "/LICENSE.txt", "pyproject.toml", "Cargo.toml", "Cargo.lock"]
 
 [dependencies]

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -28,6 +28,7 @@ dependencies:
 - pytest
 - python=3.10
 - py-xgboost>=2.0.3
+- rust=1.72
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -28,7 +28,7 @@ dependencies:
 - pytest
 - python=3.10
 - py-xgboost>=2.0.3
-- rust=1.72
+- rust=1.77
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -32,6 +32,7 @@ dependencies:
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy
+- sysroot_linux-64>=2.17
 - tpot>=0.12.0
 # FIXME: https://github.com/fugue-project/fugue/issues/526
 - triad<0.9.2

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -28,7 +28,7 @@ dependencies:
 - pytest
 - python=3.11
 - py-xgboost>=2.0.3
-- rust=1.72
+- rust=1.77
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -28,6 +28,7 @@ dependencies:
 - pytest
 - python=3.11
 - py-xgboost>=2.0.3
+- rust=1.72
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -32,6 +32,7 @@ dependencies:
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy
+- sysroot_linux-64>=2.17
 - tpot>=0.12.0
 # FIXME: https://github.com/fugue-project/fugue/issues/526
 - triad<0.9.2

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -29,7 +29,7 @@ dependencies:
 - pytest
 - python=3.12
 - py-xgboost>=2.0.3
-- rust=1.72
+- rust=1.77
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -29,6 +29,7 @@ dependencies:
 - pytest
 - python=3.12
 - py-xgboost>=2.0.3
+- rust=1.72
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -33,6 +33,7 @@ dependencies:
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy
+- sysroot_linux-64>=2.17
 # TODO: add once tpot supports python 3.12
 # - tpot>=0.12.0
 # FIXME: https://github.com/fugue-project/fugue/issues/526

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -28,7 +28,7 @@ dependencies:
 - pytest
 - python=3.9
 - py-xgboost=2.0.3
-- rust=1.72
+- rust=1.77
 - scikit-learn=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -28,6 +28,7 @@ dependencies:
 - pytest
 - python=3.9
 - py-xgboost=2.0.3
+- rust=1.72
 - scikit-learn=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -32,6 +32,7 @@ dependencies:
 - scikit-learn=1.0.0
 - sphinx
 - sqlalchemy
+- sysroot_linux-64>=2.17
 - tpot>=0.12.0
 # FIXME: https://github.com/fugue-project/fugue/issues/526
 - triad<0.9.2

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -34,6 +34,7 @@ dependencies:
 - pytest
 - python=3.10
 - py-xgboost>=2.0.3
+- rust=1.72
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -38,6 +38,7 @@ dependencies:
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy
+- sysroot_linux-64>=2.17
 - tpot>=0.12.0
 # FIXME: https://github.com/fugue-project/fugue/issues/526
 - triad<0.9.2

--- a/continuous_integration/gpuci/environment-3.10.yaml
+++ b/continuous_integration/gpuci/environment-3.10.yaml
@@ -34,7 +34,7 @@ dependencies:
 - pytest
 - python=3.10
 - py-xgboost>=2.0.3
-- rust=1.72
+- rust=1.77
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -38,6 +38,7 @@ dependencies:
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy
+- sysroot_linux-64>=2.17
 - tpot>=0.12.0
 # FIXME: https://github.com/fugue-project/fugue/issues/526
 - triad<0.9.2

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -34,7 +34,7 @@ dependencies:
 - pytest
 - python=3.9
 - py-xgboost==2.0.3
-- rust=1.72
+- rust=1.77
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/gpuci/environment-3.9.yaml
+++ b/continuous_integration/gpuci/environment-3.9.yaml
@@ -34,6 +34,7 @@ dependencies:
 - pytest
 - python=3.9
 - py-xgboost==2.0.3
+- rust=1.72
 - scikit-learn>=1.0.0
 - sphinx
 - sqlalchemy

--- a/continuous_integration/recipe/conda_build_config.yaml
+++ b/continuous_integration/recipe/conda_build_config.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 rust_compiler:
     - rust
 rust_compiler_version:
-    - '1.72'
+    - '1.77'
 maturin:
     - '1.3'
 xz:        # [linux64]

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -19,4 +19,4 @@ dependencies:
   - pygments>=2.7.1
   - tabulate
   - ucx-proc=*=cpu
-  - rust=1.72
+  - rust=1.77


### PR DESCRIPTION
For the sake of simplifying CI and the eventual work that may need to happen around the [stdlib('c') migration](https://conda-forge.org/news/2024/03/24/stdlib-migration/), and especially considering it seems like an upcoming conda rust 1.78 might not play well with the current version of `sysroot_linux-64` getting installed in CI environments, this PR attempts to pin us across CI where possible to one version of conda-forge's Rust - 1.77.